### PR TITLE
관리자 회원목록 페이지에서,  이메일이 이중으로 중복 출력되는 버그 수정

### DIFF
--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -94,7 +94,7 @@ class memberAdminView extends member
 			}
 		}
 		$config = $this->memberConfig;
-		$memberIdentifiers = array('email_address'=>'email_address', 'user_id'=>'user_id', 'user_name'=>'user_name', 'nick_name'=>'nick_name');
+		$memberIdentifiers = array('user_id'=>'user_id', 'user_name'=>'user_name', 'nick_name'=>'nick_name');
 		$usedIdentifiers = array();	
 
 		if(is_array($config->signupForm))


### PR DESCRIPTION
관리자 회원목록 페이지에서,  이메일이 이중으로 중복 출력되는 현상 발생
tpl 파일에서,  email 을 강제로 제일 앞에 출력하고 있는데
또 $usedIdentifiers  에서 이메일을 한번 더 출력하게 되어있어서  ( 이메일은 필수기재사항이다보니, 무조건 이 변수에 포함되기에)

tpl 의 제일앞의 이메일에는 회원팝업 이 연결되어있어 그건 그대로 두고 
대신 $usedIdentifiers  의 기준이 되는  $memberIdentifiers  를 수정해서  이메일을 제외.
