### PR TITLE
포인트 그룹 연동 설정시 최대 레벨보다 높게 설정할 수 있는 문제 수정

### DIFF
--- a/modules/point/point.admin.controller.php
+++ b/modules/point/point.admin.controller.php
@@ -60,6 +60,19 @@ class pointAdminController extends point
 			if($group->is_admin == 'Y' || $group->is_default == 'Y') continue;
 
 			$group_srl = $group->group_srl;
+
+			//if group level is higher than max level, change to max level
+			if($args->{'point_group_'.$group_srl} > $args->max_level)
+			{
+				$args->{'point_group_'.$group_srl} = $args->max_level;
+			}
+
+			//if group level is lower than 1, change to 1
+			if($args->{'point_group_'.$group_srl} < 1)
+			{
+				$args->{'point_group_'.$group_srl} = 1;
+			}
+
 			if($args->{'point_group_'.$group_srl})
 			{
 				$config->point_group[$group_srl] = $args->{'point_group_'.$group_srl};

--- a/modules/point/tpl/config.html
+++ b/modules/point/tpl/config.html
@@ -96,6 +96,7 @@
 			<label class="x_control-label" for="point_group_{$key}">{$val->title}</label>
 			<div class="x_controls">
 				<input cond="$val->is_default != 'Y'" type="number" min="0" max="1000" value="{$config->point_group[$key]}" name="point_group_{$key}" id="point_group_{$key}" style="width:50px" />
+				&nbsp;{$lang->level}
 				<span cond="$val->is_default == 'Y'" style="display:inline-block;padding-top:3px">{$lang->default_group}</span>
 			</div>
 		</div>


### PR DESCRIPTION
+혼동 방지를 위해 입력칸 옆에 레벨 표시 추가
