### PR TITLE
이미지 파일 삽입시 빈 줄 추가

### DIFF
--- a/modules/editor/tpl/js/uploader.js
+++ b/modules/editor/tpl/js/uploader.js
@@ -422,7 +422,7 @@ function insertUploadedFile(editorSequence) {
 				temp_code = '';
 				temp_code += "<img src=\""+file.download_url+"\" alt=\""+file.source_filename+"\"";
 				if(obj.complete === true) { temp_code += " width=\""+obj.width+"\" height=\""+obj.height+"\""; }
-				temp_code += " />\r\n";
+				temp_code += " />\r\n<p><br /></p>\r\n";
 				text.push(temp_code);
 			} else {
 				// 이미지외의 경우는 multimedia_link 컴포넌트 연결


### PR DESCRIPTION
&lt;p&gt;&lt;br /&gt;&lt;/p&gt;를 이미지 삽입 시 &lt;img /&gt; 다음 줄에 추가.
(사람마다 다르긴 하겠지만, 주요 포털들의 에디터 및 수많은 경우에 이미지 다음에 빈 줄을 삽입하므로, XE에도 적용되면 어떨가 해서 수정했습니다.)
