### PR TITLE
최고관리자가 남긴 콘텐츠들의 대한 관리자의 권한 조정.

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -297,6 +297,14 @@ class boardController extends board
 			$comment = $oCommentModel->getComment($obj->comment_srl, $this->grant->manager);
 		}
 
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($comment->member_srl);
+
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
+		{
+			return new Object(-1, 'msg_admin_comment_no_modify');
+		}
+
 		// if comment_srl is not existed, then insert the comment
 		if($comment->comment_srl != $obj->comment_srl)
 		{

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -68,6 +68,7 @@ class boardController extends board
 		}
 
 		$oMemberModel = getModel('member');
+		$logged_info = Context::get('logged_info');
 		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
 		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
 		{

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -67,6 +67,13 @@ class boardController extends board
 			$is_update = true;
 		}
 
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
+		{
+			return new Object(-1, 'msg_admin_document_no_modify');
+		}
+
 		// if use anonymous is true
 		if($this->module_info->use_anonymous == 'Y')
 		{

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -554,7 +554,7 @@ class boardView extends board
 		}
 
 		$oDocumentModel = getModel('document');
-
+		$logged_info = Context::get('logged_info');
 		/**
 		 * check if the category option is enabled not not
 		 **/
@@ -563,7 +563,6 @@ class boardView extends board
 			// get the user group information
 			if(Context::get('is_logged'))
 			{
-				$logged_info = Context::get('logged_info');
 				$group_srls = array_keys($logged_info->group_list);
 			}
 			else
@@ -608,7 +607,7 @@ class boardView extends board
 			return new Object(-1, 'msg_protect_content');
 		}
 
-		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
 		{
 			return new Object(-1, 'msg_admin_document_no_modify');
 		}

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -866,7 +866,6 @@ class boardView extends board
 
 		$oMemberModel = getModel('member');
 		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oComment->member_srl);
-		debugPrint($member_info);
 
 		if($member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
 		{

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -843,6 +843,7 @@ class boardView extends board
 	 **/
 	function dispBoardModifyComment()
 	{
+		$logged_info = Context::get('logged_info');
 		// check grant
 		if(!$this->grant->write_comment)
 		{
@@ -862,6 +863,15 @@ class boardView extends board
 		// get comment information
 		$oCommentModel = getModel('comment');
 		$oComment = $oCommentModel->getComment($comment_srl, $this->grant->manager);
+
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oComment->member_srl);
+		debugPrint($member_info);
+
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
+		{
+			return new Object(-1, 'msg_admin_comment_no_modify');
+		}
 
 		// if the comment is not exited, alert an error message
 		if(!$oComment->isExists())

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -597,12 +597,20 @@ class boardView extends board
 		$oDocument = $oDocumentModel->getDocument(0, $this->grant->manager);
 		$oDocument->setDocument($document_srl);
 
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+
 		if($oDocument->get('module_srl') == $oDocument->get('member_srl')) $savedDoc = TRUE;
 		$oDocument->add('module_srl', $this->module_srl);
 
 		if($oDocument->isExists() && $this->module_info->protect_content=="Y" && $oDocument->get('comment_count')>0 && $this->grant->manager==false)
 		{
 			return new Object(-1, 'msg_protect_content');
+		}
+
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
+		{
+			return new Object(-1, 'msg_admin_document_no_modify');
 		}
 
 		// if the document is not granted, then back to the password input form

--- a/modules/board/lang/lang.xml
+++ b/modules/board/lang/lang.xml
@@ -375,4 +375,7 @@
 		<value xml:lang="en"><![CDATA[You cannot modify or delete document which has any comment on it.]]></value>
 		<value xml:lang="jp"><![CDATA[コメントが登録された書き込みは修正、または削除が禁止されています。]]></value>
 	</item>
+	<item name="msg_admin_document_no_modify">
+		<value xml:lang="ko"><![CDATA[최고관리자의 게시물을 수정할 권한이 없습니다.]]></value>
+	</item>
 </lang>

--- a/modules/board/lang/lang.xml
+++ b/modules/board/lang/lang.xml
@@ -378,4 +378,7 @@
 	<item name="msg_admin_document_no_modify">
 		<value xml:lang="ko"><![CDATA[최고관리자의 게시물을 수정할 권한이 없습니다.]]></value>
 	</item>
+	<item name="msg_admin_comment_no_modify">
+		<value xml:lang="ko"><![CDATA[최고관리자의 댓글을 수정할 권한이 없습니다.]]></value>
+	</item>
 </lang>

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -779,12 +779,17 @@ class commentController extends comment
 		// create the comment model object
 		$oCommentModel = getModel('comment');
 
+		$logged_info = Context::get('logged_info');
+
 		// check if comment already exists
 		$comment = $oCommentModel->getComment($comment_srl);
 		if($comment->comment_srl != $comment_srl)
 		{
 			return new Object(-1, 'msg_invalid_request');
 		}
+
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($comment->member_srl);
 
 		$document_srl = $comment->document_srl;
 
@@ -806,6 +811,7 @@ class commentController extends comment
 		if(count($childs) > 0)
 		{
 			$deleteAllComment = TRUE;
+			$deleteAdminComment = TRUE;
 			if(!$is_admin)
 			{
 				$logged_info = Context::get('logged_info');
@@ -818,10 +824,27 @@ class commentController extends comment
 					}
 				}
 			}
+			elseif($is_admin)
+			{
+				$logged_info = Context::get('logged_info');
+				foreach($childs as $val)
+				{
+					$c_member_info = $oMemberModel->getMemberInfoByMemberSrl($val->member_srl);
+					if($c_member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
+					{
+						$deleteAdminComment = FALSE;
+						break;
+					}
+				}
+			}
 
 			if(!$deleteAllComment)
 			{
 				return new Object(-1, 'fail_to_delete_have_children');
+			}
+			elseif(!$deleteAdminComment)
+			{
+				return new Object(-1, 'msg_admin_c_comment_no_delete');
 			}
 			else
 			{
@@ -834,6 +857,11 @@ class commentController extends comment
 					}
 				}
 			}
+		}
+
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
+		{
+			return new Object(-1, 'msg_admin_comment_no_delete');
 		}
 
 		// begin transaction

