### PR TITLE
통합검색에서 제목+내용 검색 가능케 하기

### DIFF
--- a/modules/integration_search/integration_search.view.php
+++ b/modules/integration_search/integration_search.view.php
@@ -119,13 +119,15 @@ class integration_searchView extends integration_search
 					$this->setTemplateFile("file", $page);
 					break;
 				default :
-					$output['document'] = $oIS->getDocuments($target, $module_srl_list, 'title', $is_keyword, $page, 5);
+					$search_target = Context::get('search_target');
+					if(!in_array($search_target, array('title','title_content'))) $search_target = 'title_content';
+					$output['document'] = $oIS->getDocuments($target, $module_srl_list, $search_target, $is_keyword, $page, 5);
 					$output['comment'] = $oIS->getComments($target, $module_srl_list, $is_keyword, $page, 5);
 					$output['trackback'] = $oIS->getTrackbacks($target, $module_srl_list, 'title', $is_keyword, $page, 5);
 					$output['multimedia'] = $oIS->getImages($target, $module_srl_list, $is_keyword, $page, 5);
 					$output['file'] = $oIS->getFiles($target, $module_srl_list, $is_keyword, $page, 5);
 					Context::set('search_result', $output);
-					Context::set('search_target', 'title');
+					Context::set('search_target', $search_target);
 					$this->setTemplateFile("index", $page);
 					break;
 			}


### PR DESCRIPTION
통합검색 사용시 기본 skin에 `<input type="hidden" name="search_target" value="title_content">`로 되어 있으나.

통합검색을 하는 부분에서 (where가 없는경우, default) search_target 변수를 이용하지 않아서, 무조건 기본값인 제목 기준으로 검색이 되는것 같습니다.

search_target에서 title과 title_content 모두 이용이 가능하도록 변경해 보았습니다.
