### PR TITLE
DisplayHandler 실행 전에 뭔가가 출력될 경우 gzip 인코딩 오류 수정

### DIFF
--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -84,10 +84,6 @@ class DisplayHandler extends Handler
 		}
 
 		// header output
-		if($this->gz_enabled)
-		{
-			header("Content-Encoding: gzip");
-		}
 
 		$httpStatusCode = $oModule->getHttpStatusCode();
 		if($httpStatusCode && $httpStatusCode != 200)
@@ -114,9 +110,17 @@ class DisplayHandler extends Handler
 		$this->content_size = strlen($output);
 		$output .= $this->_debugOutput();
 
+		// disable gzip if output already exists
+		ob_flush();
+		if(headers_sent())
+		{
+			$this->gz_enabled = FALSE;
+		}
+
 		// results directly output
 		if($this->gz_enabled)
 		{
+			header("Content-Encoding: gzip");
 			print ob_gzhandler($output, 5);
 		}
 		else


### PR DESCRIPTION
`DisplayHandler` 실행시 이미 출력된 내용이 있는지 확인하고, 만약 있다면 gzip 압축을 사용하지 않도록 수정해 보았습니다.

모듈이나 애드온, 스킨 등을 개발하다 보면 가끔 어딘가에서 뭔가가 출력되어 버릴 경우가 있습니다. 에러메시지라든지, 불필요한 공백 문자라든지, UTF-8 BOM이라든지...

물론 완성된 작품에서 이런 것이 출력되어서는 안 되겠지만, 특히 에러메시지와 마주치는 것은 개발 과정에서 피할래야 피할 수 없는 과정이죠.

그런데 XE는 `DisplayHandler->printContent()` 실행 전에 단 1바이트라도 다른 내용이 출력되면 아래와 같이 "콘텐츠 인코딩 오류"가 발생하면서 화면 전체를 하나도 볼 수 없게 되어 버립니다. (Firefox 기준입니다. 에러가 나타나는 형태는 브라우저에 따라 다릅니다. 저 악명높은 백지현상도 이 문제의 증상 중 일부일지 모릅니다.)

![content-encoding-error](https://cloud.githubusercontent.com/assets/164058/6364652/ddf8f0f8-bcec-11e4-8731-2c2577933447.png)

위와 같은 에러가 발생하는 이유는 간단합니다. XE는 브라우저가 gzip을 지원할 경우 현재 페이지의 내용을 자동으로 압축하여 전송해 주는데, 이미 출력된 내용이 있다면 같은 페이지 안에 압축된 컨텐츠와 압축되지 않은 컨텐츠가 섞이게 되죠. 그래서 브라우저가 알아듣지 못하는 것입니다.

앞에서 말씀드린 것처럼, 완성된 작품에서는 `DisplayHandler->printContent()` 실행 전에 다른 내용이 먼저 출력되는 일이 절대 있어서는 안되겠습니다. 그러나 개발 과정에서는 위와 같은 에러가 전체화면으로 뿌려져 버리면 디버깅하기가 상당히 귀찮아집니다. 화면상에 나오는 게 아무 것도 없으니까 서버의 에러 로그를 뒤져야 하거든요. 내용을 출력하는 문제의 코드가 꼭 에러를 발생시킨다는 보장도 없고요.

압축되지 않은 컨텐츠가 명백하게 섞여 있는데도 `Content-Encoding: gzip` 헤더를 작성하는 것 역시 옳지 않은 일이라고 생각합니다. 차라리 이럴 때는 gzip 압축을 포기하는 것이 더 깔끔하지 않을까요?
