### PR TITLE
do not validate ipaddress in mobile

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1875,7 +1875,7 @@ class memberController extends member
 	{
 		$destory_session = false;
 
-		if($_SESSION['ipaddress'] != $_SERVER['REMOTE_ADDR']) $destory_session =  true;
+		if($_SESSION['ipaddress'] != $_SERVER['REMOTE_ADDR'] && !Mobile::isMobileCheckByAgent() ) $destory_session =  true;
 
 		if($destory_session)
 		{


### PR DESCRIPTION
mobile 환경(스마트폰, 태블릿)에서는 ip가 수시로 변할 수 있기에 (LTE-WiFi) 세션에서 ip를 검증하지 않도록 해 보았습니다.
