### PR TITLE
Update sitemap.html and file_list.html

### DIFF
--- a/modules/file/tpl/file_list.html
+++ b/modules/file/tpl/file_list.html
@@ -70,7 +70,7 @@ xe.lang.msg_empty_search_keyword = '{$lang->msg_empty_search_keyword}';
 				<!--@endif-->
 				<!-- one document end -->
 			<tr>
-				<td><a href="{$val->download_url}">{htmlspecialchars($val->source_filename)}</a></td>
+				<td><a href="{htmlspecialchars_decode($val->download_url)}">{htmlspecialchars($val->source_filename)}</a></td>
 				<td class="nowr">{FileHandler::filesize($val->file_size)}</td>
 				<td class="nowr">{$val->download_count}</td>
 				<td class="nowr">

--- a/modules/menu/tpl/sitemap.html
+++ b/modules/menu/tpl/sitemap.html
@@ -1881,6 +1881,9 @@ jQuery(function($){
 				showMenuSelector($(this).find('._menuSelector_menuTreeContainer'), htInfo.url);
 			}else{
 				// URL shortcut
+			        var htInfo_url = htInfo.url;
+			        htInfo_url = htInfo_url.replace(/&amp;/g, '&');
+			        htInfo.url = htInfo_url;
 				$(this).find('a[href="#fix_linkUrl"]').click();
 				$(this).find('._url_link').val($('<div />').text(htInfo.url).text());
 				


### PR DESCRIPTION
xe admin 에서 사이트 메뉴 편집 > 바로가기 메뉴타입 URL 링크 부분에서
주소 입력은 제대로 잘 되고 작동도 잘 되지만 메뉴 수정에 들어가면 URL 링크 부분에 '&' 가 'amp' 로 노출되어 확인 눌러 저장해 버리면 주소가 'amp' 포함된 주소로 바뀌어 버리는 소소한 문제점이 있었습니다.

그리고 콘텐츠 > 파일 에 존재하는 파일 링크 URL 에 & 대신 amp 가 노출되는 문제가 있었습니다.
