### PR TITLE
메시지 모듈 스킨에서 <label> 이 빠져있는 부분을 발견했습니다.

### DIFF
--- a/modules/communication/skins/default/send_message.html
+++ b/modules/communication/skins/default/send_message.html
@@ -17,12 +17,12 @@
 				<td>{$receiver_info->nick_name}</td>
 			</tr>
 			<tr>
-				<th scope="row">{$lang->title}</th>
+				<th scope="row"><label for="message_title">{$lang->title}</label></th>
 				<td><input type="text" name="title" id="message_title" value="{$source_message->title}" style="width:90%" /></td>
 			</tr>
 			<tr>
 				<th scope="row">{$lang->cmd_option}</th>
-				<td><input type="checkbox" value="Y" name="send_mail" /> {$lang->cmd_send_mail}</td>
+				<td><input type="checkbox" value="Y" name="send_mail" id="send_mail" /> <label for="send_mail">{$lang->cmd_send_mail}</label></td>
 			</tr>
 		</table>
 		{$editor}


### PR DESCRIPTION
Set <label> for input elements.

라벨이 빠진 부분에 라벨을 붙여서 pull request를 보냅니다. 큰 수정은 아닙니다.
