### PR TITLE
쪽지보내기 등이 모바일 스킨으로 안 나오는 버그 수정

### DIFF
--- a/addons/member_communication/member_communication.addon.php
+++ b/addons/member_communication/member_communication.addon.php
@@ -74,10 +74,10 @@ elseif($this->act == 'getMemberMenu' && $called_position == 'before_module_proc'
 		$oMemberController = getController('member');
 		// Add a menu for sending message
 		if($logged_info->is_admin == 'Y' || $target_member_info->allow_message == 'Y' || ($target_member_info->allow_message == 'F' && $oCommunicationModel->isFriend($member_srl)))
-			$oMemberController->addMemberPopupMenu(getUrl('', 'module', 'communication', 'act', 'dispCommunicationSendMessage', 'receiver_srl', $member_srl), 'cmd_send_message', '', 'popup');
+			$oMemberController->addMemberPopupMenu(getUrl('', 'act', 'dispCommunicationSendMessage', 'receiver_srl', $member_srl), 'cmd_send_message', '', 'popup');
 		// Add a menu for listing friends (if a friend is new)
 		if(!$oCommunicationModel->isAddedFriend($member_srl))
-			$oMemberController->addMemberPopupMenu(getUrl('', 'module', 'communication', 'act', 'dispCommunicationAddFriend', 'target_srl', $member_srl), 'cmd_add_friend', '', 'popup');
+			$oMemberController->addMemberPopupMenu(getUrl('', 'act', 'dispCommunicationAddFriend', 'target_srl', $member_srl), 'cmd_add_friend', '', 'popup');
 	}
 }
 /* End of file member_communication.addon.php */

--- a/addons/member_communication/member_communication.addon.php
+++ b/addons/member_communication/member_communication.addon.php
@@ -74,10 +74,10 @@ elseif($this->act == 'getMemberMenu' && $called_position == 'before_module_proc'
 		$oMemberController = getController('member');
 		// Add a menu for sending message
 		if($logged_info->is_admin == 'Y' || $target_member_info->allow_message == 'Y' || ($target_member_info->allow_message == 'F' && $oCommunicationModel->isFriend($member_srl)))
-			$oMemberController->addMemberPopupMenu(getUrl('', 'act', 'dispCommunicationSendMessage', 'receiver_srl', $member_srl), 'cmd_send_message', '', 'popup');
+			$oMemberController->addMemberPopupMenu(getUrl('', 'mid', Context::get('cur_mid'), 'act', 'dispCommunicationSendMessage', 'receiver_srl', $member_srl), 'cmd_send_message', '', 'popup');
 		// Add a menu for listing friends (if a friend is new)
 		if(!$oCommunicationModel->isAddedFriend($member_srl))
-			$oMemberController->addMemberPopupMenu(getUrl('', 'act', 'dispCommunicationAddFriend', 'target_srl', $member_srl), 'cmd_add_friend', '', 'popup');
+			$oMemberController->addMemberPopupMenu(getUrl('', 'mid', Context::get('cur_mid'), 'act', 'dispCommunicationAddFriend', 'target_srl', $member_srl), 'cmd_add_friend', '', 'popup');
 	}
 }
 /* End of file member_communication.addon.php */


### PR DESCRIPTION
닉네임 클릭으로 쪽지보내기나 친구추가 할 경우..
해당 링크에 module=communication 이 붙어서 가는데..

실제로 act 값을 통해 module 정보를 가져올 수 있기에 이 변수는 의미가 없는데다가
이 변수 때문에 모바일에서도 무조건 PC 용 스킨이 나오는 문제점 발생..  따라서 해당 변수를 제거

그리고 이왕 수정하는김에.
모바일에서는 팝업 대신 현재페이지니, 기존 게시판으로 돌아갈 수 있게 mid 도 추가
