### PR TITLE
이메일 재인증 오류

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1247,7 +1247,7 @@ class memberController extends member
 		$tpl_path = sprintf('%sskins/%s', $this->module_path, $member_config->skin);
 		if(!is_dir($tpl_path)) $tpl_path = sprintf('%sskins/%s', $this->module_path, 'default');
 
-		$auth_url = getFullUrl('','module','member','act','procMemberAuthAccount','member_srl',$memberInfo->member_srl, 'auth_key',$auth_info->auth_key);
+		$auth_url = getFullUrl('','module','member','act','procMemberAuthAccount','member_srl',$member_info->member_srl, 'auth_key',$auth_info->auth_key);
 		Context::set('auth_url', $auth_url);
 
 		$oTemplate = &TemplateHandler::getInstance();


### PR DESCRIPTION
인증메일 재 발송용 코드에 오류가 있습니다.
원래는 아래 처럼 와야 하는데
http://xxx.kr/index.php?module=member&act=procMemberAuthAccount&member_srl=XXX&auth_key=XXXXX
재발송에는 member_srl이 빠진 아래 처럼 인증 메일이 날아오러다고요.
확인 결과
http://xxx.kr/index.php?module=member&act=procMemberAuthAccount&auth_key=XXXXX

``` php
    /**
     * Request to re-send the authentication mail
     *
     * @return void|Object (void : success, Object : fail)
     */
    function procMemberResendAuthMail()
    {
        ...................................생략
        // Get content of the email to send a member
        Context::set('memberInfo', $memberInfo);
        Context::set('member_config', $member_config);

        $tpl_path = sprintf('%sskins/%s', $this->module_path, $member_config->skin);
        if(!is_dir($tpl_path)) $tpl_path = sprintf('%sskins/%s', $this->module_path, 'default');

        $auth_url = getFullUrl('','module','member','act','procMemberAuthAccount','member_srl',$memberInfo->member_srl, 'auth_key',$auth_info->auth_key);
        Context::set('auth_url', $auth_url);
```

$memberInfo->member_srl 이런식으로 되어있던데 다른곳과 다르게
$member_info->member_srl 이걸로 교체해야 동작 합니다.

$auth_url = getFullUrl('','module','member','act','procMemberAuthAccount','member_srl',$member_info->member_srl, 'auth_key',$auth_info->auth_key);
이 코드로 바꾸면 정상 동작합니다.
