### PR TITLE
일본어 번역(jp)

### DIFF
--- a/common/lang/lang.xml
+++ b/common/lang/lang.xml
@@ -3,6 +3,7 @@
 	<item name="help">
 		<value xml:lang="ko"><![CDATA[도움말]]></value>
 		<value xml:lang="en"><![CDATA[Help]]></value>
+		<value xml:lang="jp"><![CDATA[ヘルプ]]></value>
 	</item>
 	<item name="cmd_write">
 		<value xml:lang="ko"><![CDATA[쓰기]]></value>
@@ -91,6 +92,7 @@
 	<item name="inquiry">
 		<value xml:lang="ko"><![CDATA[조회]]></value>
 		<value xml:lang="en"><![CDATA[Inquiry]]></value>
+		<value xml:lang="jp"><![CDATA[お問い合わせ]]></value>
 	</item>
 	<item name="all">
 		<value xml:lang="ko"><![CDATA[전체]]></value>
@@ -362,7 +364,7 @@
 	<item name="cmd_vote">
 		<value xml:lang="ko"><![CDATA[추천]]></value>
 		<value xml:lang="en"><![CDATA[Recommend]]></value>
-		<value xml:lang="jp"><![CDATA[推薦]]></value>
+		<value xml:lang="jp"><![CDATA[推奨]]></value>
 		<value xml:lang="zh-CN"><![CDATA[推荐]]></value>
 		<value xml:lang="zh-TW"><![CDATA[推薦]]></value>
 		<value xml:lang="fr"><![CDATA[Recommander]]></value>
@@ -376,7 +378,7 @@
 	<item name="cmd_vote_down">
 		<value xml:lang="ko"><![CDATA[비추천]]></value>
 		<value xml:lang="en"><![CDATA[Not recommend]]></value>
-		<value xml:lang="jp"><![CDATA[非推薦]]></value>
+		<value xml:lang="jp"><![CDATA[非推奨]]></value>
 		<value xml:lang="zh-CN"><![CDATA[反对]]></value>
 		<value xml:lang="zh-TW"><![CDATA[反對]]></value>
 		<value xml:lang="fr"><![CDATA[Critiquer]]></value>
@@ -1173,6 +1175,7 @@
 	<item name="admin_email_address">
 		<value xml:lang="ko"><![CDATA[관리자 Email 주소]]></value>
 		<value xml:lang="en"><![CDATA[Admin Email Address]]></value>
+		<value xml:lang="jp"><![CDATA[管理者Eメールアドレス]]></value>
 		<value xml:lang="zh-CN"><![CDATA[站点管理员电子邮箱地址]]></value>
 		<value xml:lang="zh-TW"><![CDATA[管理員電子郵件位址]]></value>
 		<value xml:lang="tr"><![CDATA[Yönetici E-Posta Adresi]]></value>
@@ -1302,6 +1305,7 @@
 	<item name="new_title">
 		<value xml:lang="ko"><![CDATA[새 제목]]></value>
 		<value xml:lang="en"><![CDATA[New Subject]]></value>
+		<value xml:lang="jp"><![CDATA[ニュータイトル]]></value>
 	</item>
 	<item name="title_content">
 		<value xml:lang="ko"><![CDATA[제목+내용]]></value>
@@ -1951,7 +1955,7 @@
 	<item name="voted_count">
 		<value xml:lang="ko"><![CDATA[추천 수]]></value>
 		<value xml:lang="en"><![CDATA[Votes]]></value>
-		<value xml:lang="jp"><![CDATA[推薦数]]></value>
+		<value xml:lang="jp"><![CDATA[推奨数]]></value>
 		<value xml:lang="zh-CN"><![CDATA[推荐]]></value>
 		<value xml:lang="zh-TW"><![CDATA[推薦]]></value>
 		<value xml:lang="fr"><![CDATA[Recommandés]]></value>
@@ -1965,6 +1969,7 @@
 	<item name="blamed_count">
 		<value xml:lang="ko"><![CDATA[비추천 수]]></value>
 		<value xml:lang="en"><![CDATA[Blames]]></value>
