### PR TITLE
맴버모듈의 프로필이미지설정값을 지정하지 않아도 90으로 고정

### DIFF
--- a/modules/member/member.class.php
+++ b/modules/member/member.class.php
@@ -66,8 +66,8 @@ class member extends ModuleObject {
 		if(!$config->image_name_max_height) $config->image_name_max_height = '20';
 		if(!$config->image_mark_max_width) $config->image_mark_max_width = '20';
 		if(!$config->image_mark_max_height) $config->image_mark_max_height = '20';
-		if(!$config->profile_image_max_width) $config->profile_image_max_width = '80';
-		if(!$config->profile_image_max_height) $config->profile_image_max_height = '80';
+		if(!$config->profile_image_max_width) $config->profile_image_max_width = '90';
+		if(!$config->profile_image_max_height) $config->profile_image_max_height = '90';
 		if($config->group_image_mark!='Y') $config->group_image_mark = 'N';
 		if(!$config->password_strength) $config->password_strength = 'normal';
 		

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -711,7 +711,7 @@ class memberController extends member
 		$max_width = $config->profile_image_max_width;
 		if(!$max_width) $max_width = "90";
 		$max_height = $config->profile_image_max_height;
-		if(!$max_height) $max_height = "20";
+		if(!$max_height) $max_height = "90";
 		// Get a target path to save
 		$target_path = sprintf('files/member_extra_info/profile_image/%s', getNumberingPath($member_srl));
 		FileHandler::makeDir($target_path);

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -57,8 +57,8 @@ class memberModel extends member
 		if(!$config->image_name_max_height) $config->image_name_max_height = 20;
 		if(!$config->image_mark_max_width) $config->image_mark_max_width = 20;
 		if(!$config->image_mark_max_height) $config->image_mark_max_height = 20;
-		if(!$config->profile_image_max_width) $config->profile_image_max_width = 80;
-		if(!$config->profile_image_max_height) $config->profile_image_max_height = 80;
+		if(!$config->profile_image_max_width) $config->profile_image_max_width = 90;
+		if(!$config->profile_image_max_height) $config->profile_image_max_height = 90;
 		if(!$config->skin) $config->skin = 'default';
 		if(!$config->colorset) $config->colorset = 'white';
 		if(!$config->editor_skin || $config->editor_skin == 'default') $config->editor_skin = 'xpresseditor';


### PR DESCRIPTION
#719 에서 보내달라하셧던 코드를 그대로 보내드립니다

제가 했던 방법을 다시 설명드리자면 지금 현재 상태는 프로필이미지의 설정값이 없을때 값이 80으로 설정되게끔 해놨는데, 이부분의 설정값들이 워낙 다 다르게 설정된것을 확인했습니다.

첫 모듈 설치시 사용되는 class파일의 install부분의 설정값을 전부 90

그리고 controller.php 파일에서
`$max_height = $config->profile_image_max_height;`
이 고정이기 때문에, 이 부분의 설정값이 없을때 고정적인 값으로 가로크기에 맞춰서 기본값 90으로 설정햇습니다.

/아무래도 프로필이미지와 이미지닉네임의 크기를 설정하는 부분을 서로 혼돈하시고 값이 입력된것 같았습니다.

member.model.php 에서 getconfig 역시 마찬가지로 해당부분 90으로 수정 하여 사용하고 있었습니다 :)

확인하시고~ PR받아주시면 됩니다.

감사합니다 :)
