### PR TITLE
#800 템플릿 캐시 적용 시, 위젯 캐시가 지정된 위젯을 제대로 출력하지 못하는 버그 수정

### DIFF
--- a/modules/widget/widget.controller.php
+++ b/modules/widget/widget.controller.php
@@ -409,7 +409,10 @@ class widgetController extends widget
 				}
 			}
 			// cache update and cache renewal of the file mtime
-			touch($cache_file);
+			if(!$oCacheHandler->isSupport())
+			{
+				touch($cache_file);
+			}
 
 			$oWidget = $this->getWidgetObject($widget);
 			if(!$oWidget || !method_exists($oWidget,'proc')) return;


### PR DESCRIPTION
#800

템플릿 캐시의 적용 여부와 상관없이 위젯 캐시 파일을 생성하는 버그가 있어서

템플릿 캐시를 사용중일 때는 빈 캐시 파일을 생성하지 않도록 수정했습니다.
