### PR TITLE
관리모듈에서 로그아웃 후 홈페이지로 돌아가는 링크 추가

### DIFF
--- a/modules/message/skins/default/system_message.html
+++ b/modules/message/skins/default/system_message.html
@@ -43,6 +43,8 @@
 	</div>
 	<div class="login-footer" cond="!$is_logged">
 		<div class="pull-right">
+			<a href="{getFullUrl('')}">{$lang->homepage}</a>
+			|
 			<a href="{getUrl('','act','dispMemberFindAccount')}">{$lang->cmd_find_member_account}</a>
 			|
 			<a href="{getUrl('','act','dispMemberSignUpForm')}"><span>{$lang->cmd_signup}</span></a>


### PR DESCRIPTION
관리모듈에서 로그아웃하면 텅 빈 화면에 아래와 같은 메시지 하나만 덩그러니 뜹니다.

![screenshot](https://cloud.githubusercontent.com/assets/164058/6774992/6f0d068a-d16d-11e4-8b05-fd773bbf484f.png)

다시 로그인하는 것 외에는 딱히 할 수 있는 작업이 없는 거죠.

이건 시스템 메시지라서 레이아웃조차 적용되지 않기 때문에 더 난감합니다.

그래서 홈페이지로 돌아가는 링크 하나를 추가해 보았습니다.

![screenshot2](https://cloud.githubusercontent.com/assets/164058/6775002/cea3eed8-d16d-11e4-91ec-1790fe536821.PNG)
