### PR TITLE
로그인시 및 주기적으로 세션 식별자 교체해 주기

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -332,6 +332,13 @@ class Context
 		if($sess = $_POST[session_name()]) session_id($sess);
 		session_start();
 
+		// refresh session cookie if it's been more than 10 minutes since last refresh
+		if(isset($_SESSION['last_refresh']) && $_SESSION['last_refresh'] < time() - 600)
+		{
+			$_SESSION['last_refresh'] = time();
+			session_regenerate_id();
+		}
+
 		// set authentication information in Context and session
 		if(self::isInstalled())
 		{

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -575,6 +575,8 @@ class memberController extends member
 		if(!$trigger_output->toBool()) return $trigger_output;
 
 		$this->setSessionInfo();
+		$this->refreshSessionIdentifier();
+
 		// Return result
 		$this->add('member_srl', $args->member_srl);
 		$this->setMessage('success_updated');
@@ -1829,6 +1831,7 @@ class memberController extends member
 		}
 
 		$this->setSessionInfo();
+		$this->refreshSessionIdentifier();
 
 		return $output;
 	}
@@ -1885,6 +1888,15 @@ class memberController extends member
 		$this->addMemberMenu( 'dispMemberScrappedDocument', 'cmd_view_scrapped_document');
 		$this->addMemberMenu( 'dispMemberSavedDocument', 'cmd_view_saved_document');
 		$this->addMemberMenu( 'dispMemberOwnDocument', 'cmd_view_own_document');
+	}
+
+	/**
+	 * Refresh the session identifier to prevent session fixation
+	 */
+	function refreshSessionIdentifier()
+	{
+		$_SESSION['last_refresh'] = time();
+		session_regenerate_id();
 	}
 
 	/**


### PR DESCRIPTION
우연히 XE 코드베이스를 대상으로 `session_regenerate_id()`를 검색해 보았는데 단 1개의 검색 결과도 나오지 않더군요. 실제 테스트해 보아도 로그인 전후에 세션 식별자가 바뀌지 않아서, 로그인 전에 누군가가 세션 식별자를 탈취할 경우 로그인 후에도 계속 사용할 수 있겠고요.

그래서 세션 식별자를 기본 10분 간격 + 로그인 및 회원정보 변경시 추가로 교체해 주도록 하는 코드를 작성해 보았습니다. 물론 로그인 상태는 계속 유지됩니다. (로그아웃 및 탈퇴시에는 이미 `session_destroy()`를 해주고 있으므로 상관없습니다.)

일반적인 환경에서는 아무 문제도 발생하지 않는 것 같지만, 혹시 SSO처럼 특별한 환경에서 XE를 사용하거나 세션DB를 다른 프로그램과 공유하는 경우 문제가 발생할지도 모르겠습니다. 테스트 부탁드리고, 혹시 과거에 어떤 이유론가 세션 식별자를 교체하지 않기로 결정한 적이 있다면 그 이유가 아직 유효한지 가르쳐 주시면 감사하겠습니다.
