### PR TITLE
#588 템플릿 파일 오류시 오류 정보와 해당 오류가 발생한 템플릿 파일을 출력

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -365,15 +365,22 @@ class TemplateHandler
 		ob_start();
 		if(substr($buff, 0, 7) == 'file://')
 		{
-			//load cache file from disk
-			$eval_str = FileHandler::readFile(substr($buff, 7));
-			$eval_str_buffed = "?>" . $eval_str;
-			@eval($eval_str_buffed);
-			$error_info = error_get_last();
-			//parse error
-			if ($error_info['type'] == 4)
+			if(__DEBUG__)
 			{
-			    throw new Exception("Error Parsing Template - {$error_info['message']} in template file {$this->file}");
+				//load cache file from disk
+				$eval_str = FileHandler::readFile(substr($buff, 7));
+				$eval_str_buffed = "?>" . $eval_str;
+				@eval($eval_str_buffed);
+				$error_info = error_get_last();
+				//parse error
+				if ($error_info['type'] == 4)
+				{
+				    throw new Exception("Error Parsing Template - {$error_info['message']} in template file {$this->file}");
+				}
+			}
+			else
+			{
+				include(substr($buff, 7));
 			}
 		}
 		else


### PR DESCRIPTION
eval에서 발생하는 오류 대신 실제 오류가 발생한 템플릿 파일을 출력함으로 디버깅시 참고 가능하게함
file 캐시 사용시에 캐시파일을 include하는 대신 readFile후 eval하도록 수정

개선 코드(by @lansi951 ) 반영
오타 수정
#659 는 닫습니다.
