### PR TITLE
인증메일의 유효기간을 24시간으로 제한

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1279,6 +1279,12 @@ class memberController extends member
 		if(!$output->data || !$output->data[0]->auth_key)  return new Object(-1, 'msg_invalid_request');
 		$auth_info = $output->data[0];
 
+		// Update the regdate of authmail entry
+		$renewal_args = new stdClass;
+		$renewal_args->member_srl = $member_info->member_srl;
+		$renewal_args->auth_key = $auth_info->auth_key;
+		$output = executeQuery('member.updateAuthMail', $renewal_args);		
+
 		$memberInfo = array();
 		global $lang;
 		if(is_array($member_config->signupForm))

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -72,6 +72,11 @@ class memberController extends member
 			}
 		}
 
+		// Delete all previous authmail if login is successful
+		$args = new stdClass();
+		$args->member_srl = $this->memberInfo->member_srl;
+		executeQuery('member.deleteAuthMail', $args);
+
 		if(!$config->after_login_url)
 		{
 			$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('', 'mid', Context::get('mid'), 'act', '');
@@ -1125,6 +1130,12 @@ class memberController extends member
 				executeQuery('member.deleteAuthMail', $args);
 			}
 
+			return $this->stop('msg_invalid_auth_key');
+		}
+
+		if(ztime($output->data->regdate) < $_SERVER['REQUEST_TIME'] + zgap() - 86400)
+		{
+			executeQuery('member.deleteAuthMail', $args);
 			return $this->stop('msg_invalid_auth_key');
 		}
 


### PR DESCRIPTION
ID/PW찾기를 클릭했다가 비번이 기억나서 그냥 로그인하거나, 비슷한 메일주소를 가진 사람이 있는 경우 그 사람이 내 계정으로 ID/PW찾기를 시도하는 경우가 가끔 있죠. 타인의 계정을 탈취할 생각으로 일부러 계정찾기를 해보는 경우도 있겠고요.

이런 경우 대부분 인증메일을 무시하면 그만입니다. 그러나 XE는 인증메일에 유효기간이 없더군요. 제가 테스트해 보니 심지어 3년 전에 생성된 인증메일을 갖고도 비번 리셋이 가능합니다. 이건 보안상 좋지 않다고 생각됩니다.

그래서 인증메일을 통해 발송되는 인증키(auth_key)의 유효기간을 24시간으로 제한하고, 성공적으로 로그인할 경우 이전에 발급했던 인증키를 모두 삭제하는 기능을 넣어 보았습니다. 인증키의 유효기간이 지난 경우에는 ID/PW찾기 페이지로 들어가서 다시 발급받으면 됩니다.

가입인증의 경우에도 유효기간이 동일하게 24시간으로 적용되나, 유효기간이 지난 후에도 인증메일 재발송을 하면 다시 24시간 연장할 수 있습니다. 물론 인증을 완료하고 성공적으로 로그인하면 기존의 인증키는 삭제되어 더이상 사용하거나 연장할 수 없게 됩니다.
