### PR TITLE
$bUseHistory 조건 제거 하여 문서 히스토리 사용시 권한이 탈취되는 문제점 개선

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -443,7 +443,7 @@ class documentController extends document
 		if(Context::get('is_logged'))
 		{
 			$logged_info = Context::get('logged_info');
-			if($source_obj->get('member_srl')==$logged_info->member_srl || $bUseHistory)
+			if($source_obj->get('member_srl')==$logged_info->member_srl)
 			{
 				$obj->member_srl = $logged_info->member_srl;
 				$obj->user_name = htmlspecialchars_decode($logged_info->user_name);


### PR DESCRIPTION
#1014 이슈가 적용이 되어있지 않았고, 다시 한번 테스트 해보니 문서 히스토리를 사용시 문제점이 더 있어서 해당 문서 히스토리조건을 제외 시켰습니다.
