### PR TITLE
security 클래스의 화이트리스트 설정중 mncast 프로필 삭제

### DIFF
--- a/classes/security/conf/embedWhiteUrl.xml
+++ b/classes/security/conf/embedWhiteUrl.xml
@@ -15,10 +15,6 @@
 			<pattern>http://api.v.daum.net/</pattern>
 			<pattern>http://tvpot.daum.net/playlist/playlist.swf</pattern>
 		</domain>
-		<domain name="http://www.mncast.com" desc="엠엔캐스트">
-			<pattern>http://dory.mncast.com/mncHMovie.swf</pattern>
-			<pattern>http://dory.mncast.com/mncastPlayer.swf</pattern>
-		</domain>
 		<domain name="http://www.youtube.com" desc="Youtube">
 			<pattern>http://www.youtube.com/v/</pattern>
 			<pattern>http://www.youtube-nocookie.com/</pattern>


### PR DESCRIPTION
(git을 쓰는게 어색해서 그런지 이렇게 하는게 맞는지 모르겠습니다 ^^;)
mncast의 사이트가 닫힌지 어연 5년이 지나갔고, 해당 도메인 소유권도 말소되어 다른사람이 받아가 현재는 스미싱 사이트로 이용되고 있습니다.
만일의 사태를 방지하기 위해서라도 수정해야될듯 합니다.
