### PR TITLE
모듈 포맷 0.1 처리 부분의 php 5.4 대응 stdClass 정의 누락 수정

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -785,6 +785,7 @@ class moduleModel extends module
 			if(!$module_info->category) $module_info->category = 'service';
 			sscanf($xml_obj->author->attrs->date, '%d. %d. %d', $date_obj->y, $date_obj->m, $date_obj->d);
 			$module_info->date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
+			$author_obj = new stdClass();
 			$author_obj->name = $xml_obj->author->name->body;
 			$author_obj->email_address = $xml_obj->author->attrs->email_address;
 			$author_obj->homepage = $xml_obj->author->attrs->link;


### PR DESCRIPTION
모듈 포맷 0.2는 수정이 되었으나 0.1이 되어있지 않아 생길수 있는 문제 수정
