### PR TITLE
회원계정의 정지일 안내문 표현 개선

### DIFF
--- a/modules/member/lang/lang.xml
+++ b/modules/member/lang/lang.xml
@@ -1629,9 +1629,9 @@
 		<value xml:lang="vi"><![CDATA[Bạn chưa xác nhận việc đăng kí. Xin vui lòng kiểm tra Email!]]></value>
 	</item>
 	<item name="msg_user_limited">
-		<value xml:lang="ko"><![CDATA[입력한 아이디는 %s 이후부터 사용할 수 있습니다.]]></value>
-		<value xml:lang="en"><![CDATA[You have entered an ID that can be used after %s]]></value>
-		<value xml:lang="jp"><![CDATA[入力したユーザーIDは%s以降から使用できます。]]></value>
+		<value xml:lang="ko"><![CDATA[입력한 아이디는 %s 까지 사용하실 수 없습니다.]]></value>
+		<value xml:lang="en"><![CDATA[You have entered an ID that cannot be used before %s]]></value>
+		<value xml:lang="jp"><![CDATA[入力したユーザIDは%s以前まで使用できません。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[您输入的用户名%s以后才可以开始使用。]]></value>
 		<value xml:lang="zh-TW"><![CDATA[您輸入的帳號 %s 以後才可以開始使用。]]></value>
 		<value xml:lang="fr"><![CDATA[Vous avez entré un compte qui peut être utilisé depuis %s]]></value>


### PR DESCRIPTION
~이후 사용 가능을 ~까지 사용 불가로 변경
