### PR TITLE
문서 히스토리 사용중에 글을 최고관리자가 수정할 경우 글쓴이 정보 수정 및 권한 탈취 문제점 개선.

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -443,7 +443,7 @@ class documentController extends document
 		if(Context::get('is_logged'))
 		{
 			$logged_info = Context::get('logged_info');
-			if($source_obj->get('member_srl')==$logged_info->member_srl || !$bUseHistory)
+			if( $bUseHistory !== TRUE || $source_obj->get('member_srl')==$logged_info->member_srl)
 			{
 				$obj->member_srl = $logged_info->member_srl;
 				$obj->user_name = htmlspecialchars_decode($logged_info->user_name);

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -443,7 +443,7 @@ class documentController extends document
 		if(Context::get('is_logged'))
 		{
 			$logged_info = Context::get('logged_info');
-			if($source_obj->get('member_srl')==$logged_info->member_srl || $bUseHistory)
+			if($source_obj->get('member_srl')==$logged_info->member_srl || !$bUseHistory)
 			{
 				$obj->member_srl = $logged_info->member_srl;
 				$obj->user_name = htmlspecialchars_decode($logged_info->user_name);


### PR DESCRIPTION
#1001

권한및 글쓴이 정보가 바뀌는 문제점을 개선 했습니다.

혹시, 다른 경우가 필요한경우라면
알려주세요~
