### PR TITLE
게시글 제목을 공백으로 등록하는 문제

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -40,7 +40,7 @@ class boardController extends board
 		$obj->commentStatus = $obj->comment_status;
 
 		settype($obj->title, "string");
-		if($obj->title == '') $obj->title = trim(cut_str(strip_tags(nl2br($obj->content)),20,'...'));
+		if($obj->title == '') $obj->title = cut_str(trim(strip_tags(nl2br($obj->content))),20,'...');
 		//setup dpcument title tp 'Untitled'
 		if($obj->title == '') $obj->title = 'Untitled';
 

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -268,7 +268,7 @@ class documentController extends document
 		}
 		// If the tile is empty, extract string from the contents.
 		settype($obj->title, "string");
-		if($obj->title == '') $obj->title = trim(cut_str(strip_tags(nl2br($obj->content)),20,'...'));
+		if($obj->title == '') $obj->title = cut_str(trim(strip_tags(nl2br($obj->content))),20,'...');
 		// If no tile extracted from the contents, leave it untitled.
 		if($obj->title == '') $obj->title = 'Untitled';
 		// Remove XE's own tags from the contents.


### PR DESCRIPTION
우선 게시글 등록할 때 제목 부분의 노드(name=title)를 개발자 도구로 삭제합니다.
게시글 내용에 태그만 입력한 뒤(이미지 삽입 등...) 개행문자를 넣고 게시글을 등록합니다.
제목이 없을 경우 본문의 내용을 가지고 제목을 만드는데, 이때 개행문자 때문에 제목이 빈칸으로 입력되는 현상이 발생합니다.
이를 해결한 풀 리퀘스트 보냅니다.
