### PR TITLE
다국어 캐쉬 생성 오류 수정

### DIFF
--- a/modules/module/module.admin.controller.php
+++ b/modules/module/module.admin.controller.php
@@ -899,7 +899,7 @@ class moduleAdminController extends module
 			$str = "<?php if(!defined('__XE__')) exit(); \r\n";
 			foreach($langMap[$langCode] as $code => $value)
 			{
-				$str = sprintf('$lang[\'%s\'] = \'%s\';', $code, addcslashes($value, "'"));
+				$str .= sprintf('$lang[\'%s\'] = \'%s\';', $code, addcslashes($value, "'"));
 			}
 			if (!@file_put_contents(sprintf('%s/%d.%s.php', $cache_path, $args->site_srl, $langCode), $str, LOCK_EX))
 			{


### PR DESCRIPTION
다국어 캐쉬 생성 시 php 파일이 잘못 생성되어 페이지 상단에 php 파일 내용과 함께 Warning 에러가 나타납니다.
