### PR TITLE
HTML 코멘트로 디버그가 출력되지 않는 버그 수정

### DIFF
--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -292,7 +292,7 @@ class DisplayHandler extends Handler
 					$buff = 'The IP address is not allowed. Change the value of __DEBUG_PROTECT_IP__ into your IP address in config/config.user.inc.php or config/config.inc.php';
 				}
 
-				return "<!--\r\n" . implode("\r\n", $buff) . "\r\n-->";
+				return "<!--\r\n" . $buff . "\r\n-->";
 			}
 
 			// Output to a file


### PR DESCRIPTION
HTML 코멘트로 디버그 정보를 출력하도록 설정했음에도 출력되지 않는 버그 수정했습니다.
