### PR TITLE
XML Request에서 object 및 array child argument를 전송할 수 없는 문제 해결

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -219,7 +219,7 @@ class Context
 		if($this->db_info->use_sitelock == 'Y')
 		{
 			if(is_array($this->db_info->sitelock_whitelist)) $whitelist = $this->db_info->sitelock_whitelist;
-			
+
 			if(!IpFilter::filter($whitelist))
 			{
 				$title = ($this->db_info->sitelock_title) ? $this->db_info->sitelock_title : 'Maintenance in progress...';
@@ -1252,17 +1252,73 @@ class Context
 		$xml_obj = $oXml->parse();
 
 		$params = $xml_obj->methodcall->params;
-		unset($params->node_name, $params->attrs);
+		unset($params->node_name, $params->attrs, $params->body);
 
-		if(!count($params))
+		if(!count(get_object_vars($params)))
 		{
 			return;
 		}
 
-		foreach($params as $key => $obj)
+		foreach($params as $key => $val)
 		{
-			$this->set($key, $this->_filterRequestVar($key, $obj->body, 0), TRUE);
+			$this->set($key, $this->_filterXmlVars($key, $val), TRUE);
 		}
+	}
+
+	/**
+	 * Filter xml variables
+	 *
+	 * @param string $key Variable key
+	 * @param object $val Variable value
+	 * @return mixed filtered value
+	 */
+	function _filterXmlVars($key, $val)
+	{
+		if(is_array($val))
+		{
+			$stack = array();
+			foreach($val as $k => $v)
+			{
+				$stack[$k] = $this->_filterXmlVars($k, $v);
+			}
+
+			return $stack;
+		}
+
+		$body = $this->_filterRequestVar($key, trim($val->body ? $val->body : ''), 0);
+		if($body)
+		{
+			return $body;
+		}
+
+		unset($val->node_name, $val->attrs, $val->body);
+		if(!count(get_object_vars($val)))
+		{
+			return NULL;
+		}
+
+		$stack = new stdClass();
+		foreach($val as $k => $v)
+		{
+			$output = $this->_filterXmlVars($k, $v);
+			if(is_object($v) && $v->attrs->type == 'array')
+			{
+				$output = array($output);
+			}
+			if($k == 'value' && (is_array($v) || $v->attrs->type == 'array'))
+			{
+				return $output;
+			}
+
+			$stack->{$k} = $output;
+		}
+
+		if(!count(get_object_vars($stack)))
+		{
+			return NULL;
+		}
+
+		return $stack;
 	}
 
 	/**

--- a/common/js/xe.js
+++ b/common/js/xe.js
@@ -1474,17 +1474,33 @@ function xml2json(xml, tab, ignoreAttrib) {
 		// 현 url과 ajax call 대상 url의 schema 또는 port가 다르면 직접 form 전송
 		if(_u1.protocol != _u2.protocol || _u1.port != _u2.port) return send_by_form(xml_path, params);
 
-		var xml = [], i = 0;
-		xml[i++] = '<?xml version="1.0" encoding="utf-8" ?>';
-		xml[i++] = '<methodCall>';
-		xml[i++] = '<params>';
+		var xml = [],
+			xmlHelper = function(params) {
+				var stack = [];
 
-		$.each(params, function(key, val) {
-			xml[i++] = '<'+key+'><![CDATA['+val+']]></'+key+'>';
-		});
+				if ($.isArray(params)) {
+					$.each(params, function(key, val) {
+						stack.push('<value type="array">' + xmlHelper(val) + '</value>');
+					});
+				}
+				else if ($.isPlainObject(params)) {
+					$.each(params, function(key, val) {
+						stack.push('<' + key + '>' + xmlHelper(val) + '</' + key + '>');
+					});
+				}
+				else if (!$.isFunction(params)) {
+					stack.push('<![CDATA[' + params + ']]>');
+				}
 
-		xml[i++] = '</params>';
-		xml[i++] = '</methodCall>';
+				return stack.join('\n');
+			};
+
+		xml.push('<?xml version="1.0" encoding="utf-8" ?>');
+		xml.push('<methodCall>');
+		xml.push('<params>');
+		xml.push(xmlHelper(params));
+		xml.push('</params>');
+		xml.push('</methodCall>');
 
 		var _xhr = null;
 		if (_xhr && _xhr.readyState !== 0) _xhr.abort();


### PR DESCRIPTION
``` javascript
var args = {
    test1: [1, 2, [1]],
    test2: {
        test3: 1234,
        test4: {
            test5: [1],
            test6: 11,
            test7: [22],
            test8: {
                test9: [11],
                test10: 11
            }
        }
    },
    value: 11
};
exec_xml("module", "act", args);
```

XE 내장 함수 exec_xml을 사용하여 위와 같은 arguments를 전송하면 Server side XE에서 저 값들을 제대로 받지 못하는 문제가 있습니다.
이 문제를 해결한 PR을 보냅니다만, 수정 부분이 좀 많으므로 XE 코어팀에서 충분한 테스트를 거친 후 적용해주셨으면 합니다.

p.s. minify는 배포하실 때 알아서 해주실 거라고 믿고 안 했습니다 :)
