### PR TITLE
프로필 사진의 기본 사이즈 값 불일치 이슈 해결

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -699,13 +699,12 @@ class memberController extends member
 		// Check uploaded file
 		if(!checkUploadedFile($target_file)) return;
 
-		$oModuleModel = getModel('module');
-		$config = $oModuleModel->getModuleConfig('member');
+		$oMemberModel = getModel('member');
+		$config = $oMemberModel->getMemberConfig();
+
 		// Get an image size
 		$max_width = $config->profile_image_max_width;
-		if(!$max_width) $max_width = "90";
 		$max_height = $config->profile_image_max_height;
-		if(!$max_height) $max_height = "20";
 		// Get a target path to save
 		$target_path = sprintf('files/member_extra_info/profile_image/%s', getNumberingPath($member_srl));
 		FileHandler::makeDir($target_path);


### PR DESCRIPTION
 프로필 사진의 기본 사이즈 값 불일치 #716 에 대한 이슈 해결.

두가지의 해결 방법.
- $max_width, $max_height 변수값을 80으로 설정.
- Member Model의 getMemberConfig를 통해 값을 가져오도록 설정.

변수 값의 중복 선언을 피하기 위해 후자의 방법을 선택함.
혹 다른 의견있으시면 댓글 남겨주시면 확인 후 다시 커밋하겠습니다.
