### PR TITLE
#1367 한메일로 메일 발송시 CRLF 줄바꿈 버그 우회

### DIFF
--- a/classes/mail/Mail.class.php
+++ b/classes/mail/Mail.class.php
@@ -553,7 +553,7 @@ class Mail extends PHPMailer
 		if($this->Mailer == "mail")
 		{
 			$boundary = '----==' . uniqid(rand(), TRUE);
-			$this->eol = $GLOBALS['_qmail_compatibility'] == "Y" ? "\n" : "\r\n";
+			$this->eol = (preg_match('/@(daum|hanmail2?).net$/i', $this->receiptor_email) || $GLOBALS['_qmail_compatibility'] == "Y") ? "\n" : "\r\n";
 			$this->header = "Content-Type: multipart/alternative;" . $this->eol . "\tboundary=\"" . $boundary . "\"" . $this->eol . $this->eol;
 			$this->body = sprintf(
 					"--%s" . $this->eol .


### PR DESCRIPTION
https://www.xpressengine.com/index.php?mid=forum&document_srl=22971987

발송하는 서버의 MTA가 Postfix인 경우 한메일에서 CRLF를 정상적으로 인식하지 못해 헤더 사이에 한 줄이 비어버린다는 제보가 있습니다. 그래서 받는이의 메일 주소가 한메일(hanmail.net, hanmail2.net, duam.net)인 경우 Qmail 호환기능을 강제로 활성화시켜 줄바꿈을 LF로 통일하도록 해보았습니다.

그러나 다른 MTA 사용시 문제 발생의 소지가 있고, 한메일을 자기 도메인에 연결하여 쓰는 경우에 대해서는 여전히 대책이 없으므로 좀더 근본적인 해결책이 필요할 것 같습니다. 더 좋은 의견이 있는 분은 알려주세요.
