### PR TITLE
SFTP 비활성화 관련 lang 수정

### DIFF
--- a/modules/admin/lang/lang.xml
+++ b/modules/admin/lang/lang.xml
@@ -817,8 +817,8 @@
 		<value xml:lang="tr"><![CDATA[SFTP'yi kullanmak istiyor musunuz?]]></value>
 	</item>
 	<item name="disable_sftp_support">
-		<value xml:lang="ko"><![CDATA[SFTP를 사용할 수 있는 환경이 아닙니다.]]></value>
-		<value xml:lang="en"><![CDATA[It is not the environment that can use SFTP.]]></value>
+		<value xml:lang="ko"><![CDATA[SFTP를 사용하시려면 ssh2 PHP 모듈을 설치하셔야 합니다.]]></value>
+		<value xml:lang="en"><![CDATA[You should install ssh2 PHP module to use SFTP.]]></value>
 		<value xml:lang="jp"><![CDATA[SFTPを使用できる環境ではありません。]]></value>
 		<value xml:lang="zh-CN"><![CDATA[关闭SFTP]]></value>
 		<value xml:lang="tr"><![CDATA[SFTP kullanabileceğiniz bir yer değildir.]]></value>


### PR DESCRIPTION
단순히 사용이 불가능한 환경이라고 표시하는 것보다 필요한 모듈을 표시하는 것이 효과적입니다.
(구글에 XE SFTP를 치면 "XE sftp를 사용할 수 있는 환경이 아닙니다" 라고 자동완성될 정도로 검색을 많이 하시는듯 싶습니다)
