### PR TITLE
decode된 닉네임도 확인함으로 기존 닉네임과의 충돌 검사 강화

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1958,7 +1958,8 @@ class memberController extends member
 			return new Object(-1,'denied_nick_name');
 		}
 		$member_srl = $oMemberModel->getMemberSrlByNickName($args->nick_name);
-		if($member_srl) return new Object(-1,'msg_exists_nick_name');
+		$member_srl_by_decode = $oMemberModel->getMemberSrlByNickName(html_entity_decode($args->nick_name));
+		if($member_srl || $member_srl_by_decode) return new Object(-1,'msg_exists_nick_name');
 
 		$member_srl = $oMemberModel->getMemberSrlByEmailAddress($args->email_address);
 		if($member_srl) return new Object(-1,'msg_exists_email_address');


### PR DESCRIPTION
&#(10진수) 형식으로 입력하여 XE 닉네임 중복 검사를 우회할 수 있는 문제 수정.

http://www.xpressengine.com/userForum/22618608
