### PR TITLE
board module 검색 기본값 변경. 제목 → 제목+내용

### DIFF
--- a/modules/board/board.class.php
+++ b/modules/board/board.class.php
@@ -9,7 +9,7 @@
 
 class board extends ModuleObject
 {
-	var $search_option = array('title','content','title_content','comment','user_name','nick_name','user_id','tag'); ///< 검색 옵션
+	var $search_option = array('title_content','title','content','comment','user_name','nick_name','user_id','tag'); ///< 검색 옵션
 
 	var $order_target = array('list_order', 'update_order', 'regdate', 'voted_count', 'blamed_count', 'readed_count', 'comment_count', 'title'); // 정렬 옵션
 


### PR DESCRIPTION
검색을 할때 제목만으로 검색을 하는 경우 보다는 제목 + 내용으로 찾는게 일반적입니다.
그러나 게시판에서 검색시 기본으로 제목이 선택되 있어서 검색하는데에 불편함이 있는것 같습니다.

따라서 기본값으로 제목이 아닌 제목 + 내용 형태로 우선되게 변경해 보았습니다.
![ch](https://cloud.githubusercontent.com/assets/7894760/4007682/6c1dd8e2-29c9-11e4-8b6a-d238aa660d0f.png)
