### PR TITLE
icon 포맷 판단조건을 .icon 에서 icon 으로 교체

### DIFF
--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -335,7 +335,7 @@ class installAdminController extends install
 		list($width, $height, $type_no, $attrs) = @getimagesize($target_file);
 		if($iconname == 'favicon.ico')
 		{
-			if(!preg_match('/^.*\.icon$/i',$type)) {
+			if(!preg_match('/^.*\icon$/i',$type)) {
 				Context::set('msg', '*.ico '.Context::getLang('msg_possible_only_file'));
 				return;
 			}


### PR DESCRIPTION
제 서버에서는 mime type을 image/x-icon로 반환하네요.. 아마 일부 업로드가 안되는 사용자분도 이문제 때문인 것으로 추측됩니다.
