### PR TITLE
이메일을 SMTP를 통해 발송할 수 있는 기능 추가

### DIFF
--- a/admin/help/index.html
+++ b/admin/help/index.html
@@ -407,6 +407,7 @@ body,table,input,textarea,select,button{font-family:나눔고딕,NanumGothic,NG,
 									<li id="UMAN_config_general_sso">SSO 사용: 사용자가 한 번만 로그인하면 기본 사이트와 가상 사이트에 동시에 로그인이 됩니다. 가상 사이트를 사용할 때만 필요합니다.</li>
 									<li id="UMAN_config_general_db_session">인증 세션 DB 사용: 인증 시 사용되는 PHP 세션을 DB로 사용하는 기능입니다. 웹서버의 사용률이 낮은 사이트에서는 비활성화시 사이트 응답 속도가 향상될 수 있습니다. 단, 현재 접속자를 구할 수 없어 관련된 기능을 사용할 수 없게 됩니다.</li>
 									<li id="UMAN_config_general_qmail">Qmail 호환: Qmail등 CRLF를 줄 구분자로 인식하지 못하는 MTA에서 메일이 발송되도록 합니다.</li>
+									<li id="UMAN_config_general_smtp">SMTP 사용 : 인증 메일이나 기타 사이트 관리시 SMTP를 통해 이메일을 전송합니다.</li>
 									<li id="UMAN_config_general_sitelock">사이트 잠금: 지정한 IP 외 접근을 차단할 수 있습니다.</li>
 									<li id="UMAN_config_general_sitelock_whitelist">접근 허용 IP: 이곳에 관리자의 IP가 반드시 포함되어야 합니다. 만약 접근이 차단된 경우 './files/config/db.config.php' 파일에서 `'use_sitelock' => 'Y'`를 `'use_sitelock' => 'N'`으로 변경하여 차단을 해제할 수 있습니다.</li>
 								</ul>

--- a/classes/mail/Mail.class.php
+++ b/classes/mail/Mail.class.php
@@ -139,7 +139,11 @@ class Mail extends PHPMailer
 	 */
 	function Mail()
 	{
-
+		$db_info = Context::getDBInfo();
+		if($db_info->use_smtp == 'Y' && $db_info->smtp_host != NULL && $db_info->smtp_port != NULL && $db_info->smtp_secure != NULL && $db_info->smtp_username != NULL && $db_info->smtp_password != NULL)
+		{
+			$this->useSMTP(TRUE, $db_info->smtp_host, $db_info->smtp_username, $db_info->smtp_password, $db_info->smtp_secure, $db_info->smtp_port);
+		}
 	}
 
 	/**

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -74,6 +74,13 @@ class adminAdminView extends admin
 		Context::set('use_db_session', $db_info->use_db_session == 'N' ? 'N' : 'Y');
 		Context::set('use_mobile_view', $db_info->use_mobile_view == 'Y' ? 'Y' : 'N');
 		Context::set('use_ssl', $db_info->use_ssl ? $db_info->use_ssl : "none");
+		Context::set('use_smtp', $db_info->use_smtp == 'Y' ? 'Y' : 'N');
+		Context::set('smtp_host', $db_info->smtp_host ? $db_info->smtp_host : NULL);
+		Context::set('smtp_port', $db_info->smtp_port ? $db_info->smtp_port : NULL);
+		Context::set('smtp_secure', $db_info->smtp_secure ? $db_info->smtp_secure : "N");
+		Context::set('smtp_username', $db_info->smtp_username ? $db_info->smtp_username : NULL);
+		Context::set('smtp_password', $db_info->smtp_password ? $db_info->smtp_password : NULL);
+
 		if($db_info->http_port)
 		{
 			Context::set('http_port', $db_info->http_port);

--- a/modules/admin/lang/lang.xml
+++ b/modules/admin/lang/lang.xml
@@ -760,6 +760,130 @@
 		<value xml:lang="zh-CN"><![CDATA[启用Qmail]]></value>
 		<value xml:lang="tr"><![CDATA[Qmail etkinleştirin]]></value>
 	</item>
+	<item name="use_smtp">
+		<value xml:lang="ko"><![CDATA[SMTP 사용]]></value>
+		<value xml:lang="en"><![CDATA[Enable SMTP]]></value>
+		<value xml:lang="jp"><![CDATA[SMTP使用]]></value>
+		<value xml:lang="zh-CN"><![CDATA[启用SMTP]]></value>
+		<value xml:lang="tr"><![CDATA[SMTP etkinleştirin]]></value>
+	</item>
+	<item name="smtp_provider">
+		<value xml:lang="ko"><![CDATA[SMTP 제공자]]></value>
+		<value xml:lang="en"><![CDATA[SMTP]]></value>
+		<value xml:lang="jp"><![CDATA[SMTP使用]]></value>
+		<value xml:lang="zh-CN"><![CDATA[启用SMTP]]></value>
+		<value xml:lang="tr"><![CDATA[SMTP etkinleştirin]]></value>
+	</item>
+	<item name="smtp_provider_list" type="array">
+		<item name="custom">
+			 <value xml:lang="ko"><![CDATA[사용자 정의]]></value>
+			 <value xml:lang="en"><![CDATA[custom]]></value>
+			 <value xml:lang="jp"><![CDATA[カスタム]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[习惯]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[习惯]]></value>
+			 <value xml:lang="tr"><![CDATA[görenek]]></value>
+		</item>
+		<item name="gmail">
+			 <value xml:lang="ko"><![CDATA[Gmail]]></value>
+			 <value xml:lang="en"><![CDATA[Gmail]]></value>
+			 <value xml:lang="jp"><![CDATA[Gmail]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[Gmail]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[Gmail]]></value>
+			 <value xml:lang="tr"><![CDATA[Gmail]]></value>
+		</item>
+		<item name="naver">
+			 <value xml:lang="ko"><![CDATA[네이버]]></value>
+			 <value xml:lang="en"><![CDATA[Naver]]></value>
+			 <value xml:lang="jp"><![CDATA[Naver]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[Naver]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[Naver]]></value>
+			 <value xml:lang="tr"><![CDATA[Naver]]></value>
+		</item>
+		<item name="daum">
+			 <value xml:lang="ko"><![CDATA[다음]]></value>
+			 <value xml:lang="en"><![CDATA[Daum]]></value>
+			 <value xml:lang="jp"><![CDATA[Daum]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[Daum]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[Daum]]></value>
+			 <value xml:lang="tr"><![CDATA[Daum]]></value>
+		</item>
+	</item>
+	<item name="smtp_host">
+		<value xml:lang="ko"><![CDATA[SMTP 서버 주소]]></value>
+		<value xml:lang="en"><![CDATA[SMTP hostname]]></value>
+		<value xml:lang="jp"><![CDATA[SMTPサーバーアドレス]]></value>
+		<value xml:lang="zh-CN"><![CDATA[SMTP服务器名]]></value>
+		<value xml:lang="zh-TW"><![CDATA[SMTP 主機名稱]]></value>
+		<value xml:lang="de"><![CDATA[SMTP-Server hostname]]></value>
+		<value xml:lang="tr"><![CDATA[SMTP Sunucu Adı]]></value>
+		<value xml:lang="vi"><![CDATA[Tên Host SMTP]]></value>
+	</item>
+	<item name="smtp_port">
+		<value xml:lang="ko"><![CDATA[SMTP 포트]]></value>
+		<value xml:lang="en"><![CDATA[SMTP Port]]></value>
+		<value xml:lang="jp"><![CDATA[SMTPポート]]></value>
+		<value xml:lang="zh-CN"><![CDATA[SMTP端口]]></value>
+		<value xml:lang="zh-TW"><![CDATA[SMTP埠口]]></value>
+		<value xml:lang="fr"><![CDATA[le port SMTP]]></value>
+		<value xml:lang="es"><![CDATA[puerto SMTP]]></value>
+		<value xml:lang="tr"><![CDATA[SMTP Bağlantı Noktası]]></value>
+		<value xml:lang="vi"><![CDATA[cổng SMTP]]></value>
+	</item>
+	<item name="smtp_secure">
+		<value xml:lang="ko"><![CDATA[SMTP 보안 설정 사용]]></value>
+		<value xml:lang="en"><![CDATA[SMTP Secure Setting]]></value>
+		<value xml:lang="jp"><![CDATA[SMTPのセキュリティ設定]]></value>
+		<value xml:lang="zh-CN"><![CDATA[SMTP安全设置]]></value>
+		<value xml:lang="zh-TW"><![CDATA[SMTP安全设置]]></value>
+		<value xml:lang="fr"><![CDATA[Paramètres de sécurité SMTP]]></value>
+		<value xml:lang="es"><![CDATA[Configuración de seguridad SMTP]]></value>
+		<value xml:lang="tr"><![CDATA[SMTP Güvenlik Ayarları]]></value>
+		<value xml:lang="vi"><![CDATA[Cài đặt SMTP an]]></value>
+	</item>
+	<item name="smtp_secure_ssl">
+		<value xml:lang="ko"><![CDATA[SSL]]></value>
+		<value xml:lang="en"><![CDATA[SSL]]></value>
+		<value xml:lang="jp"><![CDATA[SSL]]></value>
+		<value xml:lang="zh-CN"><![CDATA[SSL]]></value>
+		<value xml:lang="zh-TW"><![CDATA[SSL]]></value>
+		<value xml:lang="fr"><![CDATA[SSL]]></value>
+		<value xml:lang="es"><![CDATA[SSL]]></value>
+		<value xml:lang="tr"><![CDATA[SSL]]></value>
+		<value xml:lang="vi"><![CDATA[SSL]]></value>
+	</item>
+	<item name="smtp_secure_tls">
+		<value xml:lang="ko"><![CDATA[TLS]]></value>
+		<value xml:lang="en"><![CDATA[TLS]]></value>
+		<value xml:lang="jp"><![CDATA[TLS]]></value>
+		<value xml:lang="zh-CN"><![CDATA[TLS]]></value>
+		<value xml:lang="zh-TW"><![CDATA[TLS]]></value>
+		<value xml:lang="fr"><![CDATA[TLS]]></value>
+		<value xml:lang="es"><![CDATA[TLS]]></value>
+		<value xml:lang="tr"><![CDATA[TLS]]></value>
+		<value xml:lang="vi"><![CDATA[TLS]]></value>
+	</item>
+	<item name="smtp_username">
+		<value xml:lang="ko"><![CDATA[SMTP 사용자명]]></value>
+		<value xml:lang="en"><![CDATA[SMTP User Name]]></value>
+		<value xml:lang="jp"><![CDATA[SMTP 名前]]></value>
+		<value xml:lang="zh-CN"><![CDATA[SMTP 姓名]]></value>
+		<value xml:lang="zh-TW"><![CDATA[SMTP 姓名]]></value>
+		<value xml:lang="fr"><![CDATA[Nom d'utilisateur SMTP]]></value>
+		<value xml:lang="es"><![CDATA[Nombre de usuario SMTP]]></value>
+		<value xml:lang="tr"><![CDATA[SMTP kullanıcı adı]]></value>
+		<value xml:lang="vi"><![CDATA[Tên người dùng SMTP]]></value>
+	</item>
+	<item name="smtp_password">
+	<value xml:lang="ko"><![CDATA[SMTP 비밀번호]]></value>
+	<value xml:lang="en"><![CDATA[SMTP Password]]></value>
+	<value xml:lang="jp"><![CDATA[SMTP パスワード]]></value>
+	<value xml:lang="zh-CN"><![CDATA[SMTP 密码]]></value>
+	<value xml:lang="zh-TW"><![CDATA[SMTP 密碼]]></value>
+	<value xml:lang="fr"><![CDATA[Mot de Passe SMTP ]]></value>
+	<value xml:lang="es"><![CDATA[Contraseña SMTP]]></value>
+	<value xml:lang="tr"><![CDATA[SMTP Şifre]]></value>
+	<value xml:lang="vi"><![CDATA[Mật khẩu SMTP]]></value>
+	</item>
 	<item name="sftp">
 		<value xml:lang="ko"><![CDATA[SFTP 사용]]></value>
 		<value xml:lang="en"><![CDATA[Use SFTP]]></value>

--- a/modules/admin/tpl/config_general.html
+++ b/modules/admin/tpl/config_general.html
@@ -225,6 +225,45 @@
 				<label for="qmail_compatibility_n" class="x_inline"><input type="radio" name="qmail_compatibility" id="qmail_compatibility_n" value="N" checked="checked"|cond="$qmail_compatibility!='Y'" /> {$lang->cmd_no}</label>
 			</div>
 		</div>
+		<div class="x_control-group">
+			<label class="x_control-label">{$lang->use_smtp} <a class="x_icon-question-sign" href="./admin/help/index.html#UMAN_config_general_smtp" target="_blank">{$lang->help}</a></label>
+			<div class="x_controls">
+				<label for="use_smtp_y" class="x_inline"><input type="radio" name="use_smtp" id="use_smtp_y" value="Y" checked="checked"|cond="$use_smtp=='Y'" /> {$lang->cmd_yes}</label>
+				<label for="use_smtp_n" class="x_inline"><input type="radio" name="use_smtp" id="use_smtp_n" value="N" checked="checked"|cond="$use_smtp!='Y'" /> {$lang->cmd_no}</label>
+			</div>
+		</div>
+		<div class="x_control-group smtp">			
+			<label class="x_control-label">{$lang->smtp_host}</label>
+			<div class="x_controls">
+				<input type="text" name="smtp_host" id="smtp_host" value="{$smtp_host}"/>
+			</div>
+		</div>
+		<div class="x_control-group smtp">
+			<label class="x_control-label">{$lang->smtp_port}</label>
+			<div class="x_controls">
+				<input type="number" name="smtp_port" id="smtp_port" size="5" value="{$smtp_port}" /></label>
+			</div>
+		</div>
+		<div class="x_control-group smtp">
+			<label class="x_control-label">{$lang->smtp_secure}</label>
+			<div class="x_controls">
+				<label for="smtp_secure_n" class="x_inline"><input type="radio" name="smtp_secure" id="smtp_secure_n" value="N" checked="checked"|cond="$smtp_secure=='N'" /> {$lang->cmd_no}</label>
+				<label for="smtp_secure_ssl" class="x_inline"><input type="radio" name="smtp_secure" id="smtp_secure_ssl" value="ssl" checked="checked"|cond="$smtp_secure=='ssl'" /> {$lang->smtp_secure_ssl}</label>
+				<label for="smtp_secure_tls" class="x_inline"><input type="radio" name="smtp_secure" id="smtp_secure_tls" value="tls" checked="checked"|cond="$smtp_secure=='tls'" /> {$lang->smtp_secure_tls}</label>
+			</div>
+		</div>
+		<div class="x_control-group smtp">			
+			<label class="x_control-label">{$lang->smtp_username}</label>
+			<div class="x_controls">
+				<input type="text" name="smtp_username" id="smtp_username" value="{$smtp_username}"/>
+			</div>
+		</div>
+		<div class="x_control-group smtp">			
+			<label class="x_control-label">{$lang->smtp_password}</label>
+			<div class="x_controls">
+				<input type="password" name="smtp_password" id="smtp_password" value="{$smtp_password}" autocomplete="off" />
+			</div>
+		</div>
 		<div class="x_clearfix btnArea">
 			<div class="x_pull-right">
 				<button type="submit" class="x_btn x_btn-primary">{$lang->cmd_save}</button>

--- a/modules/admin/tpl/js/config.js
+++ b/modules/admin/tpl/js/config.js
@@ -4,6 +4,26 @@ jQuery(function($){
 	});
 });
 
+jQuery(document).ready( function() {
+	
+	if (jQuery('input[name=use_smtp]:checked').val() == 'N')
+	{
+		jQuery('.smtp').hide();
+	}
+		
+	jQuery('input[name=use_smtp]:radio').change( function(){
+		if (jQuery('input[name=use_smtp]:checked').val() == 'Y')
+		{
+			jQuery('.smtp').show();
+		}
+		else
+		{
+			jQuery('.smtp').hide();
+		}
+	});
+	
+});
+
 function setStartModule(){
 	var target_module = jQuery('.moduleIdList option:selected').text();
 	var index_module_srl = jQuery('.moduleIdList').val();

--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -99,6 +99,14 @@ class installAdminController extends install
 		$use_html5 = Context::get('use_html5');
 		if(!$use_html5) $use_html5 = 'N';
 
+		$use_smtp = Context::get('use_smtp');
+		if($use_smtp!='Y') $use_smtp = 'N';
+		$smtp_host = Context::get('smtp_host');
+		$smtp_port = Context::get('smtp_port');
+		$smtp_secure = Context::get('smtp_secure');
+		$smtp_username = Context::get('smtp_username');
+		$smtp_password = Context::get('smtp_password');
+		
 		$db_info->default_url = $default_url;
 		$db_info->qmail_compatibility = $qmail_compatibility;
 		$db_info->use_db_session = $use_db_session;
@@ -107,6 +115,13 @@ class installAdminController extends install
 		$db_info->use_ssl = $use_ssl;
 		$db_info->use_html5 = $use_html5;
 		$db_info->admin_ip_list = $admin_ip_list;
+		$db_info->use_smtp = $use_smtp;
+		$db_info->smtp_provider = $smtp_provider;
+		$db_info->smtp_host = $smtp_host;
+		$db_info->smtp_port = $smtp_port;
+		$db_info->smtp_secure = $smtp_secure;
+		$db_info->smtp_username = $smtp_username;
+		$db_info->smtp_password = $smtp_password;
 
 		if($http_port) $db_info->http_port = (int) $http_port;
 		else if($db_info->http_port) unset($db_info->http_port);


### PR DESCRIPTION
가입한 회원수로는 약 20만명정도 되는 커뮤니티를 관리하고 있다보니 회원가입 또는 비밀번호 찾기를 할 때 이메일을 받지 못했다는 문의가 많이 들어옵니다. 대다수의 경우에는 스팸함에 있기도 하지만 종종 제대로 전달이 안 되는 것 같기도 하고 실제로 어떤 이메일이 발송되었는지 확인하기도 쉽진 않고요. sendmail로 보내는 이메일의 한계인 것 같아서 SMTP를 통해 이메일을 보낼 수 있는 기능을 추가해보았습니다.
설정 폼을 관리자 페이지 내에 어디에 추가해야 할까 고민하다가 고급 설정 아래에 두었습니다.