### PR TITLE
사용자정의 기준 정렬과 사용자정의 검색이 동시에 작동하도록 버그 수정

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -224,7 +224,13 @@ class documentModel extends document
 
 		$this->_setSearchOption($obj, $args, $query_id, $use_division);
 
-		if ($sort_check->isExtraVars)
+		if ($sort_check->isExtraVars && substr_count($obj->search_target,'extra_vars'))
+		{
+			$query_id = 'document.getDocumentListWithinExtraVarsExtraSort';
+			$args->sort_index = str_replace('documents.','',$args->sort_index);
+			$output = executeQueryArray($query_id, $args);
+		}
+		elseif ($sort_check->isExtraVars)
 		{
 			$output = executeQueryArray($query_id, $args);
 		}

--- a/modules/document/queries/getDocumentListWithinExtraVarsExtraSort.xml
+++ b/modules/document/queries/getDocumentListWithinExtraVarsExtraSort.xml
@@ -1,0 +1,61 @@
+<query id="getDocumentListWithinExtraVarsExtraSort" action="select">
+  <tables>
+    <table name="documents" alias="d" />
+    <table name="document_extra_vars" alias="ev" />
+    <table name="document_extra_vars" alias="es" />
+  </tables>
+  <columns>
+    <column name="d.*" />
+  </columns>
+  <index_hint name="idx_document_list_order" type="use" />
+  <conditions>
+    <condition operation="equal" column="ev.eid" var="sort_index" />
+    <condition operation="equal" column="ev.document_srl" default="d.document_srl" pipe="and" />
+    <condition operation="in" column="d.module_srl" var="module_srl" filter="number" pipe="and" />
+    <condition operation="notin" column="d.module_srl" var="exclude_module_srl" filter="number" pipe="and" />
+    <condition operation="in" column="d.category_srl" var="category_srl" pipe="and" />
+    <condition operation="equal" column="d.is_notice" var="s_is_notice" pipe="and" />
+    <condition operation="equal" column="d.member_srl" var="member_srl" filter="number" pipe="and" />
+    <condition operation="in" column="d.status" var="statusList" pipe="and" />
+    <group pipe="and">
+      <condition operation="more" column="d.list_order" var="division" pipe="and" />
+      <condition operation="below" column="d.list_order" var="last_division" pipe="and" />
+    </group>
+    <group pipe="and">
+      <condition operation="like" column="d.title" var="s_title" />
+      <condition operation="like" column="d.content" var="s_content" pipe="or" />
+      <condition operation="like" column="d.user_name" var="s_user_name" pipe="or" />
+      <condition operation="like" column="d.user_id" var="s_user_id" pipe="or" />
+      <condition operation="like" column="d.nick_name" var="s_nick_name" pipe="or" />
+      <condition operation="like" column="d.email_address" var="s_email_addres" pipe="or" />
+      <condition operation="like" column="d.homepage" var="s_homepage" pipe="or" />
+      <condition operation="like" column="d.tags" var="s_tags" pipe="or" />
+      <condition operation="equal" column="d.is_secret" var="s_is_secret" pipe="or" />
+      <condition operation="equal" column="d.member_srl" var="s_member_srl" pipe="or" />
+      <condition operation="more" column="d.readed_count" var="s_readed_count" pipe="or" />
+      <condition operation="more" column="d.voted_count" var="s_voted_count" pipe="or" />
+      <condition operation="less" column="d.blamed_count" var="s_blamed_count" pipe="or" />
+      <condition operation="more" column="d.comment_count" var="s_comment_count" pipe="or" />
+      <condition operation="more" column="d.trackback_count" var="s_trackback_count" pipe="or" />
+      <condition operation="more" column="d.uploaded_count" var="s_uploaded_count" pipe="or" />
+      <condition operation="like_prefix" column="d.regdate" var="s_regdate" pipe="or" />
+      <condition operation="like_prefix" column="d.last_update" var="s_last_update" pipe="or" />
+      <condition operation="like_prefix" column="d.ipaddress" var="s_ipaddress" pipe="or" />
+    </group>
+    <group pipe="and">
+      <condition operation="more" column="d.last_update" var="start_date" pipe="and" />
+      <condition operation="less" column="d.last_update" var="end_date" pipe="and" />
+    </group>
+		<group pipe="and">
+			<condition operation="equal" column="es.var_idx" var="var_idx" pipe="and" />
+			<condition operation="like" column="es.value" var="var_value" pipe="and" />
+			<condition operation="equal" column="es.document_srl" default="d.document_srl" pipe="and" />
+		</group>
+  </conditions>
+  <navigation>
+    <index var="ev.value" default="ev.value" order="order_type" />
+    <list_count var="list_count" default="20" />
+    <page_count var="page_count" default="10" />
+    <page var="page" default="1" />
+  </navigation>
+</query>


### PR DESCRIPTION
현재 사용자정의 기준으로 정렬을 하면  getDocumentListExtraSort.xml  파일이 구현되고.
이 query 는 sort_index 대신 sort가 고정되어있고
사용자정의 기준으로 검색을 하면  getDocumentListWithinExtraVars.xml  파일이 실행되는데
이건 검색만 해당 eid 로 될뿐,  실제 정렬은 사용자정의를 제외한 일반 검색만 가능하게 되어있다.

이는 사용자정의 기준으로 정렬 설정을 해두고 사용자정의 검색할때뿐만 아니라.
기본 정렬 (등록일이나 문서번호) 로 정렬 후,  목록에서 사용자정의 기준으로 재정렬 한 후,  사용자정의 검색할때도
마찬가지로 결과가 안 나오는 문제가 발생한다.

결국 각각 다른 사용자정의 기준으로도  정렬 과 검색이 각각 될 수 있도록
테이블 3개를 join 한 새로운 query 를 추가하여 구현되도록 보완했다
