### PR TITLE
관리자인 경우, 에디터의 권한 설정을 무시하고 항상 작동하도록 수정

### DIFF
--- a/modules/editor/editor.model.php
+++ b/modules/editor/editor.model.php
@@ -409,7 +409,7 @@ class editorModel extends editor
 		else $option->enable_default_component = true;
 		// Permisshion check for using extended components
 		$option->enable_component = false;
-		if($logged_info->is_admin=='Y') $option->enable_component_grant = true;
+		if($logged_info->is_admin=='Y') $option->enable_component = true;
 		elseif(count($config->enable_component_grant))
 		{
 			foreach($group_list as $group_srl => $group_info)


### PR DESCRIPTION
게시판의 추가설정 탭에서, 위지윅 에디터 의 권한 설정부분에 대해
(HTML 편집권한 / 파일첨부 권한 / 기본 컴퍼넌트 사용권한 / 확장컴포넌트 사용권한)

그룹을 체크해둬서 권한 사용을 제한해두면
최고관리자일지라도 해당 그룹에 속하지 않으면 사용권한이 제한되어버리는 버그가 존재한다
최고관리자인 경우 이 설정과 무관하게 무조건 작동하도록 수정.
