### PR TITLE
icon 포맷 판단조건을 .icon 에서 icon 으로 교체

### DIFF
--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -335,7 +335,7 @@ class installAdminController extends install
 		list($width, $height, $type_no, $attrs) = @getimagesize($target_file);
 		if($iconname == 'favicon.ico')
 		{
-			if(!preg_match('/^.*\.icon$/i',$type)) {
+			if(!preg_match('/^.*(icon).*$/',$type)) {
 				Context::set('msg', '*.ico '.Context::getLang('msg_possible_only_file'));
 				return;
 			}


### PR DESCRIPTION
http://www.xpressengine.com/forum/22752052#comment_22752133

image/x-icon으로 mime type가 넘어오는 경우가 있어서 변경합니다
