### PR TITLE
게시글 목록 페이지에서 썸네일을 불러오지 못하는 문제 해결

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -773,8 +773,6 @@ class documentItem extends Object
 		if(!$this->document_srl) return;
 		// If not specify its height, create a square
 		if(!$height) $height = $width;
-		// Return false if neither attachement nor image files in the document
-		if(!$this->get('uploaded_count') && !preg_match("!<img!is", $this->get('content'))) return;
 		// Get thumbnai_type information from document module's configuration
 		if(!in_array($thumbnail_type, array('crop','ratio')))
 		{


### PR DESCRIPTION
해당 코드가 게시글 목록 페이지에서 `$this->get('content')` 로 게시글을 제대로 불러오지 못하여 썸네일을 표시하지 못하게 막는 문제를 발견하였고 아래쪽의 코드와 첨부파일, img태그 검증기능이 중복되기 때문에 삭제하였습니다.