### PR TITLE
#1384 모바일 환경에서는 무조건 CKEditor를 활성화하도록 수정

### DIFF
--- a/modules/editor/tpl/js/editor.app.js
+++ b/modules/editor/tpl/js/editor.app.js
@@ -65,6 +65,8 @@
 
 			this.editor_sequence = data.editorSequence;
 			$form.attr('editor_sequence', data.editorSequence);
+			
+			if(CKEDITOR.env.mobile) CKEDITOR.env.isCompatible = true;
 
 			var instance = CKEDITOR.appendTo($containerEl[0], {}, $contentField.val());
 


### PR DESCRIPTION
임시방편이지만 모바일 환경은 무조건 사용 가능하도록 설정함으로 안드로이드 브라우저에서 뜨지 않는 문제를 수정하였습니다.

안드로이드 4.1.2 기본 브라우저와 모바일 크롬에서 테스트하였습니다.
