### PR TITLE
Update member.controller.php

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -2118,7 +2118,7 @@ class memberController extends member
 		
 		$member_srl = $oMemberModel->getMemberSrlByNickName($args->nick_name);
 		$member_srl_by_decode = $oMemberModel->getMemberSrlByNickName(utf8_decode($args->nick_name));
- 		if($member_srl || $member_srl_by_decode) return new Object(-1,'msg_exists_nick_name');
+ 		if(($member_srl || $member_srl_by_decode) && $orgMemberInfo->nick_name != $args->nick_name) return new Object(-1,'msg_exists_nick_name');
 
 		list($args->email_id, $args->email_host) = explode('@', $args->email_address);
 		// Website, blog, checks the address


### PR DESCRIPTION
if($member_srl || $member_srl_by_decode) return new Object(-1,'msg_exists_nick_name');

자기 자신 회원정보를 수정할 수 없음

아래로 교체함

if(($member_srl || $member_srl_by_decode) && $orgMemberInfo->nick_name != $args->nick_name) return new Object(-1,'msg_exists_nick_name');

기존정보와 비교해서 같지 않아야만 이 검사가 진행됨 2121
