### PR TITLE
PHP 5 방식의 생성자 (__construct) 사용

### DIFF
--- a/addons/mobile/classes/hdml.class.php
+++ b/addons/mobile/classes/hdml.class.php
@@ -8,9 +8,9 @@ class wap extends mobileXE {
 	/**
 	 * @brief constructor
 	 **/
-	function wap()
+	function __construct()
 	{
-		parent::mobileXE();
+		parent::__construct();
 	}
 
 	/**

--- a/addons/mobile/classes/mhtml.class.php
+++ b/addons/mobile/classes/mhtml.class.php
@@ -9,9 +9,9 @@ class wap extends mobileXE
 	/**
 	 * @brief constructor
 	 **/
-	function wap()
+	function __construct()
 	{
-		parent::mobileXE();
+		parent::__construct();
 	}
 
 	/**

--- a/addons/mobile/classes/mobile.class.php
+++ b/addons/mobile/classes/mobile.class.php
@@ -76,7 +76,7 @@ class mobileXE
 	/**
 	 * @brief constructor
 	 */
-	function mobileXE()
+	function __construct()
 	{
 		// Check navigation mode
 		if(Context::get('nm'))

--- a/addons/mobile/classes/wml.class.php
+++ b/addons/mobile/classes/wml.class.php
@@ -8,9 +8,9 @@ class wap extends mobileXE
 	/**
 	 * @brief constructor
 	 */
-	function wap()
+	function __construct()
 	{
-		parent::mobileXE();
+		parent::__construct();
 	}
 
 	/**

--- a/classes/cache/CacheApc.class.php
+++ b/classes/cache/CacheApc.class.php
@@ -30,7 +30,7 @@ class CacheApc extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheApc()
+	function __construct()
 	{
 	}
 

--- a/classes/cache/CacheFile.class.php
+++ b/classes/cache/CacheFile.class.php
@@ -35,7 +35,7 @@ class CacheFile extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheFile()
+	function __construct()
 	{
 		$this->cache_dir = _XE_PATH_ . $this->cache_dir;
 		FileHandler::makeDir($this->cache_dir);

--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -49,7 +49,7 @@ class CacheHandler extends Handler
 	 * @param boolean $always_use_file If set true, use a file cache always
 	 * @return CacheHandler
 	 */
-	function CacheHandler($target, $info = null, $always_use_file = false)
+	function __construct($target, $info = null, $always_use_file = false)
 	{
 		if(!$info)
 		{

--- a/classes/cache/CacheMemcache.class.php
+++ b/classes/cache/CacheMemcache.class.php
@@ -36,7 +36,7 @@ class CacheMemcache extends CacheBase
 	 * @param string $url url of memcache
 	 * @return void
 	 */
-	function CacheMemcache($url)
+	function __construct($url)
 	{
 		//$config['url'] = array('memcache://localhost:11211');
 		$config['url'] = is_array($url) ? $url : array($url);

--- a/classes/cache/CacheWincache.class.php
+++ b/classes/cache/CacheWincache.class.php
@@ -32,7 +32,7 @@ class CacheWincache extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheWincache()
+	function __construct()
 	{
 	}
 

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -175,7 +175,7 @@ class Context
 	 *
 	 * @return void
 	 */
-	function Context()
+	function __construct()
 	{
 		$this->oFrontEndFileHandler = new FrontEndFileHandler();
 		$this->get_vars = new stdClass();

--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -219,7 +219,7 @@ class DB
 	 * constructor
 	 * @return void
 	 */
-	function DB()
+	function __construct()
 	{
 		$this->count_cache_path = _XE_PATH_ . $this->count_cache_path;
 		$this->cache_file = _XE_PATH_ . $this->cache_file;

--- a/classes/db/DBCubrid.class.php
+++ b/classes/db/DBCubrid.class.php
@@ -49,7 +49,7 @@ class DBCubrid extends DB
 	 * constructor
 	 * @return void
 	 */
-	function DBCubrid()
+	function __construct()
 	{
 		$this->_setDBInfo();
 		$this->_connect();

--- a/classes/db/DBMssql.class.php
+++ b/classes/db/DBMssql.class.php
@@ -42,7 +42,7 @@ class DBMssql extends DB
 	 * Constructor
 	 * @return void
 	 */
-	function DBMssql()
+	function __construct()
 	{
 		$this->_setDBInfo();
 		$this->_connect();

--- a/classes/db/DBMysql.class.php
+++ b/classes/db/DBMysql.class.php
@@ -43,7 +43,7 @@ class DBMysql extends DB
 	 * Constructor
 	 * @return void
 	 */
-	function DBMysql()
+	function __construct()
 	{
 		$this->_setDBInfo();
 		$this->_connect();

--- a/classes/db/DBMysql_innodb.class.php
+++ b/classes/db/DBMysql_innodb.class.php
@@ -20,7 +20,7 @@ class DBMysql_innodb extends DBMysql
 	 * Constructor
 	 * @return void
 	 */
-	function DBMysql_innodb()
+	function __construct()
 	{
 		$this->_setDBInfo();
 		$this->_connect();

--- a/classes/db/DBMysqli.class.php
+++ b/classes/db/DBMysqli.class.php
@@ -20,7 +20,7 @@ class DBMysqli extends DBMysql
 	 * Constructor
 	 * @return void
 	 */
-	function DBMysqli()
+	function __construct()
 	{
 		$this->_setDBInfo();
 		$this->_connect();

--- a/classes/db/DBMysqli_innodb.class.php
+++ b/classes/db/DBMysqli_innodb.class.php
@@ -20,7 +20,7 @@ class DBMysqli_innodb extends DBMysql
 	 * Constructor
 	 * @return void
 	 */
-	function DBMysqli_innodb()
+	function __construct()
 	{
 		$this->_setDBInfo();
 		$this->_connect();

--- a/classes/db/queryparts/Query.class.php
+++ b/classes/db/queryparts/Query.class.php
@@ -94,7 +94,7 @@ class Query extends Object
 	 * @param string $priority
 	 * @return void
 	 */
-	function Query($queryID = NULL
+	function __construct($queryID = NULL
 	, $action = NULL
 	, $columns = NULL
 	, $tables = NULL

--- a/classes/db/queryparts/Subquery.class.php
+++ b/classes/db/queryparts/Subquery.class.php
@@ -33,7 +33,7 @@ class Subquery extends Query
 	 * @param string $join_type
 	 * @return void
 	 */
-	function Subquery($alias, $columns, $tables, $conditions, $groups, $orderby, $limit, $join_type = null)
+	function __construct($alias, $columns, $tables, $conditions, $groups, $orderby, $limit, $join_type = null)
 	{
 		$this->alias = $alias;
 

--- a/classes/db/queryparts/condition/Condition.class.php
+++ b/classes/db/queryparts/condition/Condition.class.php
@@ -41,7 +41,7 @@ class Condition
 	 * @param string $pipe
 	 * @return void
 	 */
-	function Condition($column_name, $argument, $operation, $pipe)
+	function __construct($column_name, $argument, $operation, $pipe)
 	{
 		$this->column_name = $column_name;
 		$this->argument = $argument;

--- a/classes/db/queryparts/condition/ConditionGroup.class.php
+++ b/classes/db/queryparts/condition/ConditionGroup.class.php
@@ -29,7 +29,7 @@ class ConditionGroup
 	 * @param string $pipe
 	 * @return void
 	 */
-	function ConditionGroup($conditions, $pipe = "")
+	function __construct($conditions, $pipe = "")
 	{
 		$this->conditions = array();
 		foreach($conditions as $condition)

--- a/classes/db/queryparts/condition/ConditionSubquery.class.php
+++ b/classes/db/queryparts/condition/ConditionSubquery.class.php
@@ -17,9 +17,9 @@ class ConditionSubquery extends Condition
 	 * @param string $pipe
 	 * @return void
 	 */
-	function ConditionSubquery($column_name, $argument, $operation, $pipe = "")
+	function __construct($column_name, $argument, $operation, $pipe = "")
 	{
-		parent::Condition($column_name, $argument, $operation, $pipe);
+		parent::__construct($column_name, $argument, $operation, $pipe);
 		$this->_value = $this->argument->toString();
 	}
 

--- a/classes/db/queryparts/condition/ConditionWithArgument.class.php
+++ b/classes/db/queryparts/condition/ConditionWithArgument.class.php
@@ -17,14 +17,14 @@ class ConditionWithArgument extends Condition
 	 * @param string $pipe
 	 * @return void
 	 */
-	function ConditionWithArgument($column_name, $argument, $operation, $pipe = "")
+	function __construct($column_name, $argument, $operation, $pipe = "")
 	{
 		if($argument === null)
 		{
 			$this->_show = false;
 			return;
 		}
-		parent::Condition($column_name, $argument, $operation, $pipe);
+		parent::__construct($column_name, $argument, $operation, $pipe);
 		$this->_value = $argument->getValue();
 	}
 

--- a/classes/db/queryparts/condition/ConditionWithoutArgument.class.php
+++ b/classes/db/queryparts/condition/ConditionWithoutArgument.class.php
@@ -17,9 +17,9 @@ class ConditionWithoutArgument extends Condition
 	 * @param string $pipe
 	 * @return void
 	 */
-	function ConditionWithoutArgument($column_name, $argument, $operation, $pipe = "")
+	function __construct($column_name, $argument, $operation, $pipe = "")
 	{
-		parent::Condition($column_name, $argument, $operation, $pipe);
+		parent::__construct($column_name, $argument, $operation, $pipe);
 		$tmpArray = array('in' => 1, 'notin' => 1, 'not_in' => 1);
 		if(isset($tmpArray[$operation]))
 		{

--- a/classes/db/queryparts/expression/ClickCountExpression.class.php
+++ b/classes/db/queryparts/expression/ClickCountExpression.class.php
@@ -23,9 +23,9 @@ class ClickCountExpression extends SelectExpression
 	 * @param bool $click_count
 	 * @return void
 	 */
-	function ClickCountExpression($column_name, $alias = NULL, $click_count = false)
+	function __construct($column_name, $alias = NULL, $click_count = false)
 	{
-		parent::SelectExpression($column_name, $alias);
+		parent::__construct($column_name, $alias);
 
 		if(!is_bool($click_count))
 		{

--- a/classes/db/queryparts/expression/DeleteExpression.class.php
+++ b/classes/db/queryparts/expression/DeleteExpression.class.php
@@ -24,9 +24,9 @@ class DeleteExpression extends Expression
 	 * @param mixed $value
 	 * @return void
 	 */
-	function DeleteExpression($column_name, $value)
+	function __construct($column_name, $value)
 	{
-		parent::Expression($column_name);
+		parent::__construct($column_name);
 		$this->value = $value;
 	}
 

--- a/classes/db/queryparts/expression/Expression.class.php
+++ b/classes/db/queryparts/expression/Expression.class.php
@@ -27,7 +27,7 @@ class Expression
 	 * @param string $column_name
 	 * @return void
 	 */
-	function Expression($column_name)
+	function __construct($column_name)
 	{
 		$this->column_name = $column_name;
 	}

--- a/classes/db/queryparts/expression/InsertExpression.class.php
+++ b/classes/db/queryparts/expression/InsertExpression.class.php
@@ -23,9 +23,9 @@ class InsertExpression extends Expression
 	 * @param object $argument
 	 * @return void
 	 */
-	function InsertExpression($column_name, $argument)
+	function __construct($column_name, $argument)
 	{
-		parent::Expression($column_name);
+		parent::__construct($column_name);
 		$this->argument = $argument;
 	}
 

--- a/classes/db/queryparts/expression/SelectExpression.class.php
+++ b/classes/db/queryparts/expression/SelectExpression.class.php
@@ -30,9 +30,9 @@ class SelectExpression extends Expression
 	 * @param string $alias
 	 * @return void
 	 */
-	function SelectExpression($column_name, $alias = NULL)
+	function __construct($column_name, $alias = NULL)
 	{
-		parent::Expression($column_name);
+		parent::__construct($column_name);
 		$this->column_alias = $alias;
 	}
 

--- a/classes/db/queryparts/expression/StarExpression.class.php
+++ b/classes/db/queryparts/expression/StarExpression.class.php
@@ -16,9 +16,9 @@ class StarExpression extends SelectExpression
 	 * constructor, set the column to asterisk
 	 * @return void
 	 */
-	function StarExpression()
+	function __construct()
 	{
-		parent::SelectExpression("*");
+		parent::__construct("*");
 	}
 
 	function getArgument()

--- a/classes/db/queryparts/expression/UpdateExpression.class.php
+++ b/classes/db/queryparts/expression/UpdateExpression.class.php
@@ -23,9 +23,9 @@ class UpdateExpression extends Expression
 	 * @param object $argument
 	 * @return void
 	 */
-	function UpdateExpression($column_name, $argument)
+	function __construct($column_name, $argument)
 	{
-		parent::Expression($column_name);
+		parent::__construct($column_name);
 		$this->argument = $argument;
 	}
 

--- a/classes/db/queryparts/expression/UpdateExpressionWithoutArgument.class.php
+++ b/classes/db/queryparts/expression/UpdateExpressionWithoutArgument.class.php
@@ -23,9 +23,9 @@ class UpdateExpressionWithoutArgument extends UpdateExpression
 	 * @param object $argument
 	 * @return void
 	 */
-	function UpdateExpressionWithoutArgument($column_name, $argument)
+	function __construct($column_name, $argument)
 	{
-		parent::Expression($column_name);
+		parent::__construct($column_name);
 		$this->argument = $argument;
 	}
 

--- a/classes/db/queryparts/limit/Limit.class.php
+++ b/classes/db/queryparts/limit/Limit.class.php
@@ -40,7 +40,7 @@ class Limit
 	 * @param int $page_count
 	 * @return void
 	 */
-	function Limit($list_count, $page = NULL, $page_count = NULL)
+	function __construct($list_count, $page = NULL, $page_count = NULL)
 	{
 		$this->list_count = $list_count;
 		if($page)

--- a/classes/db/queryparts/order/OrderByColumn.class.php
+++ b/classes/db/queryparts/order/OrderByColumn.class.php
@@ -27,7 +27,7 @@ class OrderByColumn
 	 * @param string $sort_order
 	 * @return void
 	 */
-	function OrderByColumn($column_name, $sort_order)
+	function __construct($column_name, $sort_order)
 	{
 		$this->column_name = $column_name;
 		$this->sort_order = $sort_order;

--- a/classes/db/queryparts/table/CubridTableWithHint.class.php
+++ b/classes/db/queryparts/table/CubridTableWithHint.class.php
@@ -34,9 +34,9 @@ class CubridTableWithHint extends Table
 	 * @param array $index_hints_list
 	 * @return void
 	 */
-	function CubridTableWithHint($name, $alias = NULL, $index_hints_list)
+	function __construct($name, $alias = NULL, $index_hints_list)
 	{
-		parent::Table($name, $alias);
+		parent::__construct($name, $alias);
 		$this->index_hints_list = $index_hints_list;
 	}
 

--- a/classes/db/queryparts/table/IndexHint.class.php
+++ b/classes/db/queryparts/table/IndexHint.class.php
@@ -27,7 +27,7 @@ class IndexHint
 	 * @param string $index_hint_type
 	 * @return void
 	 */
-	function IndexHint($index_name, $index_hint_type)
+	function __construct($index_name, $index_hint_type)
 	{
 		$this->index_name = $index_name;
 		$this->index_hint_type = $index_hint_type;

--- a/classes/db/queryparts/table/JoinTable.class.php
+++ b/classes/db/queryparts/table/JoinTable.class.php
@@ -32,9 +32,9 @@ class JoinTable extends Table
 	 * @param array $conditions
 	 * @return void
 	 */
-	function JoinTable($name, $alias, $join_type, $conditions)
+	function __construct($name, $alias, $join_type, $conditions)
 	{
-		parent::Table($name, $alias);
+		parent::__construct($name, $alias);
 		$this->join_type = $join_type;
 		$this->conditions = $conditions;
 	}

--- a/classes/db/queryparts/table/MssqlTableWithHint.class.php
+++ b/classes/db/queryparts/table/MssqlTableWithHint.class.php
@@ -34,9 +34,9 @@ class MssqlTableWithHint extends Table
 	 * @param string $index_hints_list
 	 * @return void
 	 */
-	function MssqlTableWithHint($name, $alias = NULL, $index_hints_list)
+	function __construct($name, $alias = NULL, $index_hints_list)
 	{
-		parent::Table($name, $alias);
+		parent::__construct($name, $alias);
 		$this->index_hints_list = $index_hints_list;
 	}
 

--- a/classes/db/queryparts/table/MysqlTableWithHint.class.php
+++ b/classes/db/queryparts/table/MysqlTableWithHint.class.php
@@ -34,9 +34,9 @@ class MysqlTableWithHint extends Table
 	 * @param string $index_hints_list
 	 * @return void
 	 */
-	function MysqlTableWithHint($name, $alias = NULL, $index_hints_list)
+	function __construct($name, $alias = NULL, $index_hints_list)
 	{
-		parent::Table($name, $alias);
+		parent::__construct($name, $alias);
 		$this->index_hints_list = $index_hints_list;
 	}
 

--- a/classes/db/queryparts/table/Table.class.php
+++ b/classes/db/queryparts/table/Table.class.php
@@ -27,7 +27,7 @@ class Table
 	 * @param string $alias
 	 * @return void
 	 */
-	function Table($name, $alias = NULL)
+	function __construct($name, $alias = NULL)
 	{
 		$this->name = $name;
 		$this->alias = $alias;

--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -38,7 +38,7 @@ class ExtraVar
 	 * @param int $module_srl Sequence of module
 	 * @return void
 	 */
-	function ExtraVar($module_srl)
+	function __construct($module_srl)
 	{
 		$this->module_srl = $module_srl;
 	}

--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -157,7 +157,7 @@ class ExtraItem
 	 * @param string $eid Unique id of extra variable in module
 	 * @return void
 	 */
-	function ExtraItem($module_srl, $idx, $name, $type = 'text', $default = null, $desc = '', $is_required = 'N', $search = 'N', $value = null, $eid = '')
+	function __construct($module_srl, $idx, $name, $type = 'text', $default = null, $desc = '', $is_required = 'N', $search = 'N', $value = null, $eid = '')
 	{
 		if(!$idx)
 		{

--- a/classes/file/FileObject.class.php
+++ b/classes/file/FileObject.class.php
@@ -34,7 +34,7 @@ class FileObject extends Object
 	 * @param string $mode File open mode 
 	 * @return void
 	 */
-	function FileObject($path, $mode)
+	function __construct($path, $mode)
 	{
 		if($path != NULL)
 		{

--- a/classes/httprequest/XEHttpRequest.class.php
+++ b/classes/httprequest/XEHttpRequest.class.php
@@ -41,7 +41,7 @@ class XEHttpRequest
 	 * constructor
 	 * @return void
 	 */
-	function XEHttpRequest($host, $port, $scheme='')
+	function __construct($host, $port, $scheme='')
 	{
 		$this->m_host = $host;
 		$this->m_port = $port;

--- a/classes/mail/Mail.class.php
+++ b/classes/mail/Mail.class.php
@@ -137,7 +137,7 @@ class Mail extends PHPMailer
 	 *
 	 * @return void
 	 */
-	function Mail()
+	function __construct()
 	{
 
 	}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -32,7 +32,7 @@ class ModuleHandler extends Handler
 	 * @return void
 	 * */
 
-	function ModuleHandler($module = '', $act = '', $mid = '', $document_srl = '', $module_srl = '')
+	function __construct($module = '', $act = '', $mid = '', $document_srl = '', $module_srl = '')
 	{
 		// If XE has not installed yet, set module as install
 		if(!Context::isInstalled())

--- a/classes/object/Object.class.php
+++ b/classes/object/Object.class.php
@@ -40,7 +40,7 @@ class Object
 	 * @param string $message Error message
 	 * @return void
 	 */
-	function Object($error = 0, $message = 'success')
+	function __construct($error = 0, $message = 'success')
 	{
 		$this->setError($error);
 		$this->setMessage($message);

--- a/classes/page/PageHandler.class.php
+++ b/classes/page/PageHandler.class.php
@@ -30,7 +30,7 @@ class PageHandler extends Handler
 	 * @return void
 	 */
 
-	function PageHandler($total_count, $total_page, $cur_page, $page_count = 10)
+	function __construct($total_count, $total_page, $cur_page, $page_count = 10)
 	{
 		$this->total_count = $total_count;
 		$this->total_page = $total_page;

--- a/classes/security/EmbedFilter.class.php
+++ b/classes/security/EmbedFilter.class.php
@@ -260,7 +260,7 @@ class EmbedFilter
 	 * @constructor
 	 * @return void
 	 */
-	function EmbedFilter()
+	function __construct()
 	{
 		$this->_makeWhiteDomainList();
 

--- a/classes/security/Purifier.class.php
+++ b/classes/security/Purifier.class.php
@@ -9,7 +9,7 @@ class Purifier
 	private $_config;
 	private $_def;
 
-	public function Purifier()
+	public function __construct()
 	{
 		$this->_checkCacheDir();
 

--- a/classes/security/Security.class.php
+++ b/classes/security/Security.class.php
@@ -22,7 +22,7 @@ class Security
 	 * @param mixed $var Target context
 	 * @return void
 	 */
-	function Security($var = NULL)
+	function __construct($var = NULL)
 	{
 		$this->_targetVar = $var;
 	}

--- a/classes/xml/XmlJsFilter.class.php
+++ b/classes/xml/XmlJsFilter.class.php
@@ -79,7 +79,7 @@ class XmlJsFilter extends XmlParser
 	 * @return void
 	 */
 
-	function XmlJsFilter($path, $xml_file)
+	function __construct($path, $xml_file)
 	{
 		if(substr($path, -1) !== '/')
 		{

--- a/classes/xml/XmlLangParser.class.php
+++ b/classes/xml/XmlLangParser.class.php
@@ -53,7 +53,7 @@ class XmlLangParser extends XmlParser
 	 * @param string $lang_type
 	 * @return void
 	 */
-	function XmlLangParser($xml_file, $lang_type)
+	function __construct($xml_file, $lang_type)
 	{
 		$this->lang_type = $lang_type;
 		$this->xml_file = $xml_file;

--- a/classes/xml/XmlQueryParser.class.php
+++ b/classes/xml/XmlQueryParser.class.php
@@ -49,7 +49,7 @@ class XmlQueryParser extends XmlParser
 	 * constructor
 	 * @return void
 	 */
-	function XmlQueryParser()
+	function __construct()
 	{
 
 	}

--- a/classes/xml/xmlquery/DBParser.class.php
+++ b/classes/xml/xmlquery/DBParser.class.php
@@ -60,7 +60,7 @@ class DBParser
 	 *
 	 * @return void
 	 */
-	function DBParser($escape_char_left, $escape_char_right = "", $table_prefix = "xe_")
+	function __construct($escape_char_left, $escape_char_right = "", $table_prefix = "xe_")
 	{
 		$this->escape_char_left = $escape_char_left;
 		if($escape_char_right !== "")

--- a/classes/xml/xmlquery/QueryParser.class.php
+++ b/classes/xml/xmlquery/QueryParser.class.php
@@ -30,7 +30,7 @@ class QueryParser
 	 * @param bool $isSubQuery
 	 * @return void
 	 */
-	function QueryParser($query = NULL, $isSubQuery = FALSE)
+	function __construct($query = NULL, $isSubQuery = FALSE)
 	{
 		if($query)
 		{

--- a/classes/xml/xmlquery/argument/Argument.class.php
+++ b/classes/xml/xmlquery/argument/Argument.class.php
@@ -64,7 +64,7 @@ class Argument
 	 * @return void
 	 */
 
-	function Argument($name, $value)
+	function __construct($name, $value)
 	{
 		$this->value = $value;
 		$this->name = $name;

--- a/classes/xml/xmlquery/argument/ConditionArgument.class.php
+++ b/classes/xml/xmlquery/argument/ConditionArgument.class.php
@@ -23,7 +23,7 @@ class ConditionArgument extends Argument
 	 * @param string $operation
 	 * @return void
 	 */
-	function ConditionArgument($name, $value, $operation)
+	function __construct($name, $value, $operation)
 	{
 		$operationList = array('in' => 1, 'notin' => 1, 'not_in' => 1, 'between' => 1);
 		if(isset($value) && isset($operationList[$operation]) && !is_array($value) && $value != '')
@@ -32,7 +32,7 @@ class ConditionArgument extends Argument
 			$value = str_replace('\'', '', $value);
 			$value = explode(',', $value);
 		}
-		parent::Argument($name, $value);
+		parent::__construct($name, $value);
 		$this->operation = $operation;
 	}
 

--- a/classes/xml/xmlquery/queryargument/DefaultValue.class.php
+++ b/classes/xml/xmlquery/queryargument/DefaultValue.class.php
@@ -58,7 +58,7 @@ class DefaultValue
 	 * @param mixed $value value
 	 * @return void
 	 */
-	function DefaultValue($column_name, $value)
+	function __construct($column_name, $value)
 	{
 		$dbParser = DB::getParser();
 		$this->column_name = $dbParser->parseColumnName($column_name);

--- a/classes/xml/xmlquery/queryargument/QueryArgument.class.php
+++ b/classes/xml/xmlquery/queryargument/QueryArgument.class.php
@@ -58,7 +58,7 @@ class QueryArgument
 	 * @param bool $ignore_value
 	 * @return void
 	 */
-	function QueryArgument($tag, $ignore_value = FALSE)
+	function __construct($tag, $ignore_value = FALSE)
 	{
 		static $number_of_arguments = 0;
 

--- a/classes/xml/xmlquery/queryargument/validator/QueryArgumentValidator.class.php
+++ b/classes/xml/xmlquery/queryargument/validator/QueryArgumentValidator.class.php
@@ -59,7 +59,7 @@ class QueryArgumentValidator
 	 * @param QueryArgument $argument
 	 * @return void
 	 */
-	function QueryArgumentValidator($tag, $argument)
+	function __construct($tag, $argument)
 	{
 		$this->argument = $argument;
 		$this->argument_name = $this->argument->getArgumentName();

--- a/classes/xml/xmlquery/tags/column/ColumnTag.class.php
+++ b/classes/xml/xmlquery/tags/column/ColumnTag.class.php
@@ -25,7 +25,7 @@ class ColumnTag
 	 * @param string $name
 	 * @return void
 	 */
-	function ColumnTag($name)
+	function __construct($name)
 	{
 		$this->name = $name;
 	}

--- a/classes/xml/xmlquery/tags/column/InsertColumnTag.class.php
+++ b/classes/xml/xmlquery/tags/column/InsertColumnTag.class.php
@@ -25,9 +25,9 @@ class InsertColumnTag extends ColumnTag
 	 *
 	 * @return void
 	 */
-	function InsertColumnTag($column)
+	function __construct($column)
 	{
-		parent::ColumnTag($column->attrs->name);
+		parent::__construct($column->attrs->name);
 		$dbParser = DB::getParser();
 		$this->name = $dbParser->parseColumnName($this->name);
 		$this->argument = new QueryArgument($column);

--- a/classes/xml/xmlquery/tags/column/InsertColumnTagWithoutArgument.class.php
+++ b/classes/xml/xmlquery/tags/column/InsertColumnTagWithoutArgument.class.php
@@ -17,9 +17,9 @@ class InsertColumnTagWithoutArgument extends ColumnTag
 	 * @param object $column
 	 * @return void
 	 */
-	function InsertColumnTagWithoutArgument($column)
+	function __construct($column)
 	{
-		parent::ColumnTag($column->attrs->name);
+		parent::__construct($column->attrs->name);
 		$dbParser = DB::getParser();
 		$this->name = $dbParser->parseColumnName($this->name);
 	}

--- a/classes/xml/xmlquery/tags/column/InsertColumnsTag.class.php
+++ b/classes/xml/xmlquery/tags/column/InsertColumnsTag.class.php
@@ -24,7 +24,7 @@ class InsertColumnsTag
 	 * @param array|string $xml_columns
 	 * @return void
 	 */
-	function InsertColumnsTag($xml_columns)
+	function __construct($xml_columns)
 	{
 		$this->columns = array();
 

--- a/classes/xml/xmlquery/tags/column/SelectColumnTag.class.php
+++ b/classes/xml/xmlquery/tags/column/SelectColumnTag.class.php
@@ -31,16 +31,16 @@ class SelectColumnTag extends ColumnTag
 	 * @param string|object $column
 	 * @return void
 	 */
-	function SelectColumnTag($column)
+	function __construct($column)
 	{
 		if($column == "*" || $column->attrs->name == '*')
 		{
-			parent::ColumnTag(NULL);
+			parent::__construct(NULL);
 			$this->name = "*";
 		}
 		else
 		{
-			parent::ColumnTag($column->attrs->name);
+			parent::__construct($column->attrs->name);
 			$dbParser = DB::getParser();
 			$this->name = $dbParser->parseExpression($this->name);
 

--- a/classes/xml/xmlquery/tags/column/SelectColumnsTag.class.php
+++ b/classes/xml/xmlquery/tags/column/SelectColumnsTag.class.php
@@ -25,7 +25,7 @@ class SelectColumnsTag
 	 * @internal param \Xml_Node_ $xml_columns
 	 * @return void
 	 */
-	function SelectColumnsTag($xml_columns_tag)
+	function __construct($xml_columns_tag)
 	{
 		if(!$xml_columns_tag)
 		{

--- a/classes/xml/xmlquery/tags/column/UpdateColumnTag.class.php
+++ b/classes/xml/xmlquery/tags/column/UpdateColumnTag.class.php
@@ -31,9 +31,9 @@ class UpdateColumnTag extends ColumnTag
 	 * @param object $column
 	 * @return void
 	 */
-	function UpdateColumnTag($column)
+	function __construct($column)
 	{
-		parent::ColumnTag($column->attrs->name);
+		parent::__construct($column->attrs->name);
 
 		$dbParser = DB::getParser();
 		$this->name = $dbParser->parseColumnName($this->name);

--- a/classes/xml/xmlquery/tags/column/UpdateColumnsTag.class.php
+++ b/classes/xml/xmlquery/tags/column/UpdateColumnsTag.class.php
@@ -24,7 +24,7 @@ class UpdateColumnsTag
 	 * @param array|object $xml_columns
 	 * @return void
 	 */
-	function UpdateColumnsTag($xml_columns)
+	function __construct($xml_columns)
 	{
 		$this->columns = array();
 

--- a/classes/xml/xmlquery/tags/condition/ConditionGroupTag.class.php
+++ b/classes/xml/xmlquery/tags/condition/ConditionGroupTag.class.php
@@ -29,7 +29,7 @@ class ConditionGroupTag
 	 * @param string $pipe
 	 * @return void
 	 */
-	function ConditionGroupTag($conditions, $pipe = "")
+	function __construct($conditions, $pipe = "")
 	{
 		$this->pipe = $pipe;
 

--- a/classes/xml/xmlquery/tags/condition/ConditionTag.class.php
+++ b/classes/xml/xmlquery/tags/condition/ConditionTag.class.php
@@ -59,7 +59,7 @@ class ConditionTag
 	 * @param object $condition
 	 * @return void
 	 */
-	function ConditionTag($condition)
+	function __construct($condition)
 	{
 		$this->operation = $condition->attrs->operation;
 		$this->pipe = $condition->attrs->pipe;

--- a/classes/xml/xmlquery/tags/condition/ConditionsTag.class.php
+++ b/classes/xml/xmlquery/tags/condition/ConditionsTag.class.php
@@ -22,7 +22,7 @@ class ConditionsTag
 	 * @param object $xml_conditions
 	 * @return void
 	 */
-	function ConditionsTag($xml_conditions)
+	function __construct($xml_conditions)
 	{
 		$this->condition_groups = array();
 		if(!$xml_conditions)

--- a/classes/xml/xmlquery/tags/condition/JoinConditionsTag.class.php
+++ b/classes/xml/xmlquery/tags/condition/JoinConditionsTag.class.php
@@ -16,9 +16,9 @@ class JoinConditionsTag extends ConditionsTag
 	 * @param object $xml_conditions
 	 * @return void
 	 */
-	function JoinConditionsTag($xml_conditions)
+	function __construct($xml_conditions)
 	{
-		parent::ConditionsTag($xml_conditions);
+		parent::__construct($xml_conditions);
 		$this->condition_groups[0]->conditions[0]->setPipe("");
 	}
 

--- a/classes/xml/xmlquery/tags/group/GroupsTag.class.php
+++ b/classes/xml/xmlquery/tags/group/GroupsTag.class.php
@@ -22,7 +22,7 @@ class GroupsTag
 	 * @param array|string $xml_groups
 	 * @return void
 	 */
-	function GroupsTag($xml_groups)
+	function __construct($xml_groups)
 	{
 		$this->groups = array();
 

--- a/classes/xml/xmlquery/tags/navigation/IndexTag.class.php
+++ b/classes/xml/xmlquery/tags/navigation/IndexTag.class.php
@@ -46,7 +46,7 @@ class IndexTag
 	 * @param object $index
 	 * @return void
 	 */
-	function IndexTag($index)
+	function __construct($index)
 	{
 		$this->argument_name = $index->attrs->var;
 

--- a/classes/xml/xmlquery/tags/navigation/LimitTag.class.php
+++ b/classes/xml/xmlquery/tags/navigation/LimitTag.class.php
@@ -40,7 +40,7 @@ class LimitTag
 	 * @param object $index
 	 * @return void
 	 */
-	function LimitTag($index)
+	function __construct($index)
 	{
 		if($index->page && $index->page->attrs && $index->page_count && $index->page_count->attrs)
 		{

--- a/classes/xml/xmlquery/tags/navigation/NavigationTag.class.php
+++ b/classes/xml/xmlquery/tags/navigation/NavigationTag.class.php
@@ -46,7 +46,7 @@ class NavigationTag
 	 * @param object $xml_navigation
 	 * @return void
 	 */
-	function NavigationTag($xml_navigation)
+	function __construct($xml_navigation)
 	{
 		$this->order = array();
 		if($xml_navigation)

--- a/classes/xml/xmlquery/tags/query/QueryTag.class.php
+++ b/classes/xml/xmlquery/tags/query/QueryTag.class.php
@@ -119,7 +119,7 @@ class QueryTag
 	 * @param bool $isSubQuery
 	 * @return void
 	 */
-	function QueryTag($query, $isSubQuery = FALSE)
+	function __construct($query, $isSubQuery = FALSE)
 	{
 		$this->action = $query->attrs->action;
 		$this->query_id = $query->attrs->id;

--- a/classes/xml/xmlquery/tags/table/HintTableTag.class.php
+++ b/classes/xml/xmlquery/tags/table/HintTableTag.class.php
@@ -25,9 +25,9 @@ class HintTableTag extends TableTag
 	 * @param array $index
 	 * @return void
 	 */
-	function HintTableTag($table, $index)
+	function __construct($table, $index)
 	{
-		parent::TableTag($table);
+		parent::__construct($table);
 		$this->index = $index;
 	}
 

--- a/classes/xml/xmlquery/tags/table/TableTag.class.php
+++ b/classes/xml/xmlquery/tags/table/TableTag.class.php
@@ -66,7 +66,7 @@ class TableTag
 	 * @param object $table XML <table> tag
 	 * @return void
 	 */
-	function TableTag($table)
+	function __construct($table)
 	{
 		$dbParser = DB::getParser();
 

--- a/classes/xml/xmlquery/tags/table/TablesTag.class.php
+++ b/classes/xml/xmlquery/tags/table/TablesTag.class.php
@@ -33,7 +33,7 @@ class TablesTag
 	 * @param object $xml_index_hints_tag
 	 * @return void
 	 */
-	function TablesTag($xml_tables_tag, $xml_index_hints_tag = NULL)
+	function __construct($xml_tables_tag, $xml_index_hints_tag = NULL)
 	{
 		$this->tables = array();
 

--- a/modules/comment/comment.item.php
+++ b/modules/comment/comment.item.php
@@ -30,7 +30,7 @@ class commentItem extends Object
 	 * @param array $columnList
 	 * @return void
 	 */
-	function commentItem($comment_srl = 0, $columnList = array())
+	function __construct($comment_srl = 0, $columnList = array())
 	{
 		$this->comment_srl = $comment_srl;
 		$this->columnList = $columnList;

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -53,7 +53,7 @@ class documentItem extends Object
 	 * @param array columnList
 	 * @return void
 	 */
-	function documentItem($document_srl = 0, $load_extra_vars = true, $columnList = array())
+	function __construct($document_srl = 0, $load_extra_vars = true, $columnList = array())
 	{
 		$this->document_srl = $document_srl;
 		$this->columnList = $columnList;

--- a/modules/editor/components/emoticon/emoticon.class.php
+++ b/modules/editor/components/emoticon/emoticon.class.php
@@ -15,7 +15,7 @@ class emoticon extends EditorHandler
 	/**
 	 * @brief editor_sequence and components out of the path
 	 */
-	function emoticon($editor_sequence, $component_path)
+	function __construct($editor_sequence, $component_path)
 	{
 		$this->editor_sequence = $editor_sequence;
 		$this->component_path = $component_path;

--- a/modules/editor/components/image_gallery/image_gallery.class.php
+++ b/modules/editor/components/image_gallery/image_gallery.class.php
@@ -14,7 +14,7 @@ class image_gallery extends EditorHandler
 	/**
 	 * @brief editor_sequence and components out of the path
 	 */
-	function image_gallery($editor_sequence, $component_path)
+	function __construct($editor_sequence, $component_path)
 	{
 		$this->editor_sequence = $editor_sequence;
 		$this->component_path = $component_path;

--- a/modules/editor/components/image_link/image_link.class.php
+++ b/modules/editor/components/image_link/image_link.class.php
@@ -14,7 +14,7 @@ class image_link extends EditorHandler
 	/**
 	 * @brief editor_sequence and components out of the path
 	 */
-	function image_link($editor_sequence, $component_path)
+	function __construct($editor_sequence, $component_path)
 	{
 		$this->editor_sequence = $editor_sequence;
 		$this->component_path = $component_path;

--- a/modules/editor/components/poll_maker/poll_maker.class.php
+++ b/modules/editor/components/poll_maker/poll_maker.class.php
@@ -14,7 +14,7 @@ class poll_maker extends EditorHandler
 	/**
 	 * @brief editor_sequence and components out of the path
 	 */
-	function poll_maker($editor_sequence, $component_path)
+	function __construct($editor_sequence, $component_path)
 	{
 		$this->editor_sequence = $editor_sequence;
 		$this->component_path = $component_path;

--- a/modules/member/member.class.php
+++ b/modules/member/member.class.php
@@ -18,7 +18,7 @@ class member extends ModuleObject {
 	 *
 	 * @return void
 	 */
-	function member()
+	function __construct()
 	{
 		if(!Context::isInstalled()) return;
 

--- a/modules/session/session.class.php
+++ b/modules/session/session.class.php
@@ -13,7 +13,7 @@ class session extends ModuleObject
 	var $lifetime = 18000;
 	var $session_started = false;
 
-	function session()
+	function __construct()
 	{
 		if(Context::isInstalled()) $this->session_started= true;
 	}


### PR DESCRIPTION
올해 안에 공식 발표될 PHP 7에서는 클래스와 같은 이름의 메소드를 생성자로 사용할 경우 `E_DEPRECATED` 오류가 발생합니다. 또한 차차기 버전에서는 아예 이런 방식의 생성자를 지원하지 않고 `__construct()`만 인정할 계획이라고 합니다.

참고: https://wiki.php.net/rfc/remove_php4_constructors

당장 문제가 있는 것은 아니지만, 간단하게 고칠 수 있는 것이기에 PR을 넣습니다.
- 클래스와 같은 이름의 메소드를 생성자로 사용하는 경우를 모두 찾아 `__construct()`로 변경
- `parent::부모클래스이름()` 문법을 사용하는 경우도 모두 `parent::__construct()`로 변경
