### PR TITLE
Importer 모듈 버그 수정

### DIFF
--- a/modules/importer/importer.admin.controller.php
+++ b/modules/importer/importer.admin.controller.php
@@ -937,6 +937,7 @@ class importerAdminController extends importer
 				$obj->last_update = base64_decode($xmlDoc->comment->update->body);
 				if(!$obj->last_update) $obj->last_update = $obj->regdate;
 				$obj->ipaddress = base64_decode($xmlDoc->comment->ipaddress->body);
+				$obj->status = base64_decode($xmlDoc->comment->status->body);
 				$obj->list_order = $obj->comment_srl*-1;
 				// Change content information (attachment)
 				if(count($files))


### PR DESCRIPTION
Importer 모듈에 존재하던 버그를 수정했습니다
1. 댓글의 status를 읽어오지 않아 댓글을 제대로 가져오지 못하던 문제
2. 첨부 파일을 처리하는 반복문에서 $file_obj를 계속 초기화해 첨부 파일을 제대로 가져오지 못하던 문제

위 두 문제를 수정했습니다
