### PR TITLE
#375 게시판 정렬 기준 컬럼 변경 regdate -> list_order

### DIFF
--- a/modules/board/board.admin.view.php
+++ b/modules/board/board.admin.view.php
@@ -55,7 +55,7 @@ class boardAdminView extends board {
 
 		// install order (sorting) options
 		foreach($this->order_target as $key) $order_target[$key] = Context::getLang($key);
-		$order_target['list_order'] = Context::getLang('document_srl');
+		$order_target['list_order'] = Context::getLang('regdate');
 		$order_target['update_order'] = Context::getLang('last_update');
 		Context::set('order_target', $order_target);
 	}

--- a/modules/board/board.class.php
+++ b/modules/board/board.class.php
@@ -11,7 +11,7 @@ class board extends ModuleObject
 {
 	var $search_option = array('title','content','title_content','comment','user_name','nick_name','user_id','tag'); ///< 검색 옵션
 
-	var $order_target = array('list_order', 'update_order', 'regdate', 'voted_count', 'blamed_count', 'readed_count', 'comment_count', 'title'); // 정렬 옵션
+	var $order_target = array('list_order', 'update_order', 'voted_count', 'blamed_count', 'readed_count', 'comment_count', 'title'); // 정렬 옵션
 
 	var $skin = "default"; ///< skin name
 	var $list_count = 20; ///< the number of documents displayed in a page

--- a/modules/board/skins/default/list.html
+++ b/modules/board/skins/default/list.html
@@ -11,9 +11,9 @@
 				<th scope="col" cond="$val->type=='nick_name' && $val->idx==-1"><span>{$lang->writer}</span></th>
 				<th scope="col" cond="$val->type=='user_id' && $val->idx==-1"><span>{$lang->user_id}</span></th>
 				<th scope="col" cond="$val->type=='user_name' && $val->idx==-1"><span>{$lang->user_name}</span></th>
-				<th scope="col" cond="$val->type=='regdate' && $val->idx==-1"><span><a href="{getUrl('sort_index','regdate','order_type',$order_type)}">{$lang->date}</a></span></th>
-				<th scope="col" cond="$val->type=='last_update' && $val->idx==-1"><span><a href="{getUrl('sort_index','last_update','order_type',$order_type)}">{$lang->last_update}</a></span></th>
-				<th scope="col" cond="$val->type=='last_post' && $val->idx==-1"><span><a href="{getUrl('sort_index','last_update','order_type',$order_type)}">{$lang->last_post}</a></span></th>
+				<th scope="col" cond="$val->type=='regdate' && $val->idx==-1"><span><a href="{getUrl('sort_index','list_order','order_type',$order_type)}">{$lang->date}</a></span></th>
+				<th scope="col" cond="$val->type=='last_update' && $val->idx==-1"><span><a href="{getUrl('sort_index','update_order','order_type',$order_type)}">{$lang->last_update}</a></span></th>
+				<th scope="col" cond="$val->type=='last_post' && $val->idx==-1"><span><a href="{getUrl('sort_index','update_order','order_type',$order_type)}">{$lang->last_post}</a></span></th>
 				<th scope="col" cond="$val->type=='readed_count' && $val->idx==-1"><span><a href="{getUrl('sort_index','readed_count','order_type',$order_type)}">{$lang->readed_count}</a></span></th>
 				<th scope="col" cond="$val->type=='voted_count' && $val->idx==-1"><span><a href="{getUrl('sort_index','voted_count','order_type',$order_type)}">{$lang->voted_count}</a></span></th>
 				<th scope="col" cond="$val->type=='blamed_count' && $val->idx==-1"><span><a href="{getUrl('sort_index','blamed_count','order_type',$order_type)}">{$lang->blamed_count}</a></span></th>


### PR DESCRIPTION
- 게시판모듈 설정에서 문서번호 정렬(list_order)을 등록일 정렬로 변경(문서번호 표기는 삭제)
- default 스킨에서 sort_index의 regdate, last_update 값을 list_order, update_order로 변경
