### PR TITLE
잘못 사용한 IMG 상수를 IMAGETYPE 상수로 교체

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -719,9 +719,9 @@ class memberController extends member
 
 		// Get file information
 		list($width, $height, $type, $attrs) = @getimagesize($target_file);
-		if(IMG_PNG == $type) $ext = 'png';
-		elseif(IMG_JPG == $type) $ext = 'jpg';
-		elseif(IMG_GIF == $type) $ext = 'gif';
+		if(IMAGETYPE_PNG == $type) $ext = 'png';
+		elseif(IMAGETYPE_JPEG == $type) $ext = 'jpg';
+		elseif(IMAGETYPE_GIF == $type) $ext = 'gif';
 		else
 		{
 			return;


### PR DESCRIPTION
IMG_PNG 값은 4인 반면 IMAGETYPE_PNG 값은 3입니다.
하지만 getimagesize 함수에서 type로 IMAGETYPE_XXX 상수를 반환하므로 IMG_PNG가 아닌 IMAGETYPE_PNG를 써야 올바른 확장자 판단이 가능합니다.

```
Index 2 is one of the IMAGETYPE_XXX constants indicating the type of the image.
```

( http://php.net/manual/en/function.getimagesize.php 에서 발췌)
