### PR TITLE
#1315 특수문자를 포함하는 랜덤 비밀번호 생성 기능

### DIFF
--- a/classes/security/Password.class.php
+++ b/classes/security/Password.class.php
@@ -293,6 +293,30 @@ class Password
 	}
 
 	/**
+	 * @brief Generate a temporary password using the secure salt generator
+	 * @param int $length The number of bytes to return
+	 * @return string
+	 */
+	public function createTemporaryPassword($length = 16)
+	{
+		while(true)
+		{
+			$source = $this->createSecureSalt(128, 'printable');
+			$source = preg_replace('/[iIoOjl10\'"!?<>\(\)\{\}\[\]:;.,`\\\\]/', '', $source);
+			$source_length = strlen($source);
+			for($i = 0; $i < $source_length - $length; $i++)
+			{
+				$candidate = substr($source, $i, $length);
+				if(preg_match('/[a-z]/', $candidate) && preg_match('/[A-Z]/', $candidate) &&
+					preg_match('/[0-9]/', $candidate) && preg_match('/[!a-zA-Z0-9]/', $candidate))
+				{
+					return $candidate;
+				}
+			}
+		}
+	}
+
+	/**
 	 * @brief Generate the PBKDF2 hash of a string using a salt
 	 * @param string $password The password
 	 * @param string $salt The salt

--- a/classes/security/Password.class.php
+++ b/classes/security/Password.class.php
@@ -40,7 +40,7 @@ class Password
 		$algos = $this->getSupportedAlgorithms();
 		return key($algos);
 	}
-	
+
 	/**
 	 * @brief Return the currently selected hashing algorithm
 	 * @return string
@@ -62,7 +62,7 @@ class Password
 		}
 		return $algorithm;
 	}
-	
+
 	/**
 	 * @brief Return the currently configured work factor for bcrypt and other adjustable algorithms
 	 * @return int
@@ -84,7 +84,7 @@ class Password
 		}
 		return $work_factor;
 	}
-	
+
 	/**
 	 * @brief Create a hash using the specified algorithm
 	 * @param string $password The password
@@ -101,28 +101,28 @@ class Password
 		{
 			return false;
 		}
-		
+
 		$password = trim($password);
-		
+
 		switch($algorithm)
 		{
 			case 'md5':
 				return md5($password);
-			
+
 			case 'pbkdf2':
 				$iterations = pow(2, $this->getWorkFactor() + 5);
 				$salt = $this->createSecureSalt(12);
 				$hash = base64_encode($this->pbkdf2($password, $salt, 'sha256', $iterations, 24));
 				return 'sha256:'.sprintf('%07d', $iterations).':'.$salt.':'.$hash;
-			
+
 			case 'bcrypt':
 				return $this->bcrypt($password);
-			
+
 			default:
 				return false;
 		}
 	}
-	
+
 	/**
 	 * @brief Check if a password matches a hash
 	 * @param string $password The password
@@ -136,36 +136,36 @@ class Password
 		{
 			$algorithm = $this->checkAlgorithm($hash);
 		}
-		
+
 		$password = trim($password);
-		
+
 		switch($algorithm)
 		{
 			case 'md5':
 				return md5($password) === $hash || md5(sha1(md5($password))) === $hash;
-			
+
 			case 'mysql_old_password':
 				return (class_exists('Context') && substr(Context::getDBType(), 0, 5) === 'mysql') ?
 					DB::getInstance()->isValidOldPassword($password, $hash) : false;
-			
+
 			case 'mysql_password':
 				return $hash[0] === '*' && substr($hash, 1) === strtoupper(sha1(sha1($password, true)));
-			
+
 			case 'pbkdf2':
 				$hash = explode(':', $hash);
 				$hash[3] = base64_decode($hash[3]);
 				$hash_to_compare = $this->pbkdf2($password, $hash[2], $hash[0], intval($hash[1], 10), strlen($hash[3]));
 				return $this->strcmpConstantTime($hash_to_compare, $hash[3]);
-			
+
 			case 'bcrypt':
 				$hash_to_compare = $this->bcrypt($password, $hash);
 				return $this->strcmpConstantTime($hash_to_compare, $hash);
-				
+
 			default:
 				return false;
 		}
 	}
-	
+
 	/**
 	 * @brief Check the algorithm used to create a hash
 	 * @param string $hash The hash
@@ -198,7 +198,7 @@ class Password
 			return false;
 		}
 	}
-	
+
 	/**
 	 * @brief Check the work factor of a hash
 	 * @param string $hash The hash
@@ -219,7 +219,7 @@ class Password
 			return false;
 		}
 	}
-	
+
 	/**
 	 * @brief Generate a cryptographically secure random string to use as a salt
 	 * @param int $length The number of bytes to return
@@ -230,10 +230,10 @@ class Password
 	{
 		// Find out how many bytes of entropy we really need
 		$entropy_required_bytes = ceil(($format === 'hex') ? ($length / 2) : ($length * 3 / 4));
-		
+
 		// Cap entropy to 256 bits from any one source, because anything more is meaningless
 		$entropy_capped_bytes = min(32, $entropy_required_bytes);
-		
+
 		// Find and use the most secure way to generate a random string
 		$is_windows = (defined('PHP_OS') && strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
 		if(function_exists('openssl_random_pseudo_bytes') && (!$is_windows || version_compare(PHP_VERSION, '5.4', '>=')))
@@ -262,18 +262,27 @@ class Password
 				$entropy .= pack('S', rand(0, 65536) ^ mt_rand(0, 65535));
 			}
 		}
-		
+
 		// Mixing (see RFC 4086 section 5)
 		$output = '';
 		for($i = 0; $i < $entropy_required_bytes; $i += 32)
 		{
 			$output .= hash('sha256', $entropy . $i . rand(), true);
 		}
-		
+
 		// Encode and return the random string
 		if($format === 'hex')
 		{
 			return substr(bin2hex($output), 0, $length);
+		}
+		elseif($format === 'printable')
+		{
+			$salt = '';
+			for($i = 0; $i < $length; $i++)
+			{
+				$salt .= chr(33 + (crc32(sha1($i . $output)) % 94));
+			}
+			return $salt;
 		}
 		else
 		{
@@ -282,7 +291,7 @@ class Password
 			return strtr($salt, '+/=', $replacements);
 		}
 	}
-	
+
 	/**
 	 * @brief Generate the PBKDF2 hash of a string using a salt
 	 * @param string $password The password
@@ -315,7 +324,7 @@ class Password
 			return substr($output, 0, $length);
 		}
 	}
-	
+
 	/**
 	 * @brief Generate the bcrypt hash of a string using a salt
 	 * @param string $password The password
@@ -330,7 +339,7 @@ class Password
 		}
 		return crypt($password, $salt);
 	}
-	
+
 	/**
 	 * @brief Compare two strings in constant time
 	 * @param string $a The first string


### PR DESCRIPTION
`Password` 클래스의 `createSecureSalt()` 메소드를 호출할 때 두 번째 인자를 `printable`로 지정하면 영문 대소문자, 숫자, 특수문자를 모두 포함하는 랜덤 비밀번호를 생성해 줍니다.

생성되는 문자의 범위는 ASCII printable characters(32~126번)을 모두 포함합니다.
