### PR TITLE
익명게시판에서 관리자 권한으로 글 수정시 관리자 글이 되는 문제 #557 이슈.

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -79,7 +79,10 @@ class boardController extends board
 			$obj->email_address = $obj->homepage = $obj->user_id = '';
 			$obj->user_name = $obj->nick_name = 'anonymous';
 			$bAnonymous = true;
-			$oDocument->add('member_srl', $obj->member_srl);
+			if($is_update===false)
+			{
+				$oDocument->add('member_srl', $obj->member_srl);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
 #557 이슈문제 해결코드입니다.

이 이슈의 경우 부가 설명이 필요합니다.
## 코딩방법

기본적으로 처리하고 잇던 익명관련 코드를 모두 지우고 그 코드를
`update the document if it is existed` 를 처리하고 있는 if문 속에 한 곳,
`insert a new document otherwise` 를 처리하고 있는 if문속에 두 곳 넣어서 처리했습니다.
update 으로 들어가는 코드에서는 `$obj->member_srl` 을 기입하지 않도록 했습니다.

기본적으로 `insert a new document otherwise`를 처리하는 부분에서는 member_srl 을 기입할 필요가 있습니다만 글을 수정하는 `update the document if it is existed`에서는 관리자가 수정할경우도 있기때문에 따로 member_srl 을 처리할 필요가 없습니다.
그래서 해당 부분을 따로 처리해야 할 부분이라고 생각이 되어서 이렇게 처리했습니다.
## 만일의 대한 개인적인 생각

제가 판단하기로는 코드가 늘어짐에 따라 약간의 느려짐이 있겠지만(?) `안전성`을 고려한다면.. 아마 이 방법이 맞지 않을까 생각하고 이렇게 코딩해서 PR을 보내봅니다. 

결정은 XE팀에서 잘 해주시리라 믿습니다.
