### PR TITLE
잘못된 쿼리 ID 수정

### DIFF
--- a/modules/member/queries/chkAuthMail.xml
+++ b/modules/member/queries/chkAuthMail.xml
@@ -1,4 +1,4 @@
-<query id="getAuthMail" action="select">
+<query id="chkAuthMail" action="select">
     <tables>
         <table name="member_auth_mail" />
     </tables>


### PR DESCRIPTION
@YJSoft 님이 발견하신 버그인데, `chkAuthMail` XML 파일에 쿼리 ID가 잘못 지정되어 있습니다.
