### PR TITLE
#1088 모바일 메뉴(dispMenumenu)에서 새 창으로 열기 안되는 문제 수정

### DIFF
--- a/modules/menu/menu.mobile.php
+++ b/modules/menu/menu.mobile.php
@@ -27,6 +27,7 @@ class menuMobile extends moduleObject
 		$obj->href = $menu_item['href'];
 		$obj->depth = $depth;
 		$obj->text = $menu_item['text'];
+		$obj->open_window = $menu_item['open_window'];
 		$this->result[] = $obj;
 		if(!$menu_item['list']) return;
 		foreach($menu_item['list'] as $item)

--- a/modules/menu/tpl/menu.html
+++ b/modules/menu/tpl/menu.html
@@ -16,7 +16,7 @@
 		{@ $depth -= 1}
 		<!--@end-->
 		<!--@endif-->
-		<li><a href="{$val->href}" >{$val->text}</a>
+		<li><a href="{$val->href}" target="_blank"|cond="$val->open_window=='Y'">{$val->text}</a>
 			{@ $start = false }
 			{@ $depth = $val->depth }
 		<!--@end-->


### PR DESCRIPTION
모바일 메뉴를 불러오는 부분에 open_window를 가져오지 않고, 스킨에서도 해당 값을 체크하지 않아 target에 _black이 삽입되지 않는 문제 수정
