### PR TITLE
첨부 파일 설정 저장 시 Warning 에러 수정

### DIFF
--- a/modules/file/file.admin.controller.php
+++ b/modules/file/file.admin.controller.php
@@ -122,6 +122,7 @@ class fileAdminController extends file
 
 		$download_grant = Context::get('download_grant');
 
+		$file_config = new stdClass;
 		$file_config->allow_outlink = Context::get('allow_outlink');
 		$file_config->allow_outlink_format = Context::get('allow_outlink_format');
 		$file_config->allow_outlink_site = Context::get('allow_outlink_site');


### PR DESCRIPTION
추가 설정에서 첨부 파일 설정 저장 시 아래와 같은 Warning 에러가 발생해서 수정해보았습니다.

Warning: Creating default object from empty value in /xxx/xxx/public_html/modules/file/file.admin.controller.php on line 123
