### PR TITLE
외부 리소스 로딩시 프로토콜 상대주소를 지정할 수 있도록 개선

### DIFF
--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -345,6 +345,10 @@ class FrontEndFileHandler extends Handler
 		{
 			$path = './' . $path;
 		}
+		elseif(!strncmp($path, '//', 2))
+		{
+			return $path;
+		}
 
 		$path = preg_replace('@/\./|(?<!:)\/\/@', '/', $path);
 

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -653,7 +653,7 @@ class TemplateHandler
 					$metafile = '';
 					$pathinfo = pathinfo($attr['target']);
 					$doUnload = ($m[3] === 'unload');
-					$isRemote = !!preg_match('@^https?://@i', $attr['target']);
+					$isRemote = !!preg_match('@^(https?:)?//@i', $attr['target']);
 
 					if(!$isRemote)
 					{


### PR DESCRIPTION
최근 SSL 이용이 급속도로 확산되면서 대부분의 세계적인 CDN들은 `//`로 시작하는 프로토콜 상대주소(protocol-relative URL) 이용을 권장하고 있습니다. 현재 페이지가 SSL을 이용할 경우 CDN도 자동으로 SSL을 이용하고, 현재 페이지가 SSL을 이용하지 않을 경우 CDN도 SSL을 이용하지 않도록 하는 방법이죠.

그러나 현재 XE 템플릿에서 사이트 외부의 리소스를 로딩하려고 하면 반드시 `http://` 또는 `https://`로 시작하는 절대주소를 입력해야 합니다. 아래와 같이 프로토콜 상대주소를 쓰면...

```
<load target="//cdnjs.cloudflare.com/ajax/libs/less.js/2.4.0/less.min.js" />
```

당연히 안됩니다 ㅠㅠ

`TemplateHandler`와 `FrontEndFileHandler`에서 프로토콜 상대주소를 인식하지 못하기 때문인데요... 이걸 우회하려면 `Context::loadFile()`을 직접 호출하거나, 현재 페이지의 SSL 사용 여부를 판단해서 조건문으로 처리해야 합니다. 귀찮고 지저분하죠.

그래서 귀찮고 지저분하지 않도록 고쳐봤습니다. 풀리퀘 받아주세요 ^^
