### PR TITLE
가상 사이트가 아닌 경우 권한 설정에서 가입한 사용자 항목 삭제

### DIFF
--- a/modules/module/tpl/module_grants.html
+++ b/modules/module/tpl/module_grants.html
@@ -47,7 +47,7 @@
 					<select name="{$grant_name}_default" id="{$grant_name}_default" class="grant_default">
 						<!--@if($grant_item->default == 'guest')--><option value="0" <!--@if($default_grant[$grant_name]=='all')-->selected="selected"<!--@end-->>{$lang->grant_to_all}</option><!--@end-->
 						<!--@if($grant_item->default != 'manager')--><option value="-1" <!--@if($default_grant[$grant_name]=='member')-->selected="selected"<!--@end-->>{$lang->grant_to_login_user}</option><!--@end-->
-						<!--@if($grant_item->default != 'manager')--><option value="-2" <!--@if($default_grant[$grant_name]=='site')-->selected="selected"<!--@end-->>{$lang->grant_to_site_user}</option><!--@end-->
+						<option value="-2" selected="selected"|cond="$default_grant[$grant_name]=='site'" cond="$grant_item->default != 'manager' && $current_module_info->site_srl > 0">{$lang->grant_to_site_user}</option>
 						<option value="-3" <!--@if($default_grant[$grant_name]=='manager')-->selected="selected"<!--@end-->>{$lang->grant_to_admin}</option>
 						<option value="" <!--@if($default_grant[$grant_name]=='group')-->selected="selected"<!--@end-->>{$lang->grant_to_group}</option>
 					</select>


### PR DESCRIPTION
권한 설정 페이지에서 <b>로그인 사용자</b>와 <b>가입한 사용자</b>라는 항목의 의미가 모호하기 때문에, 사용자에게 혼란을 줄 수 있습니다. 특히나 단일 사이트(가상 사이트를 생성하지 않고 운영하는 사이트)를 운영하는 경우,가입한 사용자를 회원 가입한 사용자라고 잘못 해석하는 경우가 많습니다.

<b>그래서 메인 사이트에서는 보이지 않고, 가상 사이트에서만 "가입한 사용자"가 나오도록 수정했습니다.</b>

p.s 실제로 XE로 카페를 운영하는 경우라도 "가입한 사용자"는 모호한 용어입니다. "카페에 가입한 사용자"라고 명확하게 나오는 게 좋겠죠. 이는 CafeXE에서 다뤄야 할 이슈이기 때문에 이곳에서는 생략했습니다.
