### PR TITLE
문서, 댓글, 파일 모듈에서 Password 클래스를 활용하도록 변경

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -253,10 +253,10 @@ class commentController extends comment
 		// get a object of document model
 		$oDocumentModel = getModel('document');
 
-		// even for manual_inserted if password exists, md5 it.
+		// even for manual_inserted if password exists, hash it.
 		if($obj->password)
 		{
-			$obj->password = md5($obj->password);
+			$obj->password = getModel('member')->hashPassword($obj->password);
 		}
 
 		// get the original posting
@@ -677,7 +677,7 @@ class commentController extends comment
 
 		if($obj->password)
 		{
-			$obj->password = md5($obj->password);
+			$obj->password = getModel('member')->hashPassword($obj->password);
 		}
 
 		if($obj->homepage) 

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -251,8 +251,11 @@ class documentController extends document
 		if(!$obj->readed_count) $obj->readed_count = 0;
 		if($isLatest) $obj->update_order = $obj->list_order = $obj->document_srl * -1;
 		else $obj->update_order = $obj->list_order;
-		// Check the status of password hash for manually inserting. Apply md5 hashing for otherwise.
-		if($obj->password && !$obj->password_is_hashed) $obj->password = md5($obj->password);
+		// Check the status of password hash for manually inserting. Apply hashing for otherwise.
+		if($obj->password && !$obj->password_is_hashed)
+		{
+			$obj->password = getModel('member')->hashPassword($obj->password);
+		}
 		// Insert member's information only if the member is logged-in and not manually registered.
 		$logged_info = Context::get('logged_info');
 		if(Context::get('is_logged') && !$manual_inserted && !$isRestore)
@@ -437,8 +440,11 @@ class documentController extends document
 		}
 		// Change the update order
 		$obj->update_order = getNextSequence() * -1;
-		// Hash by md5 if the password exists
-		if($obj->password) $obj->password = md5($obj->password);
+		// Hash the password if it exists
+		if($obj->password)
+		{
+			$obj->password = getModel('member')->hashPassword($obj->password);
+		}
 		// If an author is identical to the modifier or history is used, use the logged-in user's information.
 		if(Context::get('is_logged'))
 		{

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -277,7 +277,8 @@ class fileController extends file
 		// Call a trigger (after)
 		$output = ModuleHandler::triggerCall('file.downloadFile', 'after', $file_obj);
 
-		$file_key = $_SESSION['__XE_FILE_KEY__'][$file_srl] = hash('md5',rand());
+		$random = new Password();
+		$file_key = $_SESSION['__XE_FILE_KEY__'][$file_srl] = $random->createSecureSalt(32, 'hex');
 		header('Location: '.getNotEncodedUrl('', 'act', 'procFileOutput','file_srl',$file_srl,'file_key',$file_key));
 		Context::close();
 		exit();
@@ -662,6 +663,9 @@ class fileController extends file
 			}
 		}
 
+		// Get random number generator
+		$random = new Password();
+		
 		// Set upload path by checking if the attachement is an image or other kinds of file
 		if(preg_match("/\.(jpe?g|gif|png|wm[va]|mpe?g|avi|swf|flv|mp[1-4]|as[fx]|wav|midi?|moo?v|qt|r[am]{1,2}|m4v)$/i", $file_info['name']))
 		{
@@ -672,10 +676,10 @@ class fileController extends file
 			$path = sprintf("./files/attach/images/%s/%s", $module_srl,getNumberingPath($upload_target_srl,3));
 
 			// special character to '_'
-			// change to md5 file name. because window php bug. window php is not recognize unicode character file name - by cherryfilter
+			// change to random file name. because window php bug. window php is not recognize unicode character file name - by cherryfilter
 			$ext = substr(strrchr($file_info['name'],'.'),1);
 			//$_filename = preg_replace('/[#$&*?+%"\']/', '_', $file_info['name']);
-			$_filename = md5(crypt(rand(1000000,900000), rand(0,100))).'.'.$ext;
+			$_filename = $random->createSecureSalt(32, 'hex').'.'.$ext;
 			$filename  = $path.$_filename;
 			$idx = 1;
 			while(file_exists($filename))
@@ -688,7 +692,7 @@ class fileController extends file
 		else
 		{
 			$path = sprintf("./files/attach/binaries/%s/%s", $module_srl, getNumberingPath($upload_target_srl,3));
-			$filename = $path.md5(crypt(rand(1000000,900000), rand(0,100)));
+			$filename = $path.$random->createSecureSalt(32, 'hex');
 			$direct_download = 'N';
 		}
 		// Create a directory
@@ -697,13 +701,16 @@ class fileController extends file
 		// Check uploaded file
 		if(!checkUploadedFile($file_info['tmp_name']))  return new Object(-1,'msg_file_upload_error');
 
+		// Get random number generator
+		$random = new Password();
+		
 		// Move the file
 		if($manual_insert)
 		{
 			@copy($file_info['tmp_name'], $filename);
 			if(!file_exists($filename))
 			{
-				$filename = $path. md5(crypt(rand(1000000,900000).$file_info['name'])).'.'.$ext;
+				$filename = $path.$random->createSecureSalt(32, 'hex').'.'.$ext;
 				@copy($file_info['tmp_name'], $filename);
 			}
 		}
@@ -711,7 +718,7 @@ class fileController extends file
 		{
 			if(!@move_uploaded_file($file_info['tmp_name'], $filename))
 			{
-				$filename = $path. md5(crypt(rand(1000000,900000).$file_info['name'])).'.'.$ext;
+				$filename = $path.$random->createSecureSalt(32, 'hex').'.'.$ext;
 				if(!@move_uploaded_file($file_info['tmp_name'], $filename))  return new Object(-1,'msg_file_upload_error');
 			}
 		}
@@ -730,7 +737,7 @@ class fileController extends file
 		$args->file_size = @filesize($filename);
 		$args->comment = NULL;
 		$args->member_srl = $member_srl;
-		$args->sid = md5(rand(rand(1111111,4444444),rand(4444445,9999999)));
+		$args->sid = $random->createSecureSalt(32, 'hex');
 
 		$output = executeQuery('file.insertFile', $args);
 		if(!$output->toBool()) return $output;
@@ -910,7 +917,8 @@ class fileController extends file
 			else
 			{
 				$path = sprintf("./files/attach/binaries/%s/%s/", $target_module_srl, $target_srl);
-				$new_file = $path.md5(crypt(rand(1000000,900000), rand(0,100)));
+				$random = new Password();
+				$new_file = $path.$random->createSecureSalt(32, 'hex');
 			}
 			// Pass if a target document to move is same
 			if($old_file == $new_file) continue;


### PR DESCRIPTION
비회원이 글이나 댓글을 쓸 때 입력하는 비밀번호를 해싱할 때, 회원 모듈에서 설정한 것과 같은 알고리듬을 사용하도록 변경했습니다.

파일 모듈에서 랜덤 파일명 및 sid를 생성할 때 `md5()`와 `rand()`에 의존하지 않고, 1.8에 새로 추가된 Password 클래스의 난수 생성기를 활용하도록 변경했습니다.

보안과 관련된 모든 코드에서 `md5()`가 사라지는 그날까지~~~!!!
