### PR TITLE
Update mcontent.class.php

### DIFF
--- a/widgets/mcontent/mcontent.class.php
+++ b/widgets/mcontent/mcontent.class.php
@@ -18,7 +18,7 @@ class mcontent extends WidgetHandler
 	function proc($args)
 	{
 		// Targets to sort
-		if(!in_array($args->order_target, array('list_order','update_order'))) $args->order_target = 'list_order';
+		if(!in_array($args->order_target, array('regdate','update_order'))) $args->order_target = 'regdate';
 		// Sort order
 		if(!in_array($args->order_type, array('asc','desc'))) $args->order_type = 'asc';
 		// The number of displayed lists
@@ -223,7 +223,14 @@ class mcontent extends WidgetHandler
 		// Get a list of documents
 		$obj->module_srl = $args->module_srl;
 		$obj->sort_index = $args->order_target;
-		$obj->order_type = $args->order_type=="desc"?"asc":"desc";
+		if($args->order_target == 'list_order' || $args->order_target == 'update_order')
+		{
+			$obj->order_type = $args->order_type=="desc"?"asc":"desc";
+		}
+		else
+		{
+			$obj->order_type = $args->order_type=="desc"?"desc":"asc";
+		}
 		$obj->list_count = $args->list_count;
 		$obj->statusList = array('PUBLIC');
 		$output = executeQueryArray('widgets.content.getNewestDocuments', $obj);


### PR DESCRIPTION
정렬 방식이 최근등록순이지만 list_order 필드를 사용. 모바일웹과 일반 웹 위젯의 정렬 방식이 달라서. 

일반웹의 등록일 기준 사용으로 가져다 맞춤.
