### PR TITLE
DB 컬럼 정보를 불러오는 기능 + DB 컬럼 속성을 변경하는 기능

### DIFF
--- a/classes/db/DBMssql.class.php
+++ b/classes/db/DBMssql.class.php
@@ -428,6 +428,46 @@ class DBMssql extends DB
 	}
 
 	/**
+	 * Modify a column
+	 * @param string $table_name table name
+	 * @param string $column_name column name
+	 * @param string $type column type, default value is 'number'
+	 * @param int $size column size
+	 * @param string|int $default default value
+	 * @param boolean $notnull not null status, default value is false
+	 * @return bool
+	 */
+	function modifyColumn($table_name, $column_name, $type = 'number', $size = '', $default = '', $notnull = false)
+	{
+		$type = $this->column_type[$type];
+		if(strtoupper($type) == 'INTEGER')
+		{
+			$size = '';
+		}
+
+		$query = sprintf("alter table %s%s alter column %s ", $this->prefix, $table_name, $column_name);
+		if($size)
+		{
+			$query .= sprintf(" %s(%s) ", $type, $size);
+		}
+		else
+		{
+			$query .= sprintf(" %s ", $type);
+		}
+
+		if($default)
+		{
+			$query .= sprintf(" default '%s' ", $default);
+		}
+		if($notnull)
+		{
+			$query .= " not null ";
+		}
+
+		return $this->_query($query) ? true : false;
+	}
+
+	/**
 	 * Check column exist status of the table
 	 * @param string $table_name table name
 	 * @param string $column_name column name
@@ -448,7 +488,7 @@ class DBMssql extends DB
 		}
 		return true;
 	}
-
+	
 	/**
 	 * Get information about a column
 	 * @param string $table_name table name

--- a/classes/db/DBMssql.class.php
+++ b/classes/db/DBMssql.class.php
@@ -450,6 +450,66 @@ class DBMssql extends DB
 	}
 
 	/**
+	 * Get information about a column
+	 * @param string $table_name table name
+	 * @param string $column_name column name
+	 * @return object
+	 */
+	function getColumnInfo($table_name, $column_name)
+	{
+		$query = sprintf("select syscolumns.name as name, systypes.name as type_name, syscolumns.length as length, " .
+			"syscolumns.isnullable as isnullable, syscomments.text as default_value from syscolumns " .
+			"inner join sysobjects on sysobjects.id = syscolumns.id " .
+			"inner join systypes on systypes.xtype = syscolumns.xtype " .
+			"left join syscomments on syscolumns.cdefault = syscomments.id " .
+			"where sysobjects.name = '%s%s' and syscolumns.name = '%s'", $this->prefix, $table_name, $column_name);
+		$result = $this->_query($query);
+		if($this->isError())
+		{
+			return;
+		}
+		$output = $this->_fetch($result);
+		if($output)
+		{
+			$dbtype = $output->type_name;
+			$size = ($output->length > 0) ? $output->length : null;
+			if($xetype = array_search("$dbtype($size)", $this->column_type))
+			{
+				$dbtype = "$dbtype($size)";
+				$size = null;
+			}
+			elseif($size !== null)
+			{
+				if($xetype = array_search($dbtype, $this->column_type))
+				{
+					// no-op
+				}
+				else
+				{
+					$xetype = $dbtype;
+				}
+			}
+			else
+			{
+				$xetype = $dbtype;
+				$size = null;
+			}
+			return (object)array(
+				'name' => $output->name,
+				'dbtype' => $dbtype,
+				'xetype' => $xetype,
+				'size' => $size,
+				'default_value' => $output->default_value,
+				'notnull' => !$output->isnullable,
+			);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	
+	/**
 	 * Add an index to the table
 	 * $target_columns = array(col1, col2)
 	 * $is_unique? unique : none

--- a/classes/db/DBMysql.class.php
+++ b/classes/db/DBMysql.class.php
@@ -341,6 +341,45 @@ class DBMysql extends DB
 	}
 
 	/**
+	 * Modify a column
+	 * @param string $table_name table name
+	 * @param string $column_name column name
+	 * @param string $type column type, default value is 'number'
+	 * @param int $size column size
+	 * @param string|int $default default value
+	 * @param boolean $notnull not null status, default value is false
+	 * @return bool
+	 */
+	function modifyColumn($table_name, $column_name, $type = 'number', $size = '', $default = '', $notnull = false)
+	{
+		$type = $this->column_type[$type];
+		if(strtoupper($type) == 'INTEGER')
+		{
+			$size = '';
+		}
+		
+		$query = sprintf("alter table `%s%s` modify `%s` ", $this->prefix, $table_name, $column_name);
+		if($size)
+		{
+			$query .= sprintf(" %s(%s) ", $type, $size);
+		}
+		else
+		{
+			$query .= sprintf(" %s ", $type);
+		}
+		if($default)
+		{
+			$query .= sprintf(" default '%s' ", $default);
+		}
+		if($notnull)
+		{
+			$query .= " not null ";
+		}
+		
+		return $this->_query($query) ? true : false;
+	}
+
+	/**
 	 * Check column exist status of the table
 	 * @param string $table_name table name
 	 * @param string $column_name column name


### PR DESCRIPTION
#894 작업을 하다가 아쉬운 점이 있어서 새 기능을 만들어 보았습니다.

현재는 모듈 업데이트를 하거나 그 밖에 DB 스키마 변경이 필요할 때 컬럼을 추가하거나 삭제할 수는 있지만, 이미 있는 컬럼의 자료형이나 길이를 변경할 수는 없도록 되어 있습니다. 그렇다고 쿼리를 직접 써서 변경한다면 XE의 원칙에 어긋나겠고요...

그래서 특정 테이블의 특정 컬럼에 대한 정보(자료형, 길이, 기본값, null여부)를 불러온 후 변경이 필요하다고 판단되면 변경을 요청할 수 있는 기능을 추가해 보았습니다.

`getColumnInfo()` 메소드는 해당 컬럼의 속성이 담긴 객체를 반환합니다.

    $column_info = $oDB->getColumnInfo('member', 'password');
    var_dump($column_info);
        object(stdClass)#18 (6) {
            ["name"]=> string(8) "password"
            ["dbtype"]=> string(7) "varchar"  // 실제 DB에서 사용하는 자료형 (DBMS마다 다름)
            ["xetype"]=> string(7) "varchar"  // XE에서 사용하는 단순화된 자료형 (number, date 등)
            ["size"]=> int(60)
            ["default_value"]=> NULL
            ["notnull"]=> bool(true)
        }

`modifyColumn()` 메소드는 컬럼 속성을 변경하는 데 사용하며, 사용하는 파라미터의 종류와 순서는 이미 있는 `addColumn()` 메소드와 같습니다. 

    // password 컬럼의 길이를 250자로 늘리는 명령
    $oDB->modifyColumn('member', 'password', 'varchar', 250, null, true);

변경이 필요하지 않은 속성까지 변경되는 것을 막기 위해서는 `getColumnInfo()` 메소드에서 받은 값을 도로 집어넣는 것이 좋습니다.

    $column_info = $oDB->getColumnInfo('member', 'password');
    $oDB->modifyColumn('member', 'password', $column_info->xetype, 250,
        $column_info->default_value, $column_info->notnull);

속성 변경에 성공한 경우 `true`, 실패한 경우 `false`를 반환합니다.

MySQL, MS SQL, 큐브리드 모두 동일한 기능을 갖도록 만들어졌으나, 일부 버전의 큐브리드는 컬럼 속성 변경이 불가능한 경우도 있습니다. 이 경우 `modifyColumn()` 메소드는 `false`를 반환하게 됩니다. 그 밖에도 DB 권한 등 여러 가지 이유로 스키마 변경에 실패할 수 있으므로, 이 메소드를 사용하는 모듈에서는 `false`를 반환하는 경우를 반드시 확인하고 적절한 조치를 취해야 합니다.

많은 테스트를 바라며, 모듈 업데이트시 새로운 기능을 구현하면서도 구 버전과의 호환성을 유지하고 싶은 분들에게 도움이 되면 좋겠습니다.