### PR TITLE
getBrowserTitle()이 동작하지 않는 문제 수정

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -1138,7 +1138,7 @@ class documentItem extends Object
 
 	function getBrowserTitle()
 	{
-		$this->getModuleName();
+		return $this->getModuleName();
 	}
 }
 /* End of file document.item.php */


### PR DESCRIPTION
값을 return 해주지 않아 정상적으로 동작하지 않는 문제 수정.
