### PR TITLE
레벨 포인트 입력칸의 너비를 늘임

### DIFF
--- a/modules/point/tpl/config.html
+++ b/modules/point/tpl/config.html
@@ -125,7 +125,7 @@
 			<tr>
 				<td>1</td>
 				<td><img src="{getUrl()}/modules/point/icons/{$config->level_icon}/1.gif" alt="1" /></td>
-				<td><label for="level_step_1" style="margin:0"><input type="number" id="level_step_1" name="level_step_1" value="{$config->level_step[1]}" style="width:60px;text-align:right" /> {$config->point_name}</label></td>
+				<td><label for="level_step_1" style="margin:0"><input type="number" id="level_step_1" name="level_step_1" value="{$config->level_step[1]}" style="width:120px;text-align:right" /> {$config->point_name}</label></td>
 {@$point_group_item = $point_group[1]}
 {@$title=array()}
 <!--@if($point_group_item)-->
@@ -149,7 +149,7 @@
 			<tr class="row{(($i-1)%2+1)}">
 				<td>{$i}</td>
 				<td><img src="{getUrl()}/modules/point/icons/{$config->level_icon}/{$i}.gif" alt="{$i}" /></td>
-				<td><label for="level_step_{$i}" style="margin:0"><input type="number" id="level_step_{$i}" name="level_step_{$i}" value="{$config->level_step[$i]}" style="width:60px;text-align:right" /> {$config->point_name}</label></td>
+				<td><label for="level_step_{$i}" style="margin:0"><input type="number" id="level_step_{$i}" name="level_step_{$i}" value="{$config->level_step[$i]}" style="width:120px;text-align:right" /> {$config->point_name}</label></td>
 				<td>{implode(', ', $title)}</td>
 			</tr>
 			<!--@end-->


### PR DESCRIPTION
기본 60px로는 레벨이 어느 정도 넘어갈 경우 포인트가 커져서 잘리기에 정확한 비교가 어려우므로 120px로 두배가량 늘였습니다.

60px
![image](https://cloud.githubusercontent.com/assets/5893514/5576310/0f4f9e88-903b-11e4-840f-4bb15897ff26.png)

120px
![image](https://cloud.githubusercontent.com/assets/5893514/5576313/1b848da8-903b-11e4-80d6-595d72ac0106.png)
