### PR TITLE
모바일(또는 textarea형)에서 댓글 수정시 줄바꿈 유지되도록 수정

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -711,6 +711,15 @@ class commentController extends comment
 		// remove XE's wn tags from contents
 		$obj->content = preg_replace('!<\!--(Before|After)(Document|Comment)\(([0-9]+),([0-9]+)\)-->!is', '', $obj->content);
 
+		if(Mobile::isFromMobilePhone())
+		{
+			if($obj->use_html != 'Y')
+			{
+				$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+			}
+			$obj->content = nl2br($obj->content);
+		}
+
 		// remove iframe and script if not a top administrator on the session
 		if($logged_info->is_admin != 'Y')
 		{


### PR DESCRIPTION
모바일에서는  댓글을 등록할때는, 줄바꿈이 인식되나
해당 댓글을 수정하여  등록 (update) 하면, 줄바꿈이 다 사라져버리고 한 줄로 나타난다.

이는 Core 의 comment 모듈에서 insertComment 에 있는 소스가 
updateComment 에는 빠져 있기 때문이어서,  해당 소스를 updateComment 에도 추가해두었다.

이로써,  textarea 형태 또는 모바일 기반에서 댓글 수정시 줄바꿈이 제대로 구현된다.
