### PR TITLE
Captcha 애드온을 켜면, PC 화면에서 jquery를 중복 로드하는 문제 수정

### DIFF
--- a/addons/captcha/captcha.addon.php
+++ b/addons/captcha/captcha.addon.php
@@ -12,8 +12,11 @@ if(!defined("__XE__")) exit();
 if(!class_exists('AddonCaptcha', false))
 {
 	// On the mobile mode, XE Core does not load jquery and xe.js as normal.
-	Context::loadFile(array('./common/js/jquery.min.js', 'head', NULL, -100000), true);
-	Context::loadFile(array('./common/js/xe.min.js', 'head', NULL, -100000), true);
+	if(Mobile::isFromMobilePhone())
+	{
+		Context::loadFile(array('./common/js/jquery.min.js', 'head', NULL, -100000), true);
+		Context::loadFile(array('./common/js/xe.min.js', 'head', NULL, -100000), true);
+	}
 
 	class AddonCaptcha
 	{

--- a/addons/captcha_member/captcha_member.addon.php
+++ b/addons/captcha_member/captcha_member.addon.php
@@ -12,8 +12,11 @@ if(!defined("__XE__")) exit();
 if(!class_exists('AddonMemberCaptcha', false))
 {
 	// On the mobile mode, XE Core does not load jquery and xe.js as normal.
-	Context::loadFile(array('./common/js/jquery.min.js', 'head', NULL, -100000), true);
-	Context::loadFile(array('./common/js/xe.min.js', 'head', NULL, -100000), true);
+	if(Mobile::isFromMobilePhone())
+	{
+		Context::loadFile(array('./common/js/jquery.min.js', 'head', NULL, -100000), true);
+		Context::loadFile(array('./common/js/xe.min.js', 'head', NULL, -100000), true);
+	}
 
 	class AddonMemberCaptcha
 	{


### PR DESCRIPTION
캡차 애드온을 켜면 PC에서 jquery를 중복으로 로드하기 때문에, 트래픽이 더 많이 나오거나 서로 충돌을 일으킬 수 있기 때문에, 모바일인 경우에만 jquery를 로드하도록 수정했습니다.
