### PR TITLE
Importer 모듈 버그 수정

### DIFF
--- a/modules/importer/importer.admin.controller.php
+++ b/modules/importer/importer.admin.controller.php
@@ -937,6 +937,7 @@ class importerAdminController extends importer
 				$obj->last_update = base64_decode($xmlDoc->comment->update->body);
 				if(!$obj->last_update) $obj->last_update = $obj->regdate;
 				$obj->ipaddress = base64_decode($xmlDoc->comment->ipaddress->body);
+				$obj->status = base64_decode($xmlDoc->comment->status->body);
 				$obj->list_order = $obj->comment_srl*-1;
 				// Change content information (attachment)
 				if(count($files))


### PR DESCRIPTION
Importer 모듈에 존재하던 버그를 수정했습니다
1. 댓글을 가져올 때, status 값을 지정해주지 않아 정상적으로 댓글이 생성되지 않던 문제
2. 첨부 파일을 가져올 때, xml 파일을 분석하는 반복문에서 계속 $file_obj를 재생성하는 문제

위 두 문제를 수정했습니다
