### PR TITLE
member 스킨내에 resend_auth_mail.html 추가

### DIFF
--- a/modules/member/skins/default/resend_auth_mail.html
+++ b/modules/member/skins/default/resend_auth_mail.html
@@ -13,3 +13,4 @@
 		<input type="submit" id="resend_button" name="" value="{$lang->cmd_resend_auth_mail}" class="btn btn-inverse" />
 	</div>
 </form>
+<include target="./common_footer.html" />


### PR DESCRIPTION
member.view.php 파일의  dispMemberResendAuthMail  함수에서
$authMemberSrl 값이 없는 경우 resend_auth_mail  파일을 여는 경우가 있는데
이 부분이 빠져있습니다.  
XE 1.7 로 넘어오면서 메일인증 페이지 대신에, 계정찾기 페이지 하단에 메인인증을 넣어서 통합해버려
이 파일이 필요없어서 지운건지 실수로 빠진건지 모르지만

예전 로그인 위젯이나,  레이아웃,  회원스킨 등을 쓰는 경우...  dispMemberResendAuthMail 함수로 접근하게 되어있는 경우도 많기에,   resend_auth_mail 파일이 있어야하는 경우가 있네요

XE 1.7 의 형태에 맞춰  XE 1.5 의 resend_auth_mail  파일을 수정해서 추가했습니다.
