### PR TITLE
favicon 등록 실패 문제 해결. 

### DIFF
--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -346,7 +346,7 @@ class installAdminController extends install
 		}
 		else if($iconname == 'mobicon.png')
 		{
-			if(!preg_match('/^.*\.png$/i',$type)) {
+			if(!preg_match('/^.*(png).*$/',$type)) {
 				Context::set('msg', '*.png '.Context::getLang('msg_possible_only_file'));
 				return;
 			}


### PR DESCRIPTION
ico 파일을 올리게 되면 type 으로 "image/vnd.microsoft.icon" 가 설정되기 때문에 .ico 가 아닌 .icon 으로 해야한다.
