### PR TITLE
PBKDF2 해시 생성시 솔트의 엔트로피 개선

### DIFF
--- a/classes/security/Password.class.php
+++ b/classes/security/Password.class.php
@@ -111,7 +111,7 @@ class Password
 
 			case 'pbkdf2':
 				$iterations = pow(2, $this->getWorkFactor() + 5);
-				$salt = $this->createSecureSalt(12);
+				$salt = $this->createSecureSalt(12, 'alnum');
 				$hash = base64_encode($this->pbkdf2($password, $salt, 'sha256', $iterations, 24));
 				return 'sha256:'.sprintf('%07d', $iterations).':'.$salt.':'.$hash;
 


### PR DESCRIPTION
PBKDF2 해시 생성에 사용되는 솔트가 16진수(`0-9`, `a-f`)로 인코딩되어 있어서 엔트로피가 글자당 4비트밖에 되지 않습니다. 안 그래도 DB의 비번 컬럼 길이 제한 때문에 솔트를 12글자로 줄여 쓰고 있는데... 총 48비트는 좀 그렇네요 ㅡ.ㅡ;; (bcrypt의 솔트는 무려 128비트입니다.)

그래서 솔트 생성 포맷을 `alnum`으로 바꾸어 글자당 6비트, 총 72비트의 엔트로피를 가지도록 수정합니다. 원래 이렇게 쓰는 게 정상인데 어딘가에서 실수가 있었던 것 같네요. (`createSecureSalt()` 메소드의 기본값을 바꿔놓고 잊어버린 듯...)
