### PR TITLE
php.ini의 파일 업로드 용량을 잘못 불러오는 문제 수정

### DIFF
--- a/modules/file/file.admin.controller.php
+++ b/modules/file/file.admin.controller.php
@@ -178,23 +178,6 @@ class fileAdminController extends file
 			else $_SESSION['file_management'][$output->file_srl] = true;
 		}
 	}
-
-	/**
-	 * Change value from human readable to byte unit
-	 *
-	 * @param string $size_str Size string
-	 * @return int The byte value for input
-	 */
-	function _changeBytes($size_str)
-	{
-		switch (substr ($size_str, -1))
-		{
-			case 'M': case 'm': return (int)$size_str * 1048576;
-			case 'K': case 'k': return (int)$size_str * 1024;
-			case 'G': case 'g': return (int)$size_str * 1073741824;
-			default: return $size_str;
-		}
-	}
 }
 /* End of file file.admin.controller.php */
 /* Location: ./modules/file/file.admin.controller.php */

--- a/modules/file/file.admin.view.php
+++ b/modules/file/file.admin.view.php
@@ -217,6 +217,10 @@ class fileAdminView extends file
 		$oFileModel = getModel('file');
 		$config = $oFileModel->getFileConfig();
 		Context::set('config',$config);
+		$iniPostMaxSize = $this->_changeBytes(ini_get('post_max_size'));
+		$iniUploadMaxSize = $this->_changeBytes(ini_get('upload_max_filesize'));
+		$iniMinSize = min($iniPostMaxSize, $iniUploadMaxSize);
+		Context::set('upload_max_filesize',$this->_changeBytes($iniMinSize / 1048576));
 		// Set a template file
 		$this->setTemplatePath($this->module_path.'tpl');
 		$this->setTemplateFile('adminConfig');

--- a/modules/file/file.class.php
+++ b/modules/file/file.class.php
@@ -150,6 +150,25 @@ class file extends ModuleObject
 	function recompileCache()
 	{
 	}
+
+	/**
+	 * Change value from human readable to byte unit
+	 *
+	 * @param string $size_str Size string
+	 * @return int The byte value for input
+	 */
+	function _changeBytes($size_str)
+	{
+		$unit = strtoupper(substr($size_str, -1));
+		$size_str = (int)$size_str;
+		switch ($unit)
+		{
+			case 'G': $size_str *= 1024;
+			case 'M': $size_str *= 1024;
+			case 'K': $size_str *= 1024;
+		}
+		return $size_str;
+	}
 }
 /* End of file file.class.php */
 /* Location: ./modules/file/file.class.php */

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -238,7 +238,9 @@ class fileModel extends file
 
 		if($logged_info->is_admin == 'Y')
 		{
-			$size = preg_replace('/[a-z]/is', '', ini_get('upload_max_filesize'));
+			$iniPostMaxSize = $this->_changeBytes(ini_get('post_max_size'));
+			$iniUploadMaxSize = $this->_changeBytes(ini_get('upload_max_filesize'));
+			$size = min($iniPostMaxSize, $iniUploadMaxSize) / 1048576;
 			$file_config->allowed_attach_size = $size;
 			$file_config->allowed_filesize = $size;
 			$file_config->allowed_filetypes = '*.*';

--- a/modules/file/tpl/adminConfig.html
+++ b/modules/file/tpl/adminConfig.html
@@ -34,7 +34,7 @@
 	<div class="x_control-group">
 		<label for="filesize" class="x_control-label">{$lang->allowed_filesize} <a class="x_icon-question-sign" href="./admin/help/index.html#UMAN_config_file_size" target="_blank">{$lang->help}</a></label>
 		<div class="x_controls">
-			<input type="number" id="filesize" name="allowed_filesize" value="{$config->allowed_filesize}" /> MB/{ini_get('upload_max_filesize')}
+			<input type="number" id="filesize" name="allowed_filesize" value="{$config->allowed_filesize}" /> MB/{$upload_max_filesize}MB
 		</div>
 	</div>
 	<div class="x_control-group">


### PR DESCRIPTION
파일 업로드 용량 체크시 관리자일 경우 ini에서 직접 불러와서 처리하는데 이때 단위 처리가 빠져있어 무조건 MB 단위로 처리되는
버그 수정
스킨과의 호환성을 위해 1048576(1024*1024)으로 나눠서 MB 단위로 처리되게 수정하였습니다.

1048576으로 나누는 부분이 걸리적거리긴 하지만 스킨 호환성을 맞추려면 어쩔수 없네요(기본 스킨이 단위 없이 MB로 간주해서 불러오게 되어 있습니다)
