### PR TITLE
moveCategoryDown에 category_srl을 저장하지 않던 문제개선.

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1557,6 +1557,7 @@ class documentController extends document
 		$this->updateCategory($cur_args);
 		// Category information
 		$next_args = new stdClass;
+		$next_args->category_srl = $next_category->category_srl;
 		$next_args->list_order = $list_order;
 		$next_args->title = $next_category->title;
 		$this->updateCategory($next_args);


### PR DESCRIPTION
moveCategoryDown에 category_srl을 저장하고 잇지 않앗었네요.

https://github.com/xpressengine/xe-core/commit/1b60833bad7924314875312bfe246b17e499c38c
해당 커밋에서 php5.4 호환성 개선하면서 삭제된 듯 합니다.
그래서 추가로 보내드립니다.
