### PR TITLE
확장변수중 checkbox, radio, select의 기본값들의 공백 제거

### DIFF
--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -424,7 +424,7 @@ class ExtraItem
 				Context::loadJavascriptPlugin('ui.datepicker');
 
 				$buff[] = '<input type="hidden" name="' . $column_name . '" value="' . $value . '" />'; 
-				$buff[] =	'<input type="text" id="date_' . $column_name . '" value="' . zdate($value, 'Y-m-d') . '" class="date" />'
+				$buff[] =	'<input type="text" id="date_' . $column_name . '" value="' . zdate($value, 'Y-m-d') . '" class="date" />';
 				$buff[] =	'<input type="button" value="' . Context::getLang('cmd_delete') . '" class="btn" id="dateRemover_' . $column_name . '" />';
 				$buff[] =	'<script type="text/javascript">';
 				$buff[] = '//<![CDATA[';


### PR DESCRIPTION
주로 글을 작성할때 checkbox', 'radio', 'select와 같이 콤마 다음에는 띄어쓰기를 사용합니다.
현재 확장변수의 기본값 옵션의 콤마 뒷부분에 공백이 포함된 내용을 사용자들이 작성할경우, 목록에 보일때 사용자들이 원치 않는 띄어쓰기까지 같이 포함됩니다.
이에 대해서 개선하기 위하여 trim을 이용했습니다.

그리고 switch 내에 같은 동작을 하는 case가 있어 병합했습니다.
