### PR TITLE
모바일 홈 화면 아이콘 등록 실패 문제 해결.

### DIFF
--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -346,7 +346,7 @@ class installAdminController extends install
 		}
 		else if($iconname == 'mobicon.png')
 		{
-			if(!preg_match('/^.*\.png$/i',$type)) {
+			if(!preg_match('/^.*(png).*$/',$type)) {
 				Context::set('msg', '*.png '.Context::getLang('msg_possible_only_file'));
 				return;
 			}


### PR DESCRIPTION
모바일 홈 화면 아이콘 등록 실패 문제 해결. 패치 이전의 코드가 정상적이여서 이전 코드로 되돌렸습니다.
