### PR TITLE
fix #610 올바르지 않은 모듈 정보의 경우 스킵

### DIFF
--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -349,6 +349,7 @@ class menuAdminModel extends menu
 		foreach($_allModules as $module_name)
 		{
 			$module = $oModuleModel->getModuleInfoXml($module_name);
+			if(!isset($module)) continue;
 			$defaultSkin = $oModuleModel->getModuleDefaultSkin($module_name, 'P');
 			$defaultMobileSkin = $oModuleModel->getModuleDefaultSkin($module_name, 'M');
 			$skinInfo = $oModuleModel->loadSkinInfo(ModuleHandler::getModulePath($module_name), $defaultSkin);


### PR DESCRIPTION
$module이 null일때 skin 관련 작업을 하면 생기는 warning때문에 사이트 디자인 설정이 불가능해지는 문제 수정.
