### PR TITLE
포인트 부족 시 글 열람 금지 설정해도, 글을 볼 수 있는 버그 패치

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -876,7 +876,9 @@ class documentController extends document
 		}
 
 		// Register session
-		$_SESSION['readed_document'][$document_srl] = true;
+		if(!$_SESSION['banned_document'][$document_srl]) {
+			$_SESSION['readed_document'][$document_srl] = true;
+		}
 
 		return TRUE;
 	}

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -423,6 +423,7 @@ class pointController extends point
 		if($config->disable_read_document == 'Y' && $point < 0 && abs($point)>$cur_point)
 		{
 			$obj->add('content', sprintf(Context::getLang('msg_disallow_by_point'), abs($point), $cur_point));
+			$_SESSION['banned_document'][$obj->document_srl] = 'true';
 			return new Object();
 		}
 		// If not logged in, pass

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -420,11 +420,11 @@ class pointController extends point
 		// Get the defaul configurations of the Point Module
 		$config = $oModuleModel->getModuleConfig('point');
 		// When the requested points are negative, compared it with the current point
-		$_SESSION['banned_document'][$obj->document_srl] = 'false';
+		$_SESSION['banned_document'][$obj->document_srl] = false;
 		if($config->disable_read_document == 'Y' && $point < 0 && abs($point)>$cur_point)
 		{
 			$obj->add('content', sprintf(Context::getLang('msg_disallow_by_point'), abs($point), $cur_point));
-			$_SESSION['banned_document'][$obj->document_srl] = 'true';
+			$_SESSION['banned_document'][$obj->document_srl] = true;
 			return new Object();
 		}
 		// If not logged in, pass

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -420,6 +420,7 @@ class pointController extends point
 		// Get the defaul configurations of the Point Module
 		$config = $oModuleModel->getModuleConfig('point');
 		// When the requested points are negative, compared it with the current point
+		$_SESSION['banned_document'][$obj->document_srl] = 'false';
 		if($config->disable_read_document == 'Y' && $point < 0 && abs($point)>$cur_point)
 		{
 			$obj->add('content', sprintf(Context::getLang('msg_disallow_by_point'), abs($point), $cur_point));


### PR DESCRIPTION
게시판에서 글 열람시 포인트 차감되게 설정해두고
포인트 설정에서 '글 열람 금지' 에 체크되어 있는 경우...

포인트 부족시 글이 안 보여야하는데
처음에는 안 보였다가.
그 후 해당 글을 새로고침하거나,  목록으로 갔다가 다시 그 글을 보거나 할경우
글이 그대로 노출되는 버그가 있습니다.

이유는 해당 글을 읽었다고 세션에 기록이 남기 때문이죠..  수정했습니다.
