### PR TITLE
문서 히스토리 사용중에 글을 최고관리자가 수정할 경우 글쓴이 정보 수정 및 권한 탈취 문제점 개선

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -443,7 +443,7 @@ class documentController extends document
 		if(Context::get('is_logged'))
 		{
 			$logged_info = Context::get('logged_info');
-			if($source_obj->get('member_srl')==$logged_info->member_srl || $bUseHistory)
+			if($bUseHistory !== TRUE || $source_obj->get('member_srl')==$logged_info->member_srl)
 			{
 				$obj->member_srl = $logged_info->member_srl;
 				$obj->user_name = htmlspecialchars_decode($logged_info->user_name);


### PR DESCRIPTION
문서 히스토리 사용중에 글을 최고관리자가 수정할 경우 글쓴이 정보 수정 및 권한 탈취 문제점 개선

#1001 
#1014 <- pull 에서 코드 문제있어서 그냥 새로 만들어서 다시 보내드립니다.
:)

@ngleader 님께서 말쑴주신 순서를 바꾸고, 확인을 명시적으로 하도록 수정했습니다.
