### PR TITLE
#1273 PC 회원가입 페이지에서 생일 삭제 버튼 작동 되도록 수정

### DIFF
--- a/modules/member/skins/default/signup_form.html
+++ b/modules/member/skins/default/signup_form.html
@@ -82,7 +82,7 @@ jQuery(function($){
 		$.extend(option,$.datepicker.regional['{$lang_type}']);
 		$(".inputDate").datepicker(option);
 		$(".dateRemover").click(function() {
-			$(this).parent().prevAll('input').val('');
+			$(this).prev('input').val('');
 			return false;});
 	});
 })(jQuery);

--- a/modules/member/skins/default/signup_form.html
+++ b/modules/member/skins/default/signup_form.html
@@ -82,7 +82,7 @@ jQuery(function($){
 		$.extend(option,$.datepicker.regional['{$lang_type}']);
 		$(".inputDate").datepicker(option);
 		$(".dateRemover").click(function() {
-			$(this).prev('input').val('');
+			$(this).prevAll('input').val('');
 			return false;});
 	});
 })(jQuery);


### PR DESCRIPTION
https://github.com/xpressengine/xe-core/issues/1273 PC 회원 가입 페이지에서 생일 삭제
버튼 작동 되도록 수정하는 PR 입니다. 스킨의 템플릿 파일 내 javascript 수정이기 때문에 영향이 크지 않습니다만, 불편할 수 있는 부분이라 생각해서 PR 보냅니다.
