### PR TITLE
통합검색 기능 ON/OFF 가능하게 수정

### DIFF
--- a/modules/integration_search/integration_search.admin.controller.php
+++ b/modules/integration_search/integration_search.admin.controller.php
@@ -27,6 +27,7 @@ class integration_searchAdminController extends integration_search
 		$oModuleModel = getModel('module');
 		$config = $oModuleModel->getModuleConfig('integration_search');
 
+		$args->enabled = Context::get('enabled');
 		$args->skin = Context::get('skin');
 		$args->target = Context::get('target');
 		$args->target_module_srl = Context::get('target_module_srl');

--- a/modules/integration_search/integration_search.view.php
+++ b/modules/integration_search/integration_search.view.php
@@ -41,6 +41,10 @@ class integration_searchView extends integration_search
 
 		$config = $oModuleModel->getModuleConfig('integration_search');
 		if(!$config) $config = new stdClass;
+		if($config->enabled == 'N')
+		{
+			return new Object(-1, 'msg_not_permitted');
+		}
 		if(!$config->skin)
 		{
 			$config->skin = 'default';

--- a/modules/integration_search/tpl/index.html
+++ b/modules/integration_search/tpl/index.html
@@ -11,6 +11,18 @@
 	<input type="hidden" name="xe_validator_id" value="modules/integration_search/tpl/index/1" />
 
 	<div class="x_control-group">
+		<label for="enabled" class="x_control-label">{$lang->integration_search}</label>
+		<div class="x_controls">
+			<label class="x_inline">
+				<input type="radio" id="enabled_y" name="enabled" value="Y" checked|cond="!$config->enabled || $config->enabled == 'Y'"> {$lang->use}
+			</label>
+			<label class="x_inline">
+				<input type="radio" id="enabled_n" name="enabled" value="N" checked|cond="$config->enabled == 'N'"> {$lang->notuse}
+			</label>
+			<p class="x_help-block">{$lang->about_use_integration_search}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
 		<label for="sample_code" class="x_control-label">{$lang->sample_code}</label>
 		<div class="x_controls" style="margin-right:14px">
 			<textarea id="sample_code" readonly style="width:100%;height:100px;cursor:text;font-family:'Courier New', Courier, monospace">{$sample_code}</textarea>


### PR DESCRIPTION
DB 부하 이슈 등의 이유로 통합검색 기능을 사용하고 싶지 않은 경우 통합검색 페이지의 접근을 차단할 필요가 있음.

통합검색 코드가 레이아웃에 없어도 직접 해당 페이지에 접근 가능함.
