### PR TITLE
#588 템플릿 파일 오류시 오류 정보와 해당 오류가 발생한 템플릿 파일을 출력

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -370,7 +370,11 @@ class TemplateHandler
 		else
 		{
 			$eval_str = "?>" . $buff;
-			eval($eval_str);
+			@eval($eval_str);
+			$error_info=error_get_last();
+			if ($error_info[type]==4){
+				echo "Error Pharsing Template - " . $error_info[message] . " in template file " . $this->file . '<br />';
+			}
 		}
 
 		return ob_get_clean();


### PR DESCRIPTION
eval에서 발생하는 오류 대신 실제 오류가 발생한 템플릿 파일을 출력함으로 디버깅시 참고 가능하게함
