### PR TITLE
관리자 화면에서 로그아웃하면 메인 페이지로 이동하도록 개선

### DIFF
--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -140,7 +140,7 @@ class adminAdminController extends admin
 		$oMemberController = getController('member');
 		$oMemberController->procMemberLogout();
 
-		header('Location: ' . getNotEncodedUrl('', 'module', 'admin'));
+		header('Location: ' . getNotEncodedUrl(''));
 	}
 
 	public function procAdminInsertDefaultDesignInfo()


### PR DESCRIPTION
관리자 화면에서 로그아웃 이후 로그인 페이지를 보여주는 것은 편리하지 않으므로,(방금 로그아웃하고 다시 로그인하지는 않겠죠) 이를 홈페이지 메인 화면 링크로 수정하였습니다.
