### PR TITLE
favicon 등록 안되는 문제 해결. type에 대해 .ico 가 아닌 .icon 으로 비교하여야 한다.

### DIFF
--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -335,7 +335,7 @@ class installAdminController extends install
 		list($width, $height, $type_no, $attrs) = @getimagesize($target_file);
 		if($iconname == 'favicon.ico')
 		{
-			if(!preg_match('/^.*\.ico$/i',$type)) {
+			if(!preg_match('/^.*\.icon$/i',$type)) {
 				Context::set('msg', '*.ico '.Context::getLang('msg_possible_only_file'));
 				return;
 			}


### PR DESCRIPTION
ico 파일을 올리게 되면 type 으로 "image/vnd.microsoft.icon" 가 설정되기 때문에 .ico 가 아닌 .icon 으로 해야한다.
