### PR TITLE
#1330 모바일 쪽지 발송시 success_return_url 오류 수정

### DIFF
--- a/modules/communication/communication.controller.php
+++ b/modules/communication/communication.controller.php
@@ -153,7 +153,7 @@ class communicationController extends communication
 			else
 			{
 				$this->setMessage('success_sended');
-				$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('',act', 'dispCommunicationMessages', 'message_type', 'S', 'receiver_srl', $receiver_srl, 'message_srl', '');
+				$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('','act', 'dispCommunicationMessages', 'message_type', 'S', 'receiver_srl', $receiver_srl, 'message_srl', '');
 				$this->setRedirectUrl($returnUrl);
 			}
 		}

--- a/modules/communication/communication.controller.php
+++ b/modules/communication/communication.controller.php
@@ -153,7 +153,7 @@ class communicationController extends communication
 			else
 			{
 				$this->setMessage('success_sended');
-				$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('act', 'dispCommunicationMessages', 'message_type', 'S', 'receiver_srl', $receiver_srl, 'message_srl', '');
+				$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('',act', 'dispCommunicationMessages', 'message_type', 'S', 'receiver_srl', $receiver_srl, 'message_srl', '');
 				$this->setRedirectUrl($returnUrl);
 			}
 		}

--- a/modules/communication/m.skins/default/send_message.html
+++ b/modules/communication/m.skins/default/send_message.html
@@ -17,7 +17,7 @@
 	<input type="hidden" name="source_content" value="{htmlspecialchars($source_message->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" />
 	<input type="hidden" name="content" value="" />
 	<input type="hidden" name="xe_validator_id" value="modules/communication/m.skins/default/send_message/1" />
-	<input type="hidden" name="success_return_url" value="{getNotEncodedUrl('',act', 'dispCommunicationSendMessage', 'receiver_srl', $receiver_info->member_srl)}" />
+	<input type="hidden" name="success_return_url" value="{getNotEncodedUrl('','act', 'dispCommunicationSendMessage', 'receiver_srl', $receiver_info->member_srl)}" />
 	<ul>
 		<li>
 			<span class="memberInfo">{$receiver_info->nick_name}</span>

--- a/modules/communication/m.skins/default/send_message.html
+++ b/modules/communication/m.skins/default/send_message.html
@@ -17,6 +17,7 @@
 	<input type="hidden" name="source_content" value="{htmlspecialchars($source_message->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" />
 	<input type="hidden" name="content" value="" />
 	<input type="hidden" name="xe_validator_id" value="modules/communication/m.skins/default/send_message/1" />
+	<input type="hidden" name="success_return_url" value="{getNotEncodedUrl('',act', 'dispCommunicationSendMessage', 'receiver_srl', $receiver_info->member_srl)}" />
 	<ul>
 		<li>
 			<span class="memberInfo">{$receiver_info->nick_name}</span>


### PR DESCRIPTION
모바일 쪽지 발송시에는 is_popup값이 Y로 전달됩니다.
따라서 alert창으로 띄우지 않고 setRedirectUrl 함수를 사용하여 success_return_url로 리다이렉트 시키는데요, 문제는 기본 스킨에는 success_return_url값이 없어서 getNotEncodedUrl를 사용해서 만드는데, 이때 content값 등 기존 값까지 전부 들어가기에 메세지 내용이 길어질 경우 정상적으로 리다이렉트가 안됩니다. 따라서 getNotEncodedUrl 인자 앞에 `'',`를 붙여 기존 모든 인자를 사용하지 않도록 변경하였습니다.

또한 기본 스킨은 직접 수정하여 제대로 발송화면으로 돌아올 수 있도록 하였습니다.
