### PR TITLE
관리자메뉴설정 에서 삭제가 안 되는 버그 패치

### DIFF
--- a/modules/admin/tpl/js/menu_setup.js
+++ b/modules/admin/tpl/js/menu_setup.js
@@ -42,7 +42,7 @@ jQuery(function($){
 	});
 
 	$('a._child_delete').click(function() {
-		var menu_item_srl = $(this).parents('li').find('._item_key').val();
+		var menu_item_srl = $(this).closest('li').find('._item_key').val();
 		listForm.find('input[name=menu_item_srl]').val(menu_item_srl);
 		listForm.submit();
 	});


### PR DESCRIPTION
관리자메뉴 설정에서, 하위메뉴들에 대해 삭제를 눌러도 삭제가 안 된다.

원인은 jquery 에서  parents()  를 사용해서이다.  
parents 는 최상위부터 다 검토하게 되는데, 동일하  li._item_key  형태가   1차 / 2차 형태에 둘 다 나오다보니 정작 jquery 로  menu_item_srl  값을 넣을때 삭제버튼을 눌렀던 해당 2차 메뉴의  값이 들어가는게 아니라 그 상위의 1차 메뉴 값이 들어가면서 무조건 '하위메뉴가 존재하여 삭제할 수 없습니다' 라는 메세지가 나오게 되는 것이다
결국,  parents 대신에 closest   를 사용해서, 삭제버튼 있는 곳에서부터 찾으니 2차 메뉴의  li._item_key 가 된다
