### PR TITLE
모바일 뷰 사용하는 경우, 사이트맵에서 메뉴 생성시 해당 모듈에 자동으로 모바일 뷰 사용 체크 되도록

### DIFF
--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -606,6 +606,12 @@ class menuAdminController extends menu
 		$cmArgs->is_skin_fix = 'N';
 		$cmArgs->is_mskin_fix = 'N';
 
+		$db_info = Context::getDBInfo();
+		if($db_info->use_mobile_view == 'Y')
+		{
+			$cmArgs->use_mobile = 'Y';
+		}
+		
 		// if mid is empty, auto create mid
 		if(!$request->module_id)
 		{


### PR DESCRIPTION
현재 사이트맵에서 메뉴 생성시, 자동으로 게시판이나 위젯 등이 생성되는데
이 때 모바일 뷰 사용 은 체크가 안 되기 때문에 
메뉴 생성 후 일일이 해당 모듈들에 대해 모바일뷰를 체크해줘야한다.

관리자 설정->일반  에서, '모바일 뷰 사용' 이 체크되어 있는 상황이면.
사이트맵에서 메뉴 추가하여 모듈 생성시에도  자동으로 각 모듈의 '모바일 뷰 사용' 이 체크되도록 수정
