### PR TITLE
줄바꿈 처리되어있는 경우 getSummary 추출 오류 수정

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -524,6 +524,8 @@ class documentItem extends Object
 	function getSummary($str_size = 50, $tail = '...')
 	{
 		$content = $this->getContent(FALSE, FALSE);
+		
+		$content = nl2br($content);
 
 		// For a newlink, inert a whitespace
 		$content = preg_replace('!(<br[\s]*/{0,1}>[\s]*)+!is', ' ', $content);


### PR DESCRIPTION
DB 에 기록될때 엔터키 처리되어있는 경우 ( </p> 태그등이 기록될때 자동으로 생김 )
getSummary 에서 이를 제대로 인식 못하는 경우가 있다.
특히 이 값을 API 등에서 이용하기 위해 script 나 json 화 할때 값이 인식이 안 된다.

따라서 getSummary 과정에  nl2br 을 미리 한번 넣어  줄바꿈을  br 처리한 후...
그 아래에 br 을 제거하는 str_replace 로 다시 제거하는 방식을 취하면 에러없이 처리 가능하다
