### PR TITLE
게시판 설정을 무시하고 비밀글을 등록하는 문제

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -89,11 +89,12 @@ class boardController extends board
 			$bAnonymous = false;
 		}
 
-		if((!$obj->status && $obj->is_secret == 'Y') || strtoupper($obj->status == 'SECRET'))
+		if($obj->is_secret == 'Y' || strtoupper($obj->status == 'SECRET'))
 		{
 			$use_status = explode('|@|', $this->module_info->use_status);
 			if(!is_array($use_status) || !in_array('SECRET', $use_status))
 			{
+				unset($obj->is_secret);
 				$obj->status = 'PUBLIC';
 			}
 		}


### PR DESCRIPTION
is_secret 값을 검사하는데 status 값 검사가 왜 같이 들어가는지 모르겠습니다.
저 코드 때문에 개발자도구로 is_secret과 status 값을 생성해서 글을 등록하면 게시판 설정과 상관없이 비밀글을 등록할 수 있는 문제가 있습니다.
이 버그를 해결한 풀 리퀘스트 보냅니다.
