### PR TITLE
exec_json으로 권한 없이 notice_list, category_list, file_list, comment_list를 가져 올 수 있는 문제 해결

### DIFF
--- a/modules/board/board.api.php
+++ b/modules/board/board.api.php
@@ -50,7 +50,7 @@ class boardAPI extends board {
 	/**
 	 * @brief category list
 	 **/
-	function dispBoardCatogoryList(&$oModule) {
+	function dispBoardCategoryList(&$oModule) {
 		$oModule->add('category_list',Context::get('category_list'));
 	}
 

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -60,7 +60,7 @@
 		<action name="dispBoardNoticeList" type="view" />
 		<action name="dispBoardContentList" type="view" />
 		<action name="dispBoardContentView" type="view" />
-		<action name="dispBoardCatogoryList" type="view" />
+		<action name="dispBoardCategoryList" type="view" />
 		<action name="dispBoardContentCommentList" type="view" />
 		<action name="dispBoardContentFileList" type="view" />
 


### PR DESCRIPTION
접근 권한 있을 때 콘솔창에서 jQuery.exec_json으로 권한 없는 것들을 볼 수 있는 문제

XE Version : 1.7.9

1.. 문제
- dispBoardNoticeList : 목록 권한 없이 공지 사항 불러 올 수 있음.
- dispBoardCategoryList : 목록 권한 없이 카테고리 목록 불러 올 수 있음.(board.api.php, module.xml에 함수명 오타도 있음)
- dispBoardContentFileList : 문서 열람 권한이 없어도, 해당 문서 document_srl만 알면 file_list를 불러 올 수 있고, 이 file_list에는 첨부파일의 절대 경로 정보가 있기 때문에 다운로드 받을 수 있음. document_srl은 단순 시리얼이기 때문에 얼마든지 대입 가능.
- dispBoardContentCommentList : 문서 열람 권한 없이 댓글 목록 불러 올 수 있음.

2.. 해결
- dispBoardNoticeList : $this->grant->list 적용
- dispBoardCategoryList : $this->grant->list 적용
- dispBoardContentFileList : $this->grant->access 적용. 문서 열람 권한 적용. 파일 다운로드 가능 그룹 체크 적용(이 부분은 그냥 하드코딩 했으며, 권한만 알면 되기 때문에 getModulePartConfig에서 불러 왔습니다. file.controller.php와 겹치는 부분이 있으니 유지 보수를 위해 권한 체크만 따로 함수를 마련하는게 낫다고 봅니다.)
- dispBoardContentCommentList : 문서 열람 권한 적용.

3.. 개선할 부분
문서 열람 권한 적용에서 $this->dispBoardContentView(); 를 호출하는데, 권한이 인정될 경우 불필요하게 $oDocument를 또 set 합니다. 별 문제가 없다면 그대로 하면 될테지만, 문제가 있다면 권한 체크용 인수를 넘겨, 권한 체크일 때는 Context::set을 건너뛰면 될 듯 합니다.
이 부분을 제가 판단할 수 없어 개발진에게 미룹니다.
