### PR TITLE
moduleModel::getModuleInfoXml()에서 standalone 속성을 처리하는 부분 제거

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -831,7 +831,6 @@ class moduleModel extends module
 
 					$type = $action->attrs->type;
 					$grant = $action->attrs->grant?$action->attrs->grant:'guest';
-					$standalone = $action->attrs->standalone=='true'?'true':'false';
 					$ruleset = $action->attrs->ruleset?$action->attrs->ruleset:'';
 					$method = $action->attrs->method?$action->attrs->method:'';
 
@@ -844,7 +843,6 @@ class moduleModel extends module
 					$info->action->{$name} = new stdClass();
 					$info->action->{$name}->type = $type;
 					$info->action->{$name}->grant = $grant;
-					$info->action->{$name}->standalone = $standalone=='true'?true:false;
 					$info->action->{$name}->ruleset = $ruleset;
 					$info->action->{$name}->method = $method;
 					if($action->attrs->menu_name)
@@ -866,7 +864,6 @@ class moduleModel extends module
 
 					$buff .= sprintf('$info->action->%s->type=\'%s\';', $name, $type);
 					$buff .= sprintf('$info->action->%s->grant=\'%s\';', $name, $grant);
-					$buff .= sprintf('$info->action->%s->standalone=%s;', $name, $standalone);
 					$buff .= sprintf('$info->action->%s->ruleset=\'%s\';', $name, $ruleset);
 					$buff .= sprintf('$info->action->%s->method=\'%s\';', $name, $method);
 


### PR DESCRIPTION
XE 최신 버전에서 더 이상 사용되지 않는 standalone 속성을 더 이상 moduleModel::getModuleInfoXml()에서 처리하지 않도록 수정했습니다.
