### PR TITLE
모듈 권한 관리 페이지의 일부 요소 문제 해결.

### DIFF
--- a/modules/module/tpl/module_grants.html
+++ b/modules/module/tpl/module_grants.html
@@ -32,7 +32,7 @@
 					<input type="text" name="admin_id" />
 					<button class="x_btn" type="button" onclick="doInsertAdmin()">{$lang->cmd_insert}</button>
 				</div>
-				<a href="#adminListHelp" class="x_icon-question-sign">{$lang->help}</a>
+				<a href="#adminListHelp" class="x_icon-question-sign" data-toggle="#adminListHelp">{$lang->help}</a>
 				<span id="adminListHelp" hidden>{$lang->about_admin_id}</span>
 			</div>
 		</div>


### PR DESCRIPTION
# adminListHelp 요소를 클릭해도 아무 반응이 없는 문제를 해결합니다.
