### PR TITLE
#857 $widget_info->extra_var 를 new stdClass 처리부분제거

### DIFF
--- a/modules/widget/widget.model.php
+++ b/modules/widget/widget.model.php
@@ -205,7 +205,6 @@ class widgetModel extends widget
 				$extra_var_count = count($extra_vars);
 
 				$buff .= sprintf('$widget_info->extra_var_count = "%s";', $extra_var_count);
-				$buff .= '$widget_info->extra_var = new stdClass;';
 				for($i=0;$i<$extra_var_count;$i++)
 				{
 					unset($var);


### PR DESCRIPTION
#857 이슈에서 위젯을 코드생성되는 페이지에서 제일 마지막 그룹의 내용만 나타나게 되어 위젯의 전체설정을 하지 못했습니다.

이 부분의 대충 대략적인 코드분석해보니, 제가 커밋 드렸던 php5.4 호환성 (그때 코드자체는 미솔님이 했던 내용 그대로 커밋 보내드렸습니다) 부분에서의 문제점이 있었던 것으로 결론되었습니다.
하나하나 디버깅 해본결과 
`$widget_info->extra_var`에 선언된것이 존재햇을텐데, 그걸 다시 new stdClass; 으로 초기화 하여 마지막 그룹 부분만 적용되버린게 아닌가 하는 제 생각을 해봅니다..

아무튼, 이 부분 해결시켰으니 바로 PR받아주셔도 될 것같습니다 :)
