### PR TITLE
관리자페이지 댓글 신고목록에서 신고취소 안 되는 버그 수정

### DIFF
--- a/modules/comment/tpl/js/comment_admin.js
+++ b/modules/comment/tpl/js/comment_admin.js
@@ -1,7 +1,7 @@
 
 function doCancelDeclare() {
     var comment_srl = new Array();
-    jQuery('#fo_list input[name=cart]:checked').each(function() {
+    jQuery('#fo_list input[name="cart[]"]:checked').each(function() {
         comment_srl[comment_srl.length] = jQuery(this).val();
     });
 


### PR DESCRIPTION
declared_list.html  에  checkbox name="cart[]"  로 되어있는데,  script 의 doCancelDeclare 에는 input[name=cart] 로 되어있어서 생긴 버그..   cart[] 로 통일 .   
