### PR TITLE
게시글을 삭제하면 해당 글 내부에 첨부된 첨부파일이 서버에서 사라지지 않는 버그 (중요! 서버용량 과부하 원인)

### DIFF
--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -823,12 +823,6 @@ class fileController extends file
 		// Success returned if no attachement exists
 		if(!is_array($file_list)||!count($file_list)) return new Object();
 
-		// Remove from the DB
-		$args = new stdClass();
-		$args->upload_target_srl = $upload_target_srl;
-		$output = executeQuery('file.deleteFiles', $args);
-		if(!$output->toBool()) return $output;
-
 		// Delete the file
 		$path = array();
 		$file_count = count($file_list);
@@ -840,6 +834,13 @@ class fileController extends file
 			$path_info = pathinfo($uploaded_filename);
 			if(!in_array($path_info['dirname'], $path)) $path[] = $path_info['dirname'];
 		}
+
+		// Remove from the DB
+		$args = new stdClass();
+		$args->upload_target_srl = $upload_target_srl;
+		$output = executeQuery('file.deleteFiles', $args);
+		if(!$output->toBool()) return $output;
+		
 		// Remove a file directory of the document
 		for($i=0, $c=count($path); $i<$c; $i++)
 		{


### PR DESCRIPTION
게시글을 삭제하면 해당 글 내부에 첨부된 첨부파일이 서버에서 사라지지 않는 버그가 있다 
원인은 실제 파일삭제하는 함수에서, files DB 의 정보를 조회해서 주소를 찾아서 삭제를 하는데.. 
글 삭제할때 deleteFiles 함수에서  DB 를 먼저 삭제해버리고 파일을 삭제하려해서 문제가 생긴다.

글수정->첨부된 파일을 파일삭제 하는 건 잘 되는데 (이건 deleteFile) 함수를 쓰니..
글 삭제시 이 문제가 생긴다.  ( 관리자->컨텐츠->파일  에서는 지워진것처럼 나와서 더 문제인듯)
