### PR TITLE
서명 을 회원가입 단계에서 바로 입력받을 수 있게 변경

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -353,6 +353,10 @@ class memberController extends member
 			$this->insertImageName($args->member_srl, $image_name['tmp_name']);
 		}
 
+		// Save Signature
+		$signature = Context::get('signature');
+		$this->putSignature($args->member_srl, $signature);
+
 		// If a virtual site, join the site
 		$site_module_info = Context::get('site_module_info');
 		if($site_module_info->site_srl > 0)

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -209,6 +209,29 @@ class memberView extends member
 		$formTags = $oMemberAdminView->_getMemberInputTag($member_info);
 		Context::set('formTags', $formTags);
 
+
+		// Editor of the module set for signing by calling getEditor
+		foreach($formTags as $formTag) {
+			if($formTag->name=='signature') {
+				$oEditorModel = getModel('editor');
+				$option = new stdClass();
+				$option->primary_key_name = 'member_srl';
+				$option->content_key_name = 'signature';
+				$option->allow_fileupload = false;
+				$option->enable_autosave = false;
+				$option->enable_default_component = true;
+				$option->enable_component = false;
+				$option->resizable = false;
+				$option->disable_html = true;
+				$option->height = 100;
+				$option->skin = $member_config->signature_editor_skin;
+				$option->colorset = $member_config->sel_editor_colorset;
+				$editor = $oEditorModel->getEditor($member_info->member_srl, $option);
+				Context::set('editor', $editor);
+			}
+		}
+
+
 		global $lang;
 		$identifierForm = new stdClass();
 		$identifierForm->title = $lang->{$member_config->identifier};

--- a/modules/member/skins/default/signup_form.html
+++ b/modules/member/skins/default/signup_form.html
@@ -41,9 +41,17 @@
 				<input type="password" name="password2" id="password2" value="" required />
 			</div>
 		</div>
-		<div class="control-group" loop="$formTags=>$formTag" cond="$formTag->name != 'signature'">
+		<div class="control-group" loop="$formTags=>$formTag">
 			<label for="{$formTag->name}" class="control-label">{$formTag->title}</label>
-			<div class="controls">{$formTag->inputTag}</div>
+			<div class="controls" cond="$formTag->name != 'signature'">{$formTag->inputTag}</div>
+			<div class="controls" cond="$formTag->name =='signature'">
+				 <input type="hidden" name="signature" value="" />
+				{$editor}
+				<style scoped>
+				.xpress-editor>#smart_content,
+				.xpress-editor>#smart_content>.tool{clear:none}
+				</style>
+			</div>
 		</div>
 		<div class="control-group">
 			<div class="control-label">{$lang->allow_mailing}</div>


### PR DESCRIPTION
서명기능은 XE 에서 원칙적으로.. 
회원가입 후, 회원정보 수정시에 입력받을 수 있게 되어있다.

원인은 서명기능에는 member_srl 값이라는 회원번호가 필요한데
회원가입단계에는이 번호가 배정되지 않아서 생긴 현상인데..

그런데 회원가입 후 $ouput 으로 나오는 member_srl 값을 이용해 나중에 서명을 따로 등록하면 된다
마치 프로필 사진 등도 가입단계에서 바로 입력받을 수 있게 된것처럼.. 서명도 가능해졌다.
게다가 서명은 어차피 서명은 DB 에 저장되는게 아니라,  files 폴더에 파일형태로 저장이 되는거기에..

member 스킨도 고쳐야하기에,  배포되어있는 member 스킨에 바로 적용되진 않겠지만.
member 모듈에 기반을 추가해두고, default 스킨에 예시가 들어있으면  추후 적용해서 쓸듯 싶다.
