### PR TITLE
[자동저장패치] 제목, 본문 내용없이 첨부파일만 등록하고 다시 접근 시 자동저장 활성화

### DIFF
--- a/modules/editor/skins/dreditor/editor.html
+++ b/modules/editor/skins/dreditor/editor.html
@@ -28,6 +28,7 @@
 <!--@if($enable_autosave)-->
 <input type="hidden" name="_saved_doc_title" value="{htmlspecialchars($saved_doc->title, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" />
 <input type="hidden" name="_saved_doc_content" value="{htmlspecialchars($saved_doc->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" />
+<input type="hidden" name="_saved_doc_document_srl" value="{$saved_doc->document_srl}" />
 <input type="hidden" name="_saved_doc_message" value="{$lang->msg_load_saved_doc}" />
 <div style="display:none"><p class="editor_autosaved_message" id="editor_autosaved_message_{$editor_sequence}" style="display:none"></p></div>
 <!--@end-->

--- a/modules/editor/skins/dreditor/js/xe_interface.js
+++ b/modules/editor/skins/dreditor/js/xe_interface.js
@@ -60,8 +60,9 @@ function _create(editor_sequence, primary_key, content_key, editor_height, color
 		if (form._saved_doc_title && form._saved_doc_title.value) { // Check auto-saved document
 			var saved_title = form._saved_doc_title.value;
 			var saved_content = form._saved_doc_content.value;
+			var saved_document_srl = form._saved_doc_document_srl.value;
 
-			if (saved_title || saved_content) {
+			if (saved_title || saved_content || saved_document_srl) {
 				// 자동저장된 문서 활용여부를 물은 후 사용하지 않는다면 자동저장된 문서 삭제
 				if(confirm(form._saved_doc_message.value)) {
 					if(typeof(form.title)!='undefined') form.title.value = saved_title;

--- a/modules/editor/skins/xpresseditor/editor.html
+++ b/modules/editor/skins/xpresseditor/editor.html
@@ -34,6 +34,7 @@
     <!--@if($enable_autosave)-->
     <input type="hidden" name="_saved_doc_title" value="{htmlspecialchars($saved_doc->title, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" />
     <input type="hidden" name="_saved_doc_content" value="{htmlspecialchars($saved_doc->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" />
+    <input type="hidden" name="_saved_doc_document_srl" value="{$saved_doc->document_srl}" />
     <input type="hidden" name="_saved_doc_message" value="{$lang->msg_load_saved_doc}" />
     <!--@end-->
     <!-- 에디터 -->

--- a/modules/editor/skins/xpresseditor/js/Xpress_Editor.js
+++ b/modules/editor/skins/xpresseditor/js/Xpress_Editor.js
@@ -5373,11 +5373,13 @@ xe.XE_AutoSave = $.Class({
 	$ON_MSG_APP_READY : function() {
 		var elTitle   = $(this.form._saved_doc_title);
 		var elContent = $(this.form._saved_doc_content);
+		var elDocument_srl = $(this.form._saved_doc_document_srl);
 
 		var title   = $.trim(elTitle.val());
 		var content = $.trim(elContent.val());
+		var document_srl = $.trim(elDocument_srl.val());
 
-		if (title || content) {
+		if (title || content || document_srl) {
 			if (confirm(this.form._saved_doc_message.value)) {
 				$(this.form.title).val(title);
 				this.oApp.setIR(content);


### PR DESCRIPTION
에디터 자동저장 기능이 첨부파일만 등록하면 자동으로 수행되어 DB에 저장되도록 되어있는데,
글 작성시 제목, 본문없이 첨부파일만 등록하고 다시 글작성을 누르면 확인을 안하는 현상이 발생합니다.

이런 문제로 쓸모없는 더미 파일이 생성되니 패치를 통해 제목, 본문 내용없이 첨부파일만으로도 자동저장 여부를 판단해줘야 한다 생각합니다.

(바른 처리는 자동임시저장 테이블에 제목, 본문 비교 말고 document_srl만 비교해서 해야함...)

ps : NuriCMS AXISJ에서는 테스트 완료되어 패치됨
