### PR TITLE
페이지나 게시판 생성 후 설정화면에 가면 '사이트기본스킨사용' 이 적용되지 않는 버그

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -405,6 +405,7 @@ class moduleModel extends module
 		$oModuleController = getController('module');
 		if(isset($module_info->browser_title)) $oModuleController->replaceDefinedLangCode($module_info->browser_title);
 
+		$this->applyDefaultSkin($module_info);
 		return $this->addModuleExtraVars($module_info);
 	}
 


### PR DESCRIPTION
페이지나 게시판 생성 후 설정화면에 가면 '사이트기본스킨사용' 이 적용되지 않는 버그
