### PR TITLE
DB import시 댓글의 status 값이 0 이 들어가서 댓글정렬이 깨지는 현상 수정

### DIFF
--- a/modules/importer/importer.admin.controller.php
+++ b/modules/importer/importer.admin.controller.php
@@ -937,7 +937,7 @@ class importerAdminController extends importer
 				$obj->last_update = base64_decode($xmlDoc->comment->update->body);
 				if(!$obj->last_update) $obj->last_update = $obj->regdate;
 				$obj->ipaddress = base64_decode($xmlDoc->comment->ipaddress->body);
-				$obj->status = base64_decode($xmlDoc->comment->status->body);
+				$obj->status = base64_decode($xmlDoc->comment->status->body)==''?'1':base64_decode($xmlDoc->comment->status->body);
 				$obj->list_order = $obj->comment_srl*-1;
 				// Change content information (attachment)
 				if(count($files))


### PR DESCRIPTION
DB import 시 댓글의 status 값이 0 이 들어가서 댓글정렬이 깨지는 현상 수정. 기본값을 1 로 변경
