### PR TITLE
카운터 숫자가 한 줄로 표시되도록 수정함.

### DIFF
--- a/modules/counter/tpl/counter.css
+++ b/modules/counter/tpl/counter.css
@@ -1,3 +1,3 @@
 .barContainer{margin-right:103px;position:relative;height:100%;}
 .graphHr{position:relative; display:inline-block; background:transparent url(images/iconBar.gif) 4px 0 repeat-x;height:5px}
-.graphHr>span{position:absolute;top:-7px;left:100%;padding-left:4px;width:100px}
+.graphHr>span{position:absolute;top:-7px;left:100%;padding-left:4px;width:100px;white-space:nowrap}


### PR DESCRIPTION
'접속 통계 관리' 화면의 '월별' 탭에서 카운트 숫자와 월별 퍼센티지를 나타내는 텍스트가 두 줄로 표시되는 문제점을 CSS를 활용하여 한 줄로 표시되도록 수정함.
