### PR TITLE
Update board.view.php

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -184,8 +184,9 @@ class boardView extends board
 		// list config, columnList setting
 		$oBoardModel = getModel('board');
 		$this->listConfig = $oBoardModel->getListConfig($this->module_info->module_srl);
-		if(!$this->listConfig) $this->listConfig = array();
-		$this->_makeListColumnList();
+		if(!$this->listConfig) $this-listConfig = array();
+		if($this->module_info->use_make_column=='Y') $this->_makeListColumnList();
+		//$this->_makeListColumnList();
 
 		// display the notice list
 		$this->dispBoardNoticeList();


### PR DESCRIPTION
목록설정의 장점을 살리면서
표시하는 부분은 사용자가 판단해서 스킨에 적용할 수 있도록 
이 옵션의 사용여부를 설정하는 것입니다.
그런데 코어에서는 강제로 목록에 설정된 값만을 목록에서 불러오도록 되어 있어서 
스킨작업시 설정할 수 없는 값은 처리하는데 어려움이 있습니다.

이부분은 skin설정 이나 여타 다른곳에 설정할 수 있으니 코어에서는 이 옵션만 제공하면 충분합니다.
