### PR TITLE
휴지통에 들어 있는 댓글을 삭제할 수 없는 문제 해결

### DIFF
--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -495,7 +495,9 @@ class commentAdminController extends comment
 
 		//already comment deleted, therefore only comment log delete
 		$oCommentController = getController('comment');
-		$output = $oCommentController->deleteCommentLog($oComment->get('comment_srl'));
+		$args = new stdClass();
+		$args->comment_srl = $oComment->get('comment_srl');
+		$output = $oCommentController->deleteCommentLog($args);
 		return $output;
 	}
 


### PR DESCRIPTION
commentController::deleteCommentLog 함수는 executeQuery 함수에 들어갈 인자를 받는데, commentAdminController::emptyTrash 함수에서 commentController::deleteCommentLog 함수를 호출할 때 object를 인자로 넘겨주지 않아서 생기는 문제다.
