### PR TITLE
#1370 불필요한 PHP4용 코드 삭제

### DIFF
--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -314,11 +314,6 @@ class DB
 		{
 			$db_type = $supported_list[$i];
 
-			if(version_compare(phpversion(), '5.0') < 0 && preg_match('/pdo/i', $db_type))
-			{
-				continue;
-			}
-
 			$class_name = sprintf("DB%s%s", strtoupper(substr($db_type, 0, 1)), strtolower(substr($db_type, 1)));
 			$class_file = sprintf(_XE_PATH_ . "classes/db/%s.class.php", $class_name);
 			if(!file_exists($class_file))

--- a/classes/mail/Mail.class.php
+++ b/classes/mail/Mail.class.php
@@ -1,14 +1,7 @@
 <?php
 /* Copyright (C) NAVER <http://www.navercorp.com> */
 
-if(version_compare(PHP_VERSION, '5.0.0', '>='))
-{
-	require_once _XE_PATH_ . "libs/phpmailer/phpmailer.php";
-}
-else
-{
-	require_once _XE_PATH_ . "libs/phpmailer/class.phpmailer.php";
-}
+require_once _XE_PATH_ . "libs/phpmailer/phpmailer.php";
 
 /**
  * Mailing class for XpressEngine


### PR DESCRIPTION
XE 최소 PHP 버전이 5.3임에도 남아있는 PHP5 미만용 코드를 삭제하였습니다.
다만 파일은 서드파티 자료 등에서 사용될 수 있으므로 삭제하지 않았습니다.
