### PR TITLE
회원 비밀번호 암호화 방법 개선

### DIFF
--- a/classes/security/Password.class.php
+++ b/classes/security/Password.class.php
@@ -19,13 +19,13 @@ class Password
 	public function getSupportedAlgorithms()
 	{
 		$retval = array();
-		if(version_compare(PHP_VERSION, '5.3.7', '>=') && defined('CRYPT_BLOWFISH'))
-		{
-			$retval['bcrypt'] = 'bcrypt';
-		}
 		if(function_exists('hash_hmac') && in_array('sha256', hash_algos()))
 		{
 			$retval['pbkdf2'] = 'pbkdf2';
+		}
+		if(version_compare(PHP_VERSION, '5.3.7', '>=') && defined('CRYPT_BLOWFISH'))
+		{
+			$retval['bcrypt'] = 'bcrypt';
 		}
 		$retval['md5'] = 'md5';
 		return $retval;

--- a/classes/security/Password.class.php
+++ b/classes/security/Password.class.php
@@ -1,0 +1,341 @@
+<?php
+/* Copyright (C) NAVER <http://www.navercorp.com> */
+
+/**
+ * This class can be used to hash passwords using various algorithms and check their validity.
+ * It is fully compatible with previous defaults, while also supporting bcrypt and pbkdf2.
+ * 
+ * @file Password.class.php
+ * @author Kijin Sung (kijin@kijinsung.com)
+ * @package /classes/security
+ * @version 1.1
+ */
+class Password
+{
+	/**
+	 * @brief Return the list of hashing algorithms supported by this server
+	 * @return array
+	 */
+	public function getSupportedAlgorithms()
+	{
+		$retval = array();
+		if(version_compare(PHP_VERSION, '5.3.7', '>=') && defined('CRYPT_BLOWFISH'))
+		{
+			$retval['bcrypt'] = 'bcrypt';
+		}
+		if(function_exists('hash_hmac') && in_array('sha256', hash_algos()))
+		{
+			$retval['pbkdf2'] = 'pbkdf2';
+		}
+		$retval['md5'] = 'md5';
+		return $retval;
+	}
+
+	/**
+	 * @brief Return the best hashing algorithm supported by this server
+	 * @return string
+	 */
+	public function getBestAlgorithm()
+	{
+		$algos = $this->getSupportedAlgorithms();
+		return key($algos);
+	}
+	
+	/**
+	 * @brief Return the currently selected hashing algorithm
+	 * @return string
+	 */
+	public function getCurrentlySelectedAlgorithm()
+	{
+		if(function_exists('getModel'))
+		{
+			$config = getModel('member')->getMemberConfig();
+			$algorithm = $config->password_hashing_algorithm;
+			if(strval($algorithm) === '')
+			{
+				$algorithm = 'md5';  // Historical default for XE
+			}
+		}
+		else
+		{
+			$algorithm = 'md5';
+		}
+		return $algorithm;
+	}
+	
+	/**
+	 * @brief Return the currently configured work factor for bcrypt and other adjustable algorithms
+	 * @return int
+	 */
+	public function getWorkFactor()
+	{
+		if(function_exists('getModel'))
+		{
+			$config = getModel('member')->getMemberConfig();
+			$work_factor = $config->password_hashing_work_factor;
+			if(!$work_factor || $work_factor < 4 || $work_factor > 31)
+			{
+				$work_factor = 8;  // Reasonable default
+			}
+		}
+		else
+		{
+			$work_factor = 8;
+		}
+		return $work_factor;
+	}
+	
+	/**
+	 * @brief Create a hash using the specified algorithm
+	 * @param string $password The password
+	 * @param string $algorithm The algorithm (optional)
+	 * @return string
+	 */
+	public function createHash($password, $algorithm = null)
+	{
+		if($algorithm === null)
+		{
+			$algorithm = $this->getCurrentlySelectedAlgorithm();
+		}
+		if(!array_key_exists($algorithm, $this->getSupportedAlgorithms()))
+		{
+			return false;
+		}
+		
+		$password = trim($password);
+		
+		switch($algorithm)
+		{
+			case 'md5':
+				return md5($password);
+			
+			case 'pbkdf2':
+				$iterations = pow(2, $this->getWorkFactor() + 5);
+				$salt = $this->createSecureSalt(12);
+				$hash = base64_encode($this->pbkdf2($password, $salt, 'sha256', $iterations, 24));
+				return 'sha256:'.sprintf('%07d', $iterations).':'.$salt.':'.$hash;
+			
+			case 'bcrypt':
+				return $this->bcrypt($password);
+			
+			default:
+				return false;
+		}
+	}
+	
+	/**
+	 * @brief Check if a password matches a hash
+	 * @param string $password The password
+	 * @param string $hash The hash
+	 * @param string $algorithm The algorithm (optional)
+	 * @return bool
+	 */
+	public function checkPassword($password, $hash, $algorithm = null)
+	{
+		$password = trim($password);
+		
+		if($algorithm === null)
+		{
+			$algorithm = $this->checkAlgorithm($hash);
+		}
+		if(!array_key_exists($algorithm, $this->getSupportedAlgorithms()))
+		{
+			return false;
+		}
+		
+		switch($algorithm)
+		{
+			case 'md5':
+				return md5($password) === $hash || md5(sha1(md5($password))) === $hash;
+			
+			case 'pbkdf2':
+				$hash = explode(':', $hash);
+				$hash[3] = base64_decode($hash[3]);
+				$hash_to_compare = $this->pbkdf2($password, $hash[2], $hash[0], intval($hash[1], 10), strlen($hash[3]));
+				return $this->strcmpConstantTime($hash_to_compare, $hash[3]);
+			
+			case 'bcrypt':
+				$hash_to_compare = $this->bcrypt($password, $hash);
+				return $this->strcmpConstantTime($hash_to_compare, $hash);
+				
+			default:
+				return false;
+		}
+	}
+	
+	/**
+	 * @brief Check the algorithm used to create a hash
+	 * @param string $hash The hash
+	 * @return string
+	 */
+	function checkAlgorithm($hash)
+	{
+		if(preg_match('/^\$2[axy]\$([0-9]{2})\$/', $hash, $matches))
+		{
+			return 'bcrypt';
+		}
+		elseif(preg_match('/^sha[0-9]+:([0-9]+):/', $hash, $matches))
+		{
+			return 'pbkdf2';
+		}
+		elseif(strlen($hash) === 32 && ctype_xdigit($hash))
+		{
+			return 'md5';
+		}
+		else
+		{
+			return false;
+		}
+	}
+	
+	/**
+	 * @brief Check the work factor of a hash
+	 * @param string $hash The hash
+	 * @return int
+	 */
+	function checkWorkFactor($hash)
+	{
+		if(preg_match('/^\$2[axy]\$([0-9]{2})\$/', $hash, $matches))
+		{
+			return intval($matches[1], 10);
+		}
+		elseif(preg_match('/^sha[0-9]+:([0-9]+):/', $hash, $matches))
+		{
+			return max(0, round(log($matches[1], 2)) - 5);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	
+	/**
+	 * @brief Generate a cryptographically secure random string to use as a salt
+	 * @param int $length The number of bytes to return
+	 * @param string $format hex or alnum
+	 * @return string
+	 */
+	public function createSecureSalt($length, $format = 'hex')
+	{
+		// Find out how many bytes of entropy we really need
+		$entropy_required_bytes = ceil(($format === 'hex') ? ($length / 2) : ($length * 3 / 4));
+		
+		// Cap entropy to 256 bits from any one source, because anything more is meaningless
+		$entropy_capped_bytes = min(32, $entropy_required_bytes);
+		
+		// Find and use the most secure way to generate a random string
+		$is_windows = (defined('PHP_OS') && strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+		if(function_exists('openssl_random_pseudo_bytes') && (!$is_windows || version_compare(PHP_VERSION, '5.4', '>=')))
+		{
+			$entropy = openssl_random_pseudo_bytes($entropy_capped_bytes);
+		}
+		elseif(function_exists('mcrypt_create_iv') && (!$is_windows || version_compare(PHP_VERSION, '5.3.7', '>=')))
+		{
+			$entropy = mcrypt_create_iv($entropy_capped_bytes, MCRYPT_DEV_URANDOM);
+		}
+		elseif(function_exists('mcrypt_create_iv') && $is_windows)
+		{
+			$entropy = mcrypt_create_iv($entropy_capped_bytes, MCRYPT_RAND);
+		}
+		elseif(!$is_windows && @is_readable('/dev/urandom'))
+		{
+			$fp = fopen('/dev/urandom', 'rb');
+			$entropy = fread($fp, $entropy_capped_bytes);
+			fclose($fp);
+		}
+		else
+		{
+			$entropy = '';
+			for($i = 0; $i < $entropy_capped_bytes; $i += 2)
+			{
+				$entropy .= pack('S', rand(0, 65536) ^ mt_rand(0, 65535));
+			}
+		}
+		
+		// Mixing (see RFC 4086 section 5)
+		$output = '';
+		for($i = 0; $i < $entropy_required_bytes; $i += 32)
+		{
+			$output .= hash('sha256', $entropy . $i . rand(), true);
+		}
+		
+		// Encode and return the random string
+		if($format === 'hex')
+		{
+			return substr(bin2hex($output), 0, $length);
+		}
+		else
+		{
+			$salt = substr(base64_encode($output), 0, $length);
+			$replacements = chr(rand(65, 90)) . chr(rand(97, 122)) . rand(0, 9);
+			return strtr($salt, '+/=', $replacements);
+		}
+	}
+	
+	/**
+	 * @brief Generate the PBKDF2 hash of a string using a salt
+	 * @param string $password The password
+	 * @param string $salt The salt
+	 * @param string $algorithm The algorithm (optional, default is sha256)
+	 * @param int $iterations Iteration count (optional, default is 8192)
+	 * @param int $length The length of the hash (optional, default is 32)
+	 * @return string
+	 */
+	public function pbkdf2($password, $salt, $algorithm = 'sha256', $iterations = 8192, $length = 24)
+	{
+		if(function_exists('hash_pbkdf2'))
+		{
+			return hash_pbkdf2($algorithm, $password, $salt, $iterations, $length, true);
+		}
+		else
+		{
+			$output = '';
+			$block_count = ceil($length / strlen(hash($algorithm, '', true)));  // key length divided by the length of one hash
+			for($i = 1; $i <= $block_count; $i++)
+			{
+				$last = $salt . pack('N', $i);  // $i encoded as 4 bytes, big endian
+				$last = $xorsum = hash_hmac($algorithm, $last, $password, true);  // first iteration
+				for($j = 1; $j < $iterations; $j++)  // The other $count - 1 iterations
+				{
+					$xorsum ^= ($last = hash_hmac($algorithm, $last, $password, true));
+				}
+				$output .= $xorsum;
+			}
+			return substr($output, 0, $length);
+		}
+	}
+	
+	/**
+	 * @brief Generate the bcrypt hash of a string using a salt
+	 * @param string $password The password
+	 * @param string $salt The salt (optional, auto-generated if empty)
+	 * @return string
+	 */
+	public function bcrypt($password, $salt = null)
+	{
+		if($salt === null)
+		{
+			$salt = '$2y$'.sprintf('%02d', $this->getWorkFactor()).'$'.$this->createSecureSalt(22, 'alnum');
+		}
+		return crypt($password, $salt);
+	}
+	
+	/**
+	 * @brief Compare two strings in constant time
+	 * @param string $a The first string
+	 * @param string $b The second string
+	 * @return bool
+	 */
+	function strcmpConstantTime($a, $b)
+	{
+		$diff = strlen($a) ^ strlen($b);
+		$maxlen = min(strlen($a), strlen($b));
+		for($i = 0; $i < $maxlen; $i++)
+		{
+			$diff |= ord($a[$i]) ^ ord($b[$i]);
+		}
+		return $diff === 0;
+	}
+}
+/* End of file : Password.class.php */
+/* Location: ./classes/security/Password.class.php */

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -283,6 +283,7 @@ if(!defined('__XE_LOADED_CLASS__'))
 	require(_XE_PATH_ . 'classes/mobile/Mobile.class.php');
 	require(_XE_PATH_ . 'classes/validator/Validator.class.php');
 	require(_XE_PATH_ . 'classes/frontendfile/FrontEndFileHandler.class.php');
+	require(_XE_PATH_ . 'classes/security/Password.class.php');
 	require(_XE_PATH_ . 'classes/security/Security.class.php');
 	require(_XE_PATH_ . 'classes/security/IpFilter.class.php');
 	if(__DEBUG__)

--- a/modules/member/lang/lang.xml
+++ b/modules/member/lang/lang.xml
@@ -1685,6 +1685,21 @@
 		<value xml:lang="en"><![CDATA[password strength]]></value>
 		<value xml:lang="jp"><![CDATA[パスワード強度]]></value>
 	</item>
+	<item name="cmd_password_hashing_algorithm">
+		<value xml:lang="ko"><![CDATA[비밀번호 암호화 알고리듬]]></value>
+		<value xml:lang="en"><![CDATA[Password Hashing Algorithm]]></value>
+		<value xml:lang="jp"><![CDATA[パスワードの暗号化アルゴリズム]]></value>
+	</item>
+	<item name="cmd_password_hashing_work_factor">
+		<value xml:lang="ko"><![CDATA[비밀번호 암호화 소요시간]]></value>
+		<value xml:lang="en"><![CDATA[Password Hashing Work Factor]]></value>
+		<value xml:lang="jp"><![CDATA[暗号化のワーク·ファクター]]></value>
+	</item>
+	<item name="cmd_password_hashing_auto_upgrade">
+		<value xml:lang="ko"><![CDATA[알고리듬 자동 업그레이드]]></value>
+		<value xml:lang="en"><![CDATA[Auto-upgrade Hashing Algorithm]]></value>
+		<value xml:lang="jp"><![CDATA[暗号化アルゴリズム自動アップグレード]]></value>
+	</item>
 	
 	<item name="password_strength_low">
 		<value xml:lang="ko"><![CDATA[낮음]]></value>
@@ -1706,6 +1721,21 @@
 		<value xml:lang="ko"><![CDATA[회원들이 비밀번호를 등록/변경할 때, 비밀번호가 설정된 보안수준을 만족해야 합니다. 단, 관리자가 직접 등록할 경우에는 적용되지 않습니다.]]></value>
 		<value xml:lang="en"><![CDATA[When members register or change the password, the password must meet the specified password strength. However, the administrator is an exception.]]></value>
 		<value xml:lang="jp"><![CDATA[会員がパスワードを登録する際に、パスワードが一定の強度を満たす必要があります。ただし、管理者が直接に登録する際には適用されません。]]></value>
+	</item>
+	<item name="about_password_hashing_algorithm">
+		<value xml:lang="ko"><![CDATA[회원들의 비밀번호를 DB에 저장할 때 암호화(해싱)하는 방식을 지정할 수 있습니다.]]></value>
+		<value xml:lang="en"><![CDATA[You can choose how to encrypt (hash) members' passwords stored in the database.]]></value>
+		<value xml:lang="jp"><![CDATA[会員のパスワードをDBに保存するときに暗号化（ハッシュ）する方法を指定することができます。]]></value>
+	</item>
+	<item name="about_password_hashing_work_factor">
+		<value xml:lang="ko"><![CDATA[시간이 오래 걸리는 알고리듬일수록 보안이 강하지만, 로그인이 오래 걸릴 수 있습니다. bcrypt 및 pbkdf2 알고리듬에만 적용됩니다.]]></value>
+		<value xml:lang="en"><![CDATA[Higher work factors are more secure, but logins may take a long time. This only applies to bcrypt and pbkdf2.]]></value>
+		<value xml:lang="jp"><![CDATA[時間がかかるアルゴリズムほどセキュリティが強いが、ログインがかかることがあります。 bcryptとpbkdf2アルゴリズムにのみ適用されます。]]></value>
+	</item>
+	<item name="about_password_hashing_auto_upgrade">
+		<value xml:lang="ko"><![CDATA[설정된 알고리듬과 다른 방법으로 암호화된 비밀번호가 있으면 다음 로그인시 설정된 알고리듬으로 자동 변환합니다.]]></value>
+		<value xml:lang="en"><![CDATA[Passwords encrypted using different algorithms will be automatically converted to the configured algorithm at next login.]]></value>
+		<value xml:lang="jp"><![CDATA[設定されたアルゴリズムとは異なる方法で暗号化されたパスワードがあれば、次のログイン時に設定されたアルゴリズムに自動的に変換します。]]></value>
 	</item>
 	
 	<item name="about_password_strength" type="array">

--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -159,8 +159,31 @@ class memberAdminController extends member
 			'enable_confirm',
 			'webmaster_name',
 			'webmaster_email',
-			'password_strength'
+			'password_strength',
+			'password_hashing_algorithm',
+			'password_hashing_work_factor',
+			'password_hashing_auto_upgrade'
 		);
+		
+		$oPassword = new Password();
+		if(!array_key_exists($args->password_hashing_algorithm, $oPassword->getSupportedAlgorithms()))
+		{
+			$args->password_hashing_algorithm = 'md5';
+		}
+		
+		$args->password_hashing_work_factor = intval($args->password_hashing_work_factor, 10);
+		if($args->password_hashing_work_factor < 4)
+		{
+			$args->password_hashing_work_factor = 4;
+		}
+		if($args->password_hashing_work_factor > 16)
+		{
+			$args->password_hashing_work_factor = 16;
+		}
+		if($args->password_hashing_auto_upgrade != 'Y')
+		{
+			$args->password_hashing_auto_upgrade = 'N';
+		}
 
 		if((!$args->webmaster_name || !$args->webmaster_email) && $args->enable_confirm == 'Y')
 		{

--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -129,8 +129,10 @@ class memberAdminView extends member
 	 */
 	public function dispMemberAdminConfig()
 	{
+		$oPassword = new Password();
+		Context::set('password_hashing_algos', $oPassword->getSupportedAlgorithms());
+		
 		$this->setTemplateFile('default_config');
-
 	}
 
 	public function dispMemberAdminSignUpConfig()

--- a/modules/member/member.class.php
+++ b/modules/member/member.class.php
@@ -71,6 +71,20 @@ class member extends ModuleObject {
 		if($config->group_image_mark!='Y') $config->group_image_mark = 'N';
 		if(!$config->password_strength) $config->password_strength = 'normal';
 		
+		if(!$config->password_hashing_algorithm)
+		{
+			$oPassword = new Password();
+			$config->password_hashing_algorithm = $oPassword->getBestAlgorithm();
+		}
+		if(!$config->password_hashing_work_factor)
+		{
+			$config->password_hashing_work_factor = 8;
+		}
+		if(!$config->password_hashing_auto_upgrade)
+		{
+			$config->password_hashing_auto_upgrade = 'Y';
+		}
+		
 		global $lang;
 		$oMemberModel = getModel('member');
 		// Create a member controller object

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1101,7 +1101,7 @@ class memberController extends member
 		}
 		else
 		{
-			$args->password = md5($output->data->new_password);
+			$args->password = getModel('member')->hashPassword($args->password);
 			unset($args->denied);
 		}
 		// Back up the value of $Output->data->is_register
@@ -1956,7 +1956,7 @@ class memberController extends member
 				$message = Context::getLang('about_password_strength');
 				return new Object(-1, $message[$config->password_strength]);
 			}
-			$args->password = md5($args->password);
+			$args->password = $oMemberModel->hashPassword($args->password);
 		}
 		elseif(!$args->password) unset($args->password);
 		if($oMemberModel->isDeniedID($args->user_id)) return new Object(-1,'denied_user_id');
@@ -2149,7 +2149,7 @@ class memberController extends member
 				return new Object(-1, $message[$config->password_strength]);
 			}
 				
-			$args->password = md5($args->password);
+			$args->password = $oMemberModel->hashPassword($args->password);
 		}
 		else $args->password = $orgMemberInfo->password;
 		if(!$args->user_name) $args->user_name = $orgMemberInfo->user_name;
@@ -2239,14 +2239,7 @@ class memberController extends member
 				return new Object(-1, $message[$config->password_strength]);
 			}
 			
-			if($this->useSha1)
-			{
-				$args->password = md5(sha1(md5($args->password)));
-			}
-			else
-			{
-				$args->password = md5($args->password);
-			}
+			$args->password = $oMemberModel->hashPassword($args->password);
 		}
 		else if($args->hashed_password)
 		{

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -996,65 +996,71 @@ class memberModel extends member
 
 	/**
 	 * @brief Compare plain text password to the password saved in DB
+	 * @param string $hashed_password The hash that was saved in DB
+	 * @param string $password_text The password to check
+	 * @param int $member_srl Set this to member_srl when comparing a member's password (optional)
+	 * @return bool
 	 */
 	function isValidPassword($hashed_password, $password_text, $member_srl=null)
 	{
 		// False if no password in entered
-		if(!$password_text) return false;
-
-		$isSha1 = ($this->useSha1 && function_exists('sha1'));
-
-		// Return true if the user input is equal to md5 hash value
-		if($hashed_password == md5($password_text))
+		if(!$password_text)
 		{
-			if($isSha1 && $member_srl > 0)
+			return false;
+		}
+		
+		// Check the password
+		$oPassword = new Password();
+		$current_algorithm = $oPassword->checkAlgorithm($hashed_password);
+		$match = $oPassword->checkPassword($password_text, $hashed_password, $current_algorithm);
+		if(!$match)
+		{
+			return false;
+		}
+		
+		// Update the encryption method if necessary
+		$config = $this->getMemberConfig();
+		if($member_srl > 0 && $config->password_hashing_auto_upgrade != 'N')
+		{
+			$need_upgrade = false;
+			
+			if(!$need_upgrade)
+			{
+				$required_algorithm = $oPassword->getCurrentlySelectedAlgorithm();
+				if($required_algorithm !== $current_algorithm) $need_upgrade = true;
+			}
+			
+			if(!$need_upgrade)
+			{
+				$required_work_factor = $oPassword->getWorkFactor();
+				$current_work_factor = $oPassword->checkWorkFactor($hashed_password);
+				if($current_work_factor !== false && $required_work_factor > $current_work_factor) $need_upgrade = true;
+			}
+			
+			if($need_upgrade === true)
 			{
 				$args = new stdClass();
 				$args->member_srl = $member_srl;
-				$args->hashed_password = md5(sha1(md5($password_text)));
+				$args->hashed_password = $this->hashPassword($password_text, $required_algorithm);
 				$oMemberController = getController('member');
 				$oMemberController->updateMemberPassword($args);
 			}
-			return true;
 		}
-
-		// Return true if the user input is equal to the value of mysql_pre4_hash_password
-		if(mysql_pre4_hash_password($password_text) == $hashed_password)
-		{
-			if($isSha1 && $member_srl > 0)
-			{
-				$args = new stdClass();
-				$args->member_srl = $member_srl;
-				$args->hashed_password = md5(sha1(md5($password_text)));
-				$oMemberController = getController('member');
-				$oMemberController->updateMemberPassword($args);
-			}
-			return true;
-		}
-
-		// Verify the password by using old_password if the current db is MySQL. If correct, return true.
-		if(substr(Context::getDBType(),0,5)=='mysql')
-		{
-			$oDB = &DB::getInstance();
-			if($oDB->isValidOldPassword($password_text, $hashed_password))
-			{
-				if($isSha1 && $member_srl > 0)
-				{
-					$args = new stdClass();
-					$args->member_srl = $member_srl;
-					$args->hashed_password = md5(sha1(md5($password_text)));
-					$oMemberController = getController('member');
-					$oMemberController->updateMemberPassword($args);
-				}
-				return true;
-			}
-		}
-
-		if($isSha1 && $hashed_password == md5(sha1(md5($password_text)))) return true;
-
-		return false;
+		
+		return true;
 	}
-
+	
+	/**
+	 * @brief Create a hash of plain text password
+	 * @param string $password_text The password to hash
+	 * @param string $algorithm The algorithm to use (optional, only set this when you want to use a non-default algorithm)
+	 * @return string
+	 */
+	function hashPassword($password_text, $algorithm = null)
+	{
+		$oPassword = new Password();
+		return $oPassword->createHash($password_text, $algorithm);
+	}
 	
 	function checkPasswordStrength($password, $strength)
 	{

--- a/modules/member/ruleset/insertDefaultConfig.xml
+++ b/modules/member/ruleset/insertDefaultConfig.xml
@@ -7,5 +7,8 @@
 		<field name="webmaster_name" required="true" length="2:40" />
 		<field name="webmaster_email" length="1:200" rule="email" />
 		<field name="password_strength" required="true" />
+		<field name="password_hashing_algorithm" required="true" />
+		<field name="password_hashing_work_factor" required="true" />
+		<field name="password_hashing_auto_upgrade" required="true" />
     </fields>
 </ruleset>

--- a/modules/member/tpl/default_config.html
+++ b/modules/member/tpl/default_config.html
@@ -30,6 +30,32 @@
 		</div>
 	</div>
 	<div class="x_control-group">
+		<label class="x_control-label">{$lang->cmd_password_hashing_algorithm}</label>
+		<div class="x_controls">
+			<select name="password_hashing_algorithm" id="password_hashing_algorithm" style="width:auto">
+				<option value="{$key}" selected="selected"|cond="$config->password_hashing_algorithm==$key" loop="$password_hashing_algos=>$key,$val">{$val}</option>
+			</select>
+			<p class="x_help-block">{$lang->about_password_hashing_algorithm}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
+		<label class="x_control-label">{$lang->cmd_password_hashing_work_factor}</label>
+		<div class="x_controls">
+			<select name="password_hashing_work_factor" id="password_hashing_work_factor" style="width:auto">
+				<option value="{$i}" selected="selected"|cond="$config->password_hashing_work_factor==$i" loop="$i=4;$i<=16;$i++">{sprintf('%02d', $i)}</option>
+			</select>
+			<p class="x_help-block">{$lang->about_password_hashing_work_factor}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
+		<label class="x_control-label">{$lang->cmd_password_hashing_auto_upgrade}</label>
+		<div class="x_controls">
+			<label for="password_hashing_auto_upgrade_y" class="x_inline"><input type="radio" name="password_hashing_auto_upgrade" id="password_hashing_auto_upgrade_y" value="Y" checked="checked"|cond="$config->password_hashing_auto_upgrade == 'Y'" /> {$lang->cmd_yes}</label>
+			<label for="password_hashing_auto_upgrade_n" class="x_inline"><input type="radio" name="password_hashing_auto_upgrade" id="password_hashing_auto_upgrade_n" value="N" checked="checked"|cond="$config->password_hashing_auto_upgrade != 'Y'" /> {$lang->cmd_no}</label>
+			<p class="x_help-block">{$lang->about_password_hashing_auto_upgrade}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
 		<label class="x_control-label" for="webmaster_name">{$lang->webmaster_name}</label>
 		<div class="x_controls">
 			<input type="text" id="webmaster_name" name="webmaster_name" value="{$config->webmaster_name}" size="20" />


### PR DESCRIPTION
이슈 #889 에서 말씀드렸던 개선안입니다. 몇 년 묵은 소원이었는데 이제야 시간을 내서 작업을 해봤네요.

기존 회원DB 및 다른 모듈들과 100% 호환성을 유지하면서, 회원 로그인 비밀번호 저장시 PBKDF2, bcrypt 등 강력한 암호화(해싱) 함수 사용을 가능하도록 하는 것을 목표로 합니다.

변경한 내역은 크게 3부분으로 나누어 설명할 수 있겠습니다.
#### 첫째, 비밀번호 암호화(해싱) 기능을 전담하는 클래스 추가

새로 추가한 파일은 `classes/security/Password.class.php`입니다. PBKDF2 알고리듬처럼 이미 공개되어 있는 정보를 가져다 쓴 몇몇 부분을 제외하면 모두 제가 직접 구현하였으며, 이 풀리퀘를 받아들이실 경우 저작권은 네이버 XE개발팀에 드리겠습니다.

`Password` 클래스는 아래와 같은 기능을 수행합니다.
- 현재 시스템에서 사용 가능한 해싱 함수의 목록을 작성하고 (`getSupportedAlgorithms()` 메소드) 그 중 가장 강력한 보안을 제공하는 알고리듬을 추천합니다. (`getBestAlgorithm()` 메소드)
- 주어진 비밀번호를 주어진 알고리듬으로 해싱합니다. (`createHash()` 메소드)
- 이렇게 생성하여 DB에 저장해 두었던 해시를 사용자가 입력한 비밀번호와 비교합니다. (`checkPassword()` 메소드)
- 지원하는 해싱 알고리듬 목록은 아래와 같습니다:
  - md5 (기존 XE 기본값)
  - md5+sha1+md5 (기존 XE에서 `$useSha1`을 지정할 경우 사용하던 옵션)
  - PBKDF2 (PKCS#5 v2 표준, sha256 기반) **PHP 5.1.2~5.3.6에서 추천**
  - bcrypt **PHP 5.3.7 이상에서 추천**
  - 그 밖의 알고리듬들은 11월 12일에 삭제했습니다.
- 해시를 넘겨주면 해시의 길이, 특정 문자열의 존재여부 등을 통해 어떤 알고리듬으로 생성된 해시인지 자동으로 파악합니다. (`guessAlgorithm()` 메소드) 따라서 새 방식으로 해싱된 비밀번호는 물론, 기존의 어떤 방식으로 해싱된 비밀번호라도 정확하게 확인이 가능합니다.
- 일부 해싱 함수는 무작위로 생성된 솔트를 필요로 합니다. `openssl` 모듈, `mcrypt` 모듈, `/dev/urandom`, `mt_rand()` 등 현재 시스템에서 사용 가능한 가장 강력한 엔트로피 출처를 파악하여 각 함수가 필요로 하는 규격의 솔트를 자동으로 생성합니다. (`createSecureSalt()` 메소드) 이 기능은 비번 암호화 외에도 무작위로 생성된 문자열이 필요한 곳에서는 얼마든지 활용이 가능할 것으로 보입니다.
- 테스트 편의를 위해, XE와 별도로 사용하더라도 모든 기능이 정상적으로 동작하도록 만들었습니다. 그러나 XE 환경에서 사용시 아래에서 설명드릴 설정에 따라 자동으로 알고리듬을 선택하는 등의 헤택(?)이 있습니다.
#### 둘째, `member` 모듈에서 비밀번호 처리시 위의 클래스와 연동합니다.
- `memberModel` 클래스의 `isValidPassword()` 메소드를 고쳐서 `Password` 클래스와 연동하도록 합니다. 기존의 방식으로 암호화된 비번과 새로 추가된 알고리듬까지 이 함수 하나로 모두 지원합니다.
- `memberModel` 클래스에 `hashPassword()` 메소드를 추가하여 `Password` 클래스와 연동하도록 합니다. 문서, 댓글, 게시판 등의 모듈을 보면 비번을 확인할 때는 `memberModel` 클래스의 `isValidPassword()` 메소드를 호출하는데, 비번을 해싱할 때는 모두 각자 `md5()`를 사용하고 있습니다. 지금까지 XE에서 비번 확인 메소드는 제공했지만 비번 해싱 메소드는 별도로 제공하지 않았기 때문입니다. 해싱 메소드를 제공함으로써 앞으로 XE 모듈을 개발하시는 분들의 편의를 도모합니다.
- `memberController` 클래스에서 회원 가입 및 직접 추가, 회원 정보 및 비번 변경, 비번 리셋 등의 작업을 할 때는 언제나 `memberModel` 클래스의 `hashPassword()` 메소드를 호출하도록 하여 일관성을 높였습니다.
#### 셋째, 관리 페이지에서 해싱 방법을 직접 지정할 수 있도록 하였습니다.

회원 설정에 비밀번호 암호화와 관련된 설정 항목 3가지를 추가하였습니다. (스크린샷 참조)

![untitled](https://cloud.githubusercontent.com/assets/164058/5008790/84502b0c-6aa3-11e4-9e67-98b1aec307ce.png)
- 기존에 운영중이던 사이트에 패치를 적용하면 기본값은 md5로 설정됩니다. 기존 버전과의 호환성을 보장하기 위해서입니다. 그러나 패치를 적용한 후에는 목록에서 원하는 알고리듬을 선택하여 변경할 수 있습니다. (PHP 5.3.6 이하에서는 bcrypt 옵션이 나타나지 않습니다.)
- 암호화 소요시간은 bcrypt의 work factor를 의미합니다. 4~16 범위에서 조절할 수 있으며, 기본값은 8입니다. 권장하는 범위는 8~12 사이입니다. (원래 bcrypt는 4~31 범위를 지원하지만, 16이 넘어가면 서버에 무리가 많이 갑니다. 너무 높은 값을 실수로 선택하는 것을 방지하기 위해 화면상에는 16까지만 표시합니다.)
- PBKDF2에도 소요시간 설정이 동일하게 적용됩니다. 같은 설정 하의 bcrypt와 비슷한 시간이 소요되도록 했습니다.
- 암호화 방법 자동 변환 설정은 현재 설정된 알고리듬과 다른 알고리듬으로 해싱된 비밀번호가 발견될 경우 자동으로 변환할지의 여부를 결정합니다. 물론 해싱 함수는 복호화가 불가능하므로, 다음번에 로그인하거나 비밀번호를 변경할 때 변환이 이루어집니다.
#### 기타
- 처음 설치할 때는 서버에서 지원하는 가장 강력한 알고리듬을 자동으로 선택합니다. PHP 5.3.7 이상에서는 bcrypt, 5.3.6 이하에서는 PBKDF2이지만, PHP 모듈이 이상하게 설치되어 있는 경우 기존과 같이 md5로 선택될 수도 있습니다.
- 문서, 댓글, 게시판, 방명록, 위키, textyle 등 다른 모듈에는 영향을 주지 않습니다. (로그인 비밀번호를 제외하면 대부분의 모듈들이 자체적으로 `md5()`를 사용하고, 비번을 확인할 때만 `memberModel`의 `isValidPassword()` 메소드를 호출하고 있습니다. `isValidPassword()` 메소드는 기존의 md5 해시와 100% 호환되기 때문에 괜찮습니다.) 호환성 테스트에 대한 자세한 내용은 #889 를 참조하시기 바랍니다.
- 모든 클래스와 메소드에는 철저하게 주석을 넣고, XE 코딩 스타일에 맞추려고 노력했습니다.

무지막지하게 큰 패치와 스크롤 압박 쩌는 풀리퀘 내용을 읽어주셔서 감사합니다. 호환성 문제가 있다거나, 설정을 조금 다른 방식으로 하면 좋겠다거나, 그 밖에 지적하실 부분이 있으면 얼마든지 알려주세요. 바꿀 건 바꾸고, 고칠 건 고치더라도, XE의 비번저장 보안은 꼭 개선되었으면 좋겠습니다.

그래도 저처럼 코어 개발자님들과 일면식도 없는 사람이 이런 풀리퀘도 넣을 수 있고... 이래저래 자유 소프트웨어 만세입니다 ^__^
