### PR TITLE
크롤러를 조금 더 확인해줍니다.

### DIFF
--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -1487,9 +1487,9 @@ function isCrawler($agent = NULL)
 		$agent = $_SERVER['HTTP_USER_AGENT'];
 	}
 
-	$check_agent = array('bot', 'spider', 'spyder', 'crawl', 'http://', 'google', 'yahoo', 'slurp', 'yeti', 'daum', 'teoma', 'fish', 'hanrss', 'facebook', 'yandex', 'infoseek', 'stackrambler');
+	$check_agent = array('bot', 'spider', 'spyder', 'crawl', 'http://', 'google', 'yahoo', 'slurp', 'yeti', 'daum', 'teoma', 'fish', 'hanrss', 'facebook', 'yandex', 'infoseek', 'askjeeves', 'stackrambler');
 	$check_ip = array(
-		'211.245.21.110-211.245.21.119' /* mixsh */
+		/*'211.245.21.110-211.245.21.119' mixsh is closed */
 	);
 
 	foreach($check_agent as $str)

--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -1487,7 +1487,7 @@ function isCrawler($agent = NULL)
 		$agent = $_SERVER['HTTP_USER_AGENT'];
 	}
 
-	$check_agent = array('bot', 'spider', 'google', 'yahoo', 'daum', 'teoma', 'fish', 'hanrss', 'facebook');
+	$check_agent = array('bot', 'spider', 'spyder', 'crawl', 'http://', 'google', 'yahoo', 'slurp', 'yeti', 'daum', 'teoma', 'fish', 'hanrss', 'facebook', 'yandex', 'infoseek', 'stackrambler');
 	$check_ip = array(
 		'211.245.21.110-211.245.21.119' /* mixsh */
 	);


### PR DESCRIPTION
isCrawler 함수에 크롤러의 UA에만 사용되는 문구를 조금 더 추가한 PR 입니다.
함수를 잘 살펴보시면, ip 대역으로도 구분할 수 있습니다. 참고 하시기 바랍니다.

ip로 필터링 할 때, 걱정되는 것은, 크롤러가 돌아가는 ip에서 크롤링 외의 목적으로 접근할 수도 있지 않을까 하는 것입니다.
