### PR TITLE
PHP 5.6 HTTP_RAW_POST_DATA Deprecated 대응

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1108,6 +1108,23 @@ class Context
 
 		return isset($methods[$method]) ? $method : 'HTML';
 	}
+	
+	/**
+	 * Determine if request value is valid XML
+	 *
+	 * @param string $xml is xml content
+	 **/
+	static public function isValidXML($xml){
+		$_parse = @simplexml_load_string($xml);
+		if($_parse)
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
 
 	/**
 	 * Determine request method
@@ -1120,13 +1137,13 @@ class Context
 		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
 
 		$self->js_callback_func = $self->getJSCallbackFunc();
-		
-		// $HTTP_RAW_POST_DATA has been deprecated on PHP 5.6
+
+		// PHP 5.6 이상에서 '$HTTP_RAW_POST_DATA' Deprecated 대응
 		if(version_compare(PHP_VERSION, '5.6.0', '>='))
 		{
 			($type && $self->request_method = $type) or
 					(strpos($_SERVER['CONTENT_TYPE'], 'json') && $self->request_method = 'JSON') or
-					(file_get_contents("php://input") && $self->request_method = 'XMLRPC') or
+					($self->isValidXML(file_get_contents("php://input")) && $self->request_method = 'XMLRPC') or
 					($self->js_callback_func && $self->request_method = 'JS_CALLBACK') or
 					($self->request_method = $_SERVER['REQUEST_METHOD']);
 		}
@@ -1238,9 +1255,7 @@ class Context
 			return;
 		}
 
-		$params = array();.
-		
-		// $HTTP_RAW_POST_DATA has been deprecated on PHP 5.6
+		$params = array();
 		if(version_compare(PHP_VERSION, '5.6.0', '>='))
 		{
 			$params = array();
@@ -1269,8 +1284,7 @@ class Context
 		{
 			return;
 		}
-		
-		// $HTTP_RAW_POST_DATA has been deprecated on PHP 5.6
+
 		if(version_compare(PHP_VERSION, '5.6.0', '>='))
 		{
 			$xml = file_get_contents("php://input");
@@ -1278,12 +1292,6 @@ class Context
 		else
 		{
 			$xml = $GLOBALS['HTTP_RAW_POST_DATA'];
-		}
-
-		if(Security::detectingXEE($xml))
-		{
-			header("HTTP/1.0 400 Bad Request");
-			exit;
 		}
 		
 		if(Security::detectingXEE($xml))

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -421,7 +421,7 @@ class Context
 	 *
 	 * @return void
 	 */
-	function loadDBInfo()setRequestMethod
+	function loadDBInfo()
 	{
 		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
 

--- a/modules/document/schemas/documents.xml
+++ b/modules/document/schemas/documents.xml
@@ -20,7 +20,7 @@
     <column name="nick_name" type="varchar" size="80" notnull="notnull" />
     <column name="member_srl" type="number" size="11" notnull="notnull" index="idx_member_srl" />
     <column name="email_address" type="varchar" size="250" notnull="notnull" />
-    <column name="homepage" type="varchar" size="250" notnull="notnull" />
+    <column name="homepage" type="varchar" size="250" />
     <column name="tags" type="text" />
     <column name="extra_vars" type="text" />
     <column name="regdate" type="date" index="idx_regdate" />


### PR DESCRIPTION
PHP 5.6 버전에서 PHP.ini의 always_populate_raw_post_data값이 -1 이 아닌 경우 Deprecated 오류가 발생하며, 이는 PHP.ini 설정 error_reporting 값에 ~E_DEPRECATED 가 포함되어 있지 않을 경우 config.inc.php 에서 수행하는 error_reporting() 으로 Override 가 되지 않습니다.
PHP 5.6 에서는 $HTTP_RAW_POST_DATA , $GLOBALS['HTTP_RAW_POST_DATA'] 를 대신하여 file_get_contents("php://input")를 사용하는 것을 권장합니다.
always_populate_raw_post_data 값이 -1 일 경우에는 $HTTP_RAW_POST_DATA 변수를 사용할 수 없습니다.