### PR TITLE
browser_title이 없을 경우 warning 발생하는 문제 수정

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -403,7 +403,7 @@ class moduleModel extends module
 		else $module_info = $mid_info;
 
 		$oModuleController = getController('module');
-		$oModuleController->replaceDefinedLangCode($module_info->browser_title);
+		if(isset($module_info->browser_title)) $oModuleController->replaceDefinedLangCode($module_info->browser_title);
 
 		return $this->addModuleExtraVars($module_info);
 	}


### PR DESCRIPTION
apache 2.4/ php5.4게시글 관리 등에서 문제 발생
xe core 1.7.5 beta1
