### PR TITLE
회원정보보기시 공개 안 한 정보에 대해서도 최고관리자는 볼 수 있도록 변경

### DIFF
--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -119,7 +119,7 @@ class memberView extends member
 				continue;
 			}
 
-			if($memberInfo->member_srl != $logged_info->member_srl && $formInfo->isPublic != 'Y')
+			if($logged_info->is_admin != 'Y' && $memberInfo->member_srl != $logged_info->member_srl && $formInfo->isPublic != 'Y')
 			{
 				continue;
 			}


### PR DESCRIPTION
현재 관리자페이지의 회원목록에서 조회/수정  시에는 볼 수 있으나
사이트 상에서 닉네임 클릭 후 회원정보보기시 
최고관리자여도,  공개 안 한 정보에 대해서도 볼 수 없도록 되어있는데
최고관리자의 경우 예외적으로 비공개 정보도 볼 수 있도록 변경.
(어차피 관리자페이지에서 다 볼 수 있고,  확인 필요한 사항들도 있는데 일일이 관리자페이지로 되돌아와 검색해야하는게 상당히 불편한듯.)
