### PR TITLE
krzip_search.js load문 삭제

### DIFF
--- a/modules/member/tpl/insert_member.html
+++ b/modules/member/tpl/insert_member.html
@@ -1,4 +1,3 @@
-<load target="js/krzip_search.js" />
 <load target="js/member_admin.js" />
 <!--%load_js_plugin("ui.datepicker")-->
 <script>


### PR DESCRIPTION
krzip 모듈에서 자동으로 불러올 뿐더러,
경로도 잘못됐기 때문에 제거했습니다.