+		<value xml:lang="jp"><![CDATA[非推奨数]]></value>
 		<value xml:lang="zh-CN"><![CDATA[Blames]]></value>
 		<value xml:lang="zh-TW"><![CDATA[Blames]]></value>
 		<value xml:lang="tr"><![CDATA[Suçlama]]></value>
@@ -2388,6 +2393,7 @@
 	<item name="unit_count">
 		<value xml:lang="ko"><![CDATA[회]]></value>
 		<value xml:lang="en"><![CDATA[count]]></value>
+		<value xml:lang="jp"><![CDATA[回]]></value>
 	</item>
 	<item name="unit_week" type="array">
 		<item name="Monday">
@@ -2620,22 +2626,27 @@
 	<item name="about_ipaddress_input">
 		<value xml:lang="ko"><![CDATA[IP주소 입력형식<br />1. 와일드카드(*) 사용가능(예: 192.168.0.*)<br />2. 하이픈(-)을 사용하여 대역으로 입력가능<br />(단, 대역폭으로 입력할 경우 와일드카드 사용불가. 예: 192.168.0.1-192.168.0.254)<br />3.여러개의 항목은 줄을 바꾸어 입력하세요]]></value>
 		<value xml:lang="en"><![CDATA[IP address input format<br />You can use wildcard(*) (ex: 192.168.0.*)<br />You can use hyphen(*) for ip range  (you can't use wild card with hyphen, ex: 192.168.0.1-192.168.0.254)<br />]]></value>
+		<value xml:lang="jp"><![CDATA[IPアドレス入力方法<br />１．ワイルドカード（＊）使用可能（例：192.168.0.*)<br />２．ハイフン（-）を使用して帯域で入力可能<br />（ただし、帯域幅で入力する場合、ワイルドカードは使用不可。例：192.168.0.1-192.168.0.254）<br />３．複数の項目は行を変えて入力してください。]]></value>
 	</item>
 	<item name="msg_invalid_ip">
 		<value xml:lang="ko"><![CDATA[잘못된 IP주소 형식입니다.]]></value>
 		<value xml:lang="en"><![CDATA[Specified IP address is invalid.]]></value>
+		<value xml:lang="jp"><![CDATA[正しくないIPアドレス形式です。]]></value>
 	</item>
 	<item name="msg_no_root">
 		<value xml:lang="ko"><![CDATA[루트는 선택 할 수 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[You cannot select a root.]]></value>
+		<value xml:lang="jp"><![CDATA[ルートは選択できません。]]></value>
 	</item>
 	<item name="msg_no_shortcut">
 		<value xml:lang="ko"><![CDATA[바로가기는 선택 할 수 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[You cannot select a shortcut.]]></value>
+		<value xml:lang="jp"><![CDATA[ショートカットは選択できません。]]></value>
 	</item>
 	<item name="msg_select_menu">
 		<value xml:lang="ko"><![CDATA[대상 메뉴 선택]]></value>
 		<value xml:lang="en"><![CDATA[Select target menu]]></value>
+		<value xml:lang="jp"><![CDATA[対象メニュー選択]]></value>
 	</item>
 	<item name="msg_call_server">
 		<value xml:lang="ko"><![CDATA[서버에 요청 중입니다. 잠시만 기다려주세요.]]></value>
@@ -2876,6 +2887,7 @@
 	<item name="msg_empty_search_target">
 		<value xml:lang="ko"><![CDATA[검색대상이 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Cannot find the Search target.]]></value>
+		<value xml:lang="jp"><![CDATA[検索対象がありません。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[搜索不到目标]]></value>
 		<value xml:lang="zh-TW"><![CDATA[搜尋不到目標]]></value>
 		<value xml:lang="tr"><![CDATA[Arama amacı bulunamadı]]></value>
@@ -2883,6 +2895,7 @@
 	<item name="msg_empty_search_keyword">
 		<value xml:lang="ko"><![CDATA[검색어가 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Cannot find the Keyword.]]></value>
+		<value xml:lang="jp"><![CDATA[キーワードがありません。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[搜索不到关键字]]></value>
 		<value xml:lang="zh-TW"><![CDATA[搜尋不到關鍵字]]></value>
 		<value xml:lang="tr"><![CDATA[Anahtar kelime yok]]></value>
@@ -2890,6 +2903,7 @@
 	<item name="comment_to_be_approved">
 		<value xml:lang="ko"><![CDATA[관리자의 확인이 필요한 댓글입니다.]]></value>
 		<value xml:lang="en"><![CDATA[Your comment must be approved by admin before being published.]]></value>
+		<value xml:lang="jp"><![CDATA[管理者の確認が必要なコメントです。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[您的回复在通过管理员审核之后才会被显示出来。]]></value>
 		<value xml:lang="tr"><![CDATA[Yorumunuz, yayınlanmadan önce adminden onay almanız gerekir]]></value>
 	</item>
@@ -2952,6 +2966,7 @@
 	<item name="success_declare_canceled">
 		<value xml:lang="ko"><![CDATA[신고 취소되었습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Declare was canceled successfully.]]></value>
+		<value xml:lang="jp"><![CDATA[通報が取り消しされました。]]></value>
 	</item>
 	<item name="success_restore">
 		<value xml:lang="ko"><![CDATA[복원했습니다.]]></value>
@@ -2964,7 +2979,7 @@
 	<item name="success_voted">
 		<value xml:lang="ko"><![CDATA[추천했습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Recommended successfully.]]></value>
-		<value xml:lang="jp"><![CDATA[推薦しました。]]></value>
+		<value xml:lang="jp"><![CDATA[推奨しました。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[推荐成功！]]></value>
 		<value xml:lang="zh-TW"><![CDATA[推薦成功！]]></value>
 		<value xml:lang="fr"><![CDATA[Voté avec succès]]></value>
@@ -2978,7 +2993,7 @@
 	<item name="success_blamed">
 		<value xml:lang="ko"><![CDATA[비추천했습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Not recommended successfully.]]></value>
-		<value xml:lang="jp"><![CDATA[非推薦しました。]]></value>
+		<value xml:lang="jp"><![CDATA[非推奨しました。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[反对成功！]]></value>
 		<value xml:lang="zh-TW"><![CDATA[反對成功！]]></value>
 		<value xml:lang="fr"><![CDATA[Blâmé avec succès]]></value>
@@ -2992,6 +3007,7 @@
 	<item name="success_copied">
 		<value xml:lang="ko"><![CDATA[복사했습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Copied successfully.]]></value>
+		<value xml:lang="jp"><![CDATA[コピしました。]]></value>
 	</item>
 	<item name="success_moved">
 		<value xml:lang="ko"><![CDATA[이동했습니다.]]></value>
@@ -3075,6 +3091,7 @@
 	<item name="fail_to_update">
 		<value xml:lang="ko"><![CDATA[수정하지 못했습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Fail to update.]]></value>
+		<value xml:lang="jp"><![CDATA[修正されませんでした。]]></value>
 		<value xml:lang="tr"><![CDATA[Güncellenemedi]]></value>
 	</item>
 	<item name="fail_to_delete">
@@ -3108,7 +3125,7 @@
 	<item name="failed_voted">
 		<value xml:lang="ko"><![CDATA[추천할 수 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[No permission to Recommend.]]></value>
-		<value xml:lang="jp"><![CDATA[推薦できません。]]></value>
+		<value xml:lang="jp"><![CDATA[推奨できません。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[您不能推荐！]]></value>
 		<value xml:lang="zh-TW"><![CDATA[無法推薦！]]></value>
 		<value xml:lang="fr"><![CDATA[N'a pas pu recommander]]></value>
@@ -3122,7 +3139,7 @@
 	<item name="failed_blamed">
 		<value xml:lang="ko"><![CDATA[비추천할 수 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[No permission to Not Recommend.]]></value>
-		<value xml:lang="jp"><![CDATA[非推薦できません。]]></value>
+		<value xml:lang="jp"><![CDATA[非推奨できません。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[您不能投反对！]]></value>
 		<value xml:lang="zh-TW"><![CDATA[無法反對！]]></value>
 		<value xml:lang="fr"><![CDATA[N'a pas pu blâmer]]></value>
@@ -3192,7 +3209,7 @@
 	<item name="confirm_vote">
 		<value xml:lang="ko"><![CDATA[추천하시겠습니까?]]></value>
 		<value xml:lang="en"><![CDATA[Are you sure you want to recommend?]]></value>
-		<value xml:lang="jp"><![CDATA[推薦しますか？]]></value>
+		<value xml:lang="jp"><![CDATA[推奨しますか？]]></value>
 		<value xml:lang="zh-CN"><![CDATA[确定要推荐吗?]]></value>
 		<value xml:lang="zh-TW"><![CDATA[確定要推薦嗎?]]></value>
 		<value xml:lang="fr"><![CDATA[Vous voulez recommander?]]></value>
@@ -3283,6 +3300,7 @@
 	<item name="confirm_process">
 		<value xml:lang="ko"><![CDATA[처리하시겠습니까?]]></value>
 		<value xml:lang="en"><![CDATA[Are you sure you want to process?]]></value>
+		<value xml:lang="jp"><![CDATA[処理しますか？]]></value>
 	</item>
 	<item name="column_type">
 		<value xml:lang="ko"><![CDATA[형식]]></value>
@@ -3694,6 +3712,7 @@
 		<item name="invalid_mid">
 			<value xml:lang="ko"><![CDATA[%s의 형식이 잘못되었습니다. 첫 글자는 영문으로 시작해야 하며 '영문+숫자+_'로만 입력해야 합니다.]]></value>
 			<value xml:lang="en"><![CDATA[The format of %s is invalid. Module ID should be begun with a letter. Subsequent characters may be letters, digits or underscore characters.]]></value>
+			<value xml:lang="jp"><![CDATA[%sの形式が正しくありません。 最初の文字は英文から始め、「英文＋数字＋_」組合せで入力が必要です。]]></value>
 			<value xml:lang="zh-CN"><![CDATA[%s 格式错误。 模块名称只能用英文、数字及下划线，开头必须是英文。]]></value>
 			<value xml:lang="zh-TW"><![CDATA[%s 格式錯誤。 模組名稱只能使用英文、數字及底線，開頭必須是英文。]]></value>
 			<value xml:lang="tr"><![CDATA[%s formatı geçersizdir. Modülün ID'si harf ile başlaması gerekmektedir.]]></value>
@@ -3757,6 +3776,7 @@
 	<item name="cmd_set_multilingual">
 		<value xml:lang="ko"><![CDATA[다국어 설정]]></value>
 		<value xml:lang="en"><![CDATA[Select Language]]></value>
+		<value xml:lang="jp"><![CDATA[多言語設定]]></value>
 		<value xml:lang="zh-CN"><![CDATA[选择语言]]></value>
 		<value xml:lang="zh-TW"><![CDATA[選擇語言]]></value>
 		<value xml:lang="de"><![CDATA[Sprache wählen]]></value>
@@ -3765,6 +3785,7 @@
 	<item name="cmd_multilingual">
 		<value xml:lang="ko"><![CDATA[다국어]]></value>
 		<value xml:lang="en"><![CDATA[Language]]></value>
+		<value xml:lang="jp"><![CDATA[多言語]]></value>
 		<value xml:lang="zh-CN"><![CDATA[语言]]></value>
 		<value xml:lang="zh-TW"><![CDATA[語言]]></value>
 		<value xml:lang="de"><![CDATA[Sprache]]></value>
@@ -3773,6 +3794,7 @@
 	<item name="find_site">
 		<value xml:lang="ko"><![CDATA[사이트 찾기]]></value>
 		<value xml:lang="en"><![CDATA[Find Site]]></value>
+		<value xml:lang="jp"><![CDATA[サイト検索]]></value>
 		<value xml:lang="zh-CN"><![CDATA[查找站点]]></value>
 		<value xml:lang="zh-TW"><![CDATA[尋找網站]]></value>
 		<value xml:lang="de"><![CDATA[Website Finden]]></value>
@@ -3781,6 +3803,7 @@
 	<item name="captcha">
 		<value xml:lang="ko"><![CDATA[Captcha]]></value>
 		<value xml:lang="en"><![CDATA[Captcha]]></value>
+		<value xml:lang="jp"><![CDATA[キャプチャ]]></value>
 		<value xml:lang="zh-CN"><![CDATA[图形验证码]]></value>
 		<value xml:lang="zh-TW"><![CDATA[圖形驗證]]></value>
 		<value xml:lang="tr"><![CDATA[Güvenlik Kodu]]></value>
@@ -3788,6 +3811,7 @@
 	<item name="reload">
 		<value xml:lang="ko"><![CDATA[새로고침]]></value>
 		<value xml:lang="en"><![CDATA[reload]]></value>
+		<value xml:lang="jp"><![CDATA[再読み込み]]></value>
 		<value xml:lang="zh-CN"><![CDATA[重新加载]]></value>
 		<value xml:lang="zh-TW"><![CDATA[重新讀取]]></value>
 		<value xml:lang="tr"><![CDATA[tekrar yükle]]></value>
@@ -3795,6 +3819,7 @@
 	<item name="play">
 		<value xml:lang="ko"><![CDATA[음성재생]]></value>
 		<value xml:lang="en"><![CDATA[play]]></value>
+		<value xml:lang="jp"><![CDATA[プレイ]]></value>
 		<value xml:lang="zh-CN"><![CDATA[播放]]></value>
 		<value xml:lang="zh-TW"><![CDATA[播放]]></value>
 		<value xml:lang="tr"><![CDATA[Oynat]]></value>
@@ -3802,6 +3827,7 @@
 	<item name="use_and_display">
 		<value xml:lang="ko"><![CDATA[사용+노출]]></value>
 		<value xml:lang="en"><![CDATA[Use+Display]]></value>
+		<value xml:lang="jp"><![CDATA[使用＋ディスプレイ]]></value>
 		<value xml:lang="zh-CN"><![CDATA[使用+显示]]></value>
 		<value xml:lang="zh-TW"><![CDATA[使用+顯示]]></value>
 		<value xml:lang="tr"><![CDATA[Kullan + Göster]]></value>
@@ -3809,6 +3835,7 @@
 	<item name="mobile">
 		<value xml:lang="ko"><![CDATA[모바일]]></value>
 		<value xml:lang="en"><![CDATA[Mobile]]></value>
+		<value xml:lang="jp"><![CDATA[モバイル]]></value>
 	</item>
 	<item name="mobile_view">
 		<value xml:lang="ko"><![CDATA[모바일 뷰 사용]]></value>
@@ -3860,6 +3887,7 @@
 	<item name="skip_to_content">
 		<value xml:lang="ko"><![CDATA[메뉴 건너뛰기]]></value>
 		<value xml:lang="en"><![CDATA[Skip to content]]></value>
+		<value xml:lang="jp"><![CDATA[メニュースキップ]]></value>
 	</item>
 	<item name="dashboard">
 		 <value xml:lang="ko"><![CDATA[대시보드]]></value>
@@ -3878,13 +3906,16 @@
 	<item name="yes">
 		<value xml:lang="ko"><![CDATA[예]]></value>
 		<value xml:lang="en"><![CDATA[Yes]]></value>
+		<value xml:lang="jp"><![CDATA[はい]]></value>
 	</item>
 	<item name="not">
 		<value xml:lang="ko"><![CDATA[아니오]]></value>
 		<value xml:lang="en"><![CDATA[No]]></value>
+		<value xml:lang="jp"><![CDATA[いいえ]]></value>
 	</item>
 	<item name="msg_default_url_is_null">
 		<value xml:lang="ko"><![CDATA[기본 URL 설정이 안 되어 있습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Default url is null.]]></value>
+		<value xml:lang="jp"><![CDATA[基本URLが設定されていません。]]></value>
 	</item>
 </lang>


### PR DESCRIPTION
XE 기본 언어에 추가되지 않은 일본어를 번역했습니다.
1. XE 기본언어에 일본어 번역 추가
2. 추천이란 단어를 변경 推薦 -> 推奨
3. inquiry를 お問い合わせ로 번역(어째서인지 한국어는 '조회'란 언어로 되어있는데 누가 좀 알려주세요.) 
