### PR TITLE
관리자 계정에서 문서첨부제한이 풀리지 않는 문제 해결

### DIFF
--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -238,7 +238,9 @@ class fileModel extends file
 
 		if($logged_info->is_admin == 'Y')
 		{
-			$file_config->allowed_filesize = preg_replace("/[a-z]/is","",ini_get('upload_max_filesize'));
+			$size = preg_replace('/[a-z]/is', '', ini_get('upload_max_filesize'));
+			$file_config->allowed_attach_size = $size;
+			$file_config->allowed_filesize = $size;
 			$file_config->allowed_filetypes = '*.*';
 		}
 		return $file_config;


### PR DESCRIPTION
관리자 계정에서 글을 작성할 때, 파일첨부제한은 제대로 PHP에서 설정한 최대한도로 풀려 있지만, 문서첨부제한은 XE에서 설정한 값으로 제한되는 문제가 있습니다.
PR 보내드립니다.
