### PR TITLE
zdate 변경에 의한 4자리나 6자리 날짜값에 대한 이상현상 패치

### DIFF
--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -714,6 +714,9 @@ function zdate($str, $format = 'Y-m-d H:i:s', $conversion = TRUE)
 		}
 	}
 
+	if(strlen($str)==4) $str.="0101";
+	if(strlen($str)==6) $str.="01";
+	
 	$date = new DateTime($str);
 	$string = $date->format($format);
 


### PR DESCRIPTION
XE 1.7.8 에서  XE 1.7.9 로 넘어가면서 zdate 구하는 방식이 변경되었는데

$string = date($format, ztime($str));  

대신에

$date = new DateTime($str);
$string = $date->format($format);

로 바뀌면서  ( 1970 년 이하를 반영할 수 있게 되면서 소스를 간략하게 바꾸고파서 변경한 듯한데)
추가적으로 생긴 문제가

기존에는 $str 이 6자리 ( 즉, YYYYMM ) 형태인 경우에도  zdate 로 'Y',  'm' 을 구할 수 있었는데
현재 바뀐 방식에서는 최소 8자리 까지 ( YYYYMMDD) 까지 $str 값이 넘어가지 않으면  zdate 로 'Y','m'  값이 제대로 안 구해지네요
8자리가 아닌 경우, 입력된 $str 가 아니라, 그냥 현재 날짜의 Y,m 값이 구해지는 구조가 되네요  마치 $str 값을 안 넣은것처럼...

처음부터 YYYYMMDD 가 아닌 경우 에러가 났으면  대처를 했을텐데
갑자기 최신 버전에 바뀌면서,  이 부분때문에 오작동하는  자료들이 있네요  (최소한 제가 쓰던 달력위젯은 에러가 나네요)

편법으로 에러가 안 나게 하기 위해서..  년도만 넣은 4자리,  또는 년월까지 넣은 6자리에 대해 강제로 1월1일 값을 넣어주면 됩니다
(기존 XE 1.7.8 이전에서는 1월1일 로 처리가 되었거든요)