### PR TITLE
PHP 5.5 이상에서 캐시파일 변경시 opcache_invalidate() 호출

### DIFF
--- a/classes/cache/CacheFile.class.php
+++ b/classes/cache/CacheFile.class.php
@@ -78,6 +78,10 @@ class CacheFile extends CacheBase
 		$content[] = 'if(!defined(\'__XE__\')) { exit(); }';
 		$content[] = 'return \'' . addslashes(serialize($obj)) . '\';';
 		FileHandler::writeFile($cache_file, implode(PHP_EOL, $content));
+		if(function_exists('opcache_invalidate'))
+		{
+			@opcache_invalidate($cache_file, true);
+		}
 	}
 
 	/**
@@ -139,6 +143,10 @@ class CacheFile extends CacheBase
 	function _delete($_key)
 	{
 		$cache_file = $this->getCacheFileName($_key);
+		if(function_exists('opcache_invalidate'))
+		{
+			@opcache_invalidate($cache_file, true);
+		}
 		FileHandler::removeFile($cache_file);
 	}
 


### PR DESCRIPTION
PHP 5.5 이상, opcache가 설치된 서버에서 파일 캐시를 사용할 경우 발생하는 문제입니다. 관리모듈에서 사이트 설정이나 모듈 설정을 변경하고 "저장"을 클릭하면 변경내역이 바로 적용되지 않고 예전의 값으로 돌아간 것처럼 보입니다. 약 3초 후에 페이지를 새로고침하면 변경내역이 적용된 상태로 나타나고요.

APC 등 과거의 옵코드 캐시와 달리, opcache는 PHP 파일이 변경되더라도 일정 시간이 지나기 전에는 다시 컴파일하지 않기 때문에 이런 현상이 발생합니다. 우분투 서버에서는 기본값이 2초입니다. 캐시파일이 변경되더라도 2초간은 예전의 내용이 계속 읽혀지는 거죠.

opcache가 설치된 서버에서 파일 캐시 핸들러의 `put` 또는 `delete` 메소드를 호출하면 변경 또는 삭제된 파일을 즉시 opcache에서 삭제하여 재컴파일을 요구하도록 조치하였습니다. 파일 캐시 핸들러 외에도 PHP 파일을 작성한 후 곧바로 다시 include하여 사용하는 경우 언제든지 똑같은 문제가 발생할 수 있지만, 일단 가장 많이 사용하는 캐시 핸들러부터 수정하는 것이 좋겠습니다.
