### PR TITLE
잘못된 selector의 사용 fix

### DIFF
--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -57,7 +57,7 @@
 
 			// 파일 선택
 			$(this.file_list_container).on('change', function(e) {
-				var $el = $('.xe-uploader-filelist select option:selected');
+				var $el = this.file_list_container.find('option:selected');
 				self.selected_files = [];
 				$el.each(function(idx, el) {
 					self.selected_files.push(el);

--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -57,7 +57,7 @@
 
 			// 파일 선택
 			$(this.file_list_container).on('change', function(e) {
-				var $el = $('option:selected', this.file_list_container);
+				var $el = $('.xe-uploader-filelist select option:selected');
 				self.selected_files = [];
 				$el.each(function(idx, el) {
 					self.selected_files.push(el);


### PR DESCRIPTION
http://stackoverflow.com/a/1409359
This will start in your variable $container1 and then look for all spans

해당 container가 아닌 문서 전체에서 검색이 되므로, file upload select뿐만 아니라 다른 모든 select의 선택된 값이 입력되어서, 삭제시 오류가 발생합니다. 본문 삽입에는 if(!fileinfo) return; 로 예외 처리가 되어 있으나 이는 임시 조치로, 궁극적인 해결책은 애초에 정확한 selector를 사용하는 것입니다.