### PR TITLE
확장변수를 이용한 XSS 공격 가능성 차단

### DIFF
--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -225,6 +225,11 @@ class ExtraItem
 					$values = explode(',', $value);
 				}
 
+				$values = array_values($values);
+				for($i = 0, $c = count($values); $i < $c; $i++)
+				{
+					$values[$i] = trim(htmlspecialchars($values[$i], ENT_COMPAT | ENT_HTML401, 'UTF-8', false));
+				}
 				return $values;
 
 			case 'checkbox' :
@@ -247,11 +252,11 @@ class ExtraItem
 					$values = array($value);
 				}
 
+				$values = array_values($values);
 				for($i = 0, $c = count($values); $i < $c; $i++)
 				{
 					$values[$i] = trim(htmlspecialchars($values[$i], ENT_COMPAT | ENT_HTML401, 'UTF-8', false));
 				}
-
 				return $values;
 
 			case 'kr_zip' :
@@ -268,6 +273,11 @@ class ExtraItem
 					$values = array($value);
 				}
 
+				$values = array_values($values);
+				for($i = 0, $c = count($values); $i < $c; $i++)
+				{
+					$values[$i] = trim(htmlspecialchars($values[$i], ENT_COMPAT | ENT_HTML401, 'UTF-8', false));
+				}
 				return $values;
 
 			//case 'date' :


### PR DESCRIPTION
게시판에서 주소(zip) 및 전화번호(tel) 형식의 확장변수를 사용할 경우 사용자가 입력한 내용이 제대로 필터링되지 않아 임의의 HTML 태그 및 스크립트를 사용할 수 있습니다. (전화번호의 경우 숫자만 입력할 수 있도록 되어 있으나, 브라우저의 개발자도구를 사용하면 숫자 외의 내용도 입력할 수 있습니다.)

홈페이지 주소, 단일/다중 선택 형식의 확장변수는 제대로 필터링이 이루어지고 있는데, 주소와 전화번호만 누락된 것 같습니다. 그래서 단일/다중 선택 형식의 필터링에 사용하는 코드를 주소와 전화번호 쪽에도 적용하도록 수정했습니다.

또한 배열 키가 정수가 아닐 경우 필터링을 우회할 수 있으므로 array_values 함수를 사용하여 배열 키를 정수로 강제하도록 했습니다. 얼마 전에 드루팔이 배열 키 때문에 호되게 당한 적이 있죠.
