### PR TITLE
작성글보기 기능시 닉네임 기준이 아니라 회원번호 기준으로 검색되도록

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -458,7 +458,7 @@ class boardController extends board
 		}
 
 		//search
-		$url = getUrl('','mid',$mid,'search_target','nick_name','search_keyword',$member_info->nick_name);
+		$url = getUrl('','mid',$mid,'search_target','member_srl','search_keyword',$member_srl);
 		$oMemberController = getController('member');
 		$oMemberController->addMemberPopupMenu($url, 'cmd_view_own_document', '');
 


### PR DESCRIPTION
닉네임 클릭시 뜨는 메뉴 중 '작성글보기' 를 클릭시 닉네임을 기준으로 검색이 된다.
문제는, 실제 글 작성시의 닉네임을 기준으로 검색되는게 아니라,  해당 회원의 현재 닉네임 기준으로 검색이 된다.
memberpopup 자체가 회원번호를 기준으로 하다보니, 어쩔 수 없는 상황이긴한데..

회원이 닉네임을 중간에 변경한 경우.. 예전 닉네임의 글을 클릭해 '작성글보기'를 하면
해당 닉네임글은 정작 검색이 되지 않고,  닉네임 변경 후의 글들만 검색되는  이상한 현상이 나타난다

그럴바에야,  차라리 그냥 회원번호 기준으로 검색하는게 나을것 같다.
이 또한 문제는 있는데..   닉네임을 변경 전후의 연계성을 끊고파도 다 노출되어버리는 현상이 생기는데..
현재의 membermenu 를 바꾸려면  class="member_회원번호"  로 들어가는 모든 부분을 다 고쳐야하기에
버그 보다는 차라리  아예 회원번호로 검색되게 하거나,   아니면 아예 작성글보기  기능을 없애거나 해야할듯하다.

이렇게 회원번호로 검색하면 일단 닉네임 전후의 모든 글이 다 제대로 검색은 되는데..
게시판의 검색 항목에  회원번호 이용한 검색이 나타나지 않기에..  제목 -> 회원번호  이렇게 보이는 단점은 있다

검색대상에 회원번호를  일부러 안 나오게 한건지, 즉 이를 선택하게 해도 되는지 여부가 불확실해서..
이 부분은 굳이 수정해두지 않았는데...  이 부분도 반영하고프면

modules/board/board.class.php 에서

var $search_option = array('title','content','title_content','comment','user_name','nick_name','user_id','tag'); ///< 검색 옵션

부분을

var $search_option = array('title','content','title_content','comment','user_name','nick_name','user_id','tag','member_srl'); ///< 검색 옵션

로 바꾸고
lang.xml 에  member_srl 을  회원번호  로 설정하면 된다.