### PR TITLE
인증메일 재전송시 메일수신자 이름이 기재되지 않는 버그

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1264,7 +1264,7 @@ class memberController extends member
 		$oMail->setTitle( Context::getLang('msg_confirm_account_title') );
 		$oMail->setContent($content);
 		$oMail->setSender( $member_config->webmaster_name?$member_config->webmaster_name:'webmaster', $member_config->webmaster_email);
-		$oMail->setReceiptor( $args->email_address, $args->email_address );
+		$oMail->setReceiptor( $member_info->user_name, $member_info->email_address );
 		$oMail->send();
 
 		$msg = sprintf(Context::getLang('msg_confirm_mail_sent'), $args->email_address);


### PR DESCRIPTION
수신자 정보가 기록되는 setReceiptor 쪽에 $args 변수 형식으로 둘 다 값이 들어가는 형태를
$member_info 를 기반으로 입력되도록 변경 (그래야 이름 부분이 정확하게 들어감)

ps. 이름 항목을 사용 안 하는 경우, 닉네임이 대신 들어가나요?  확인해본적이 없어서...
