### PR TITLE
불필요한 익명 함수 제거

### DIFF
--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -328,8 +328,7 @@ class DB
 
 			unset($oDB);
 			require_once($class_file);
-			$tmp_fn = create_function('', "return new {$class_name}();");
-			$oDB = $tmp_fn();
+			$oDB = new $class_name();
 
 			if(!$oDB)
 			{

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -1060,14 +1060,13 @@ class ModuleHandler extends Handler
 				return NULL;
 			}
 
-			// Create an instance with eval function
+			// Create an instance
 			require_once($class_file);
 			if(!class_exists($instance_name, false))
 			{
 				return NULL;
 			}
-			$tmp_fn = create_function('', "return new {$instance_name}();");
-			$oModule = $tmp_fn();
+			$oModule = new $instance_name();
 			if(!is_object($oModule))
 			{
 				return NULL;

--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -724,22 +724,19 @@ function zdate($str, $format = 'Y-m-d H:i:s', $conversion = TRUE)
 		$month = (int) substr($str, 4, 2);
 		$day = (int) substr($str, 6, 2);
 
-		// leading zero?
-		$lz = create_function('$n', 'return ($n>9?"":"0").$n;');
-
 		$trans = array(
 			'Y' => $year,
-			'y' => $lz($year % 100),
-			'm' => $lz($month),
+			'y' => sprintf('%02d', $year % 100),
+			'm' => sprintf('%02d', $month),
 			'n' => $month,
-			'd' => $lz($day),
+			'd' => sprintf('%02d', $day),
 			'j' => $day,
 			'G' => $hour,
-			'H' => $lz($hour),
+			'H' => sprintf('%02d', $hour),
 			'g' => $hour % 12,
-			'h' => $lz($hour % 12),
-			'i' => $lz($min),
-			's' => $lz($sec),
+			'h' => sprintf('%02d', $hour % 12),
+			'i' => sprintf('%02d', $min),
+			's' => sprintf('%02d', $sec),
 			'M' => getMonthName($month),
 			'F' => getMonthName($month, FALSE)
 		);

--- a/modules/editor/editor.model.php
+++ b/modules/editor/editor.model.php
@@ -550,8 +550,7 @@ class editorModel extends editor
 			if(!file_exists($class_file)) return new Object(-1, sprintf(Context::getLang('msg_component_is_not_founded'), $component));
 			// Create an object after loading the class file
 			require_once($class_file);
-			$tmp_fn = create_function('$seq,$path', "return new {$component}(\$seq,\$path);");
-			$oComponent = $tmp_fn($editor_sequence, $class_path);
+			$oComponent = new $component($editor_sequence, $class_path);
 			if(!$oComponent) return new Object(-1, sprintf(Context::getLang('msg_component_is_not_founded'), $component));
 			// Add configuration information
 			$component_info = $this->getComponent($component, $site_srl);


### PR DESCRIPTION
혹시 벌써 PHP 5.3 클로져를 사용하는 코드가 있나 살펴보다가 (실망스럽게도 없더군요) 불필요한 `create_function()` 몇 개를 발견했습니다.
- `new $class_name()` 문법은 PHP 4에서는 지원되지 않았지만 PHP 5에서는 아무 문제가 없으므로 굳이 성능이 떨어지는 익명 함수를 사용하여 우회할 필요가 없습니다.
- `zdate()` 함수에서 한자리수 날짜 앞에 0을 붙여 두자리수로 바꾸는 데 사용하는 익명 함수는 훨씬 간단하고 성능도 좋은 `sprintf()`로 변경하였습니다.
- `Validator` 클래스에서 사용하는 익명 함수는 딱히 클로져로 바꾸기도 뭣해서 그냥 두었습니다.
