### PR TITLE
잘못된 모듈 정보의 경우 파싱하지 않음

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -1501,6 +1501,7 @@ class moduleModel extends module
 			$info = $this->getModuleInfoXml($module_name);
 			unset($obj);
 
+			if(!isset($info)) continue;
 			$info->module = $module_name;
 			$info->created_table_count = $created_table_count;
 			$info->table_count = $table_count;


### PR DESCRIPTION
modules 폴더 안 올바르지 않은 구조의 폴더가 있을 경우 문제가 됨

zip 파일까지 파싱해 버리는 것 같은데 해당 부분 수정 필요(modules 폴더로 zip 업로드 뒤 ssh로 압축풀기 진행 후 zip 파일을 미삭제시 오류의 원인이 됨)