--- a/modules/comment/lang/lang.xml
+++ b/modules/comment/lang/lang.xml
@@ -312,4 +312,10 @@
 		<value xml:lang="en"><![CDATA[There are no selected comment.]]></value>
 		<value xml:lang="jp"><![CDATA[選択したコメントがありません。]]></value>
 	</item>
+	<item name="msg_admin_comment_no_delete">
+		<value xml:lang="ko"><![CDATA[최고관리자의 댓글을 삭제 할 수 없습니다.]]></value>
+	</item>
+	<item name="msg_admin_c_comment_no_delete">
+		<value xml:lang="ko"><![CDATA[이 댓글에 최고관리자의 댓글이 있어 삭제할 수 없습니다.]]></value>
+	</item>
 </lang>

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -719,13 +719,21 @@ class documentAdminController extends document
 	  */
 	function procDocumentAdminMoveToTrash()
 	{
+		$logged_info = Context::get('logged_info');
 		$document_srl = Context::get('document_srl');
 
 		$oDocumentModel = getModel('document');
 		$oDocumentController = getController('document');
 		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
 		if(!$oDocument->isGranted()) return $this->stop('msg_not_permitted');
-	
+
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
+		{
+			return new Object(-1, 'msg_admin_document_no_move_to_trash');
+		}
+
 		$oModuleModel = getModel('module');
 		$module_info = $oModuleModel->getModuleInfoByDocumentSrl($document_srl);
 

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -79,6 +79,14 @@ class documentAdminController extends document
 			$oDocument = $oDocumentModel->getDocument($document_srl);
 			if(!$oDocument->isExists()) continue;
 
+			$oMemberModel = getModel('member');
+			$logged_info = Context::get('logged_info');
+			$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+			if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
+			{
+				return new Object();
+			}
+
 			$source_category_srl = $oDocument->get('category_srl');
 
 			unset($obj);

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -706,6 +706,7 @@ class documentController extends document
 	 */
 	function moveDocumentToTrash($obj)
 	{
+		$logged_info = Context::get('logged_info');
 		$trash_args = new stdClass();
 		// Get trash_srl if a given trash_srl doesn't exist
 		if(!$obj->trash_srl) $trash_args->trash_srl = getNextSequence();
@@ -713,6 +714,13 @@ class documentController extends document
 		// Get its module_srl which the document belongs to
 		$oDocumentModel = getModel('document');
 		$oDocument = $oDocumentModel->getDocument($obj->document_srl);
+
+		$oMemberModel = getModel('member');
+		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
+		{
+			return new Object(-1, 'msg_admin_document_no_move_to_trash');
+		}
 
 		$trash_args->module_srl = $oDocument->get('module_srl');
 		$obj->module_srl = $oDocument->get('module_srl');
@@ -724,7 +732,6 @@ class documentController extends document
 		// Insert member's information only if the member is logged-in and not manually registered.
 		if(Context::get('is_logged')&&!$manual_inserted)
 		{
-			$logged_info = Context::get('logged_info');
 			$trash_args->member_srl = $logged_info->member_srl;
 
 			// user_id, user_name and nick_name already encoded

--- a/modules/document/lang/lang.xml
+++ b/modules/document/lang/lang.xml
@@ -874,4 +874,7 @@
 		<value xml:lang="jp"><![CDATA[タイトルがないドキュメントです。]]></value>
 		<value xml:lang="zh-TW"><![CDATA[此文章無標題。]]></value>
 	</item>
+	<item name="msg_admin_document_no_move_to_trash">
+		<value xml:lang="ko"><![CDATA[최고관리자의 게시물을 휴지통으로 이동시킬 권한이 없습니다.]]></value>
+	</item>
 </lang>


### PR DESCRIPTION
이 PR 에서는
- 최고관리자가 남긴 게시물 수정할 수 없음
- 최고관리자의 게시물을 휴지통으로 이동할 수 없도록 개선.
- 최고관리자의 게시물을 일반관리자가 이동 시키지 못하도록 개선.
- 댓글을 수정할 수 없음. 
- 댓글을 삭제 할 수 없음.

댓글 삭제 부분은 다음과 같이 처리 했습니다.

처음 부분을 return으로 처리 해버리니, 
`$childs as $val` 부분에서 관리자를 읽어들이는 부분의 코드가 안먹혀 마지막에 

``` php
    if($member_info->is_admin == 'Y' && $logged_info->is_admin == 'N')
    {
        return new Object(-1, 'msg_admin_comment_no_delete');
    }
```

처리 시켰습니다.

그리고 `$deleteAdminComment` 함수를 만들었습니다.
대댓글중에 따로 최고관리자의 글이 있을경우 오류 메세지를 명확하게 확실하게 띄어주기 위해서 따로 분리하여 제작 했습니다.
