### PR TITLE
[fetch] call a trigger before moduleHandler init

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -89,6 +89,9 @@ class ModuleHandler extends Handler
 			}
 		}
 
+		// call a trigger before moduleHandler init
+		ModuleHandler::triggerCall('moduleHandler.init', 'before', $this);
+
 		// execute addon (before module initialization)
 		$called_position = 'before_module_init';
 		$oAddonController = getController('addon');


### PR DESCRIPTION
moduleHandler에 애드온 첫 실행부분에 트리거를 추가했습니다.

트리거 추가 이유
- 모듈의 코어 컨트롤 영역을 애드온 부분까지 확장하기 위함
- 애드온 after_module_proc에는 트리거가 있는데 before_module_init에는 없기에 추가

기대되는 내용
- 애드온+모듈 패키지로 구성되던 방식을 단일 모듈로 구현가능해 짐으로 개발, 관리, 유지보수가 수월해짐

ps1 : $output->toBool() 체크를 넣을까 했지만.. display나 기타 before영역에서는 그냥 사용되기 때문에, 또 넣어서 생기는 문제가 있을거 같아 단순히 트리거만 수행시켰습니다.
ps2 : $this->module_info로 넘기지 않는 이유는... 최초수행부분이라 module_info값은 없고 $this에 단순 값만이 있기에 이걸 추가했습니다.
ps3 : 1.7.4에 이 부분이 추가된다면 배포에 맞춰서 첫빠따로 해당 기능을 활용한 모듈을 배포하겠습니다.(multidomain)
