### PR TITLE
변경된 신고수 전달 위해 declared_count add 처리

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1257,6 +1257,8 @@ class documentController extends document
 			return $output;
 		}
 
+		$this->add('declared_count', $declared_count+1);
+
 		// Call a trigger (after)
 		$trigger_obj->declared_count = $declared_count + 1;
 		$trigger_output = ModuleHandler::triggerCall('document.declaredDocument', 'after', $trigger_obj);


### PR DESCRIPTION
신고 후 변한 신고수를 애드온등에 이용하기 위해
declared_count 변수로 add 처리했다.

다만, voted_count 나 blamed_count 는 return $output 하지만
declaredDocument  함수는  return 처리가 되지 않기에  
procDocumentDeclared  대신에  declaredDocument 함수에 직접 추가