### PR TITLE
모바일뷰 사용 안 할때 (반응형등에서)  '모바일에서 최적화된 화면으로 보기' 가 나오는 버그 패치 

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -667,7 +667,8 @@ class ModuleHandler extends Handler
 				'dispEditorConfigPreview' => 1,
 				'dispLayoutPreviewWithModule' => 1
 		);
-		if($type == "view" && $this->module_info->use_mobile == "Y" && Mobile::isMobileCheckByAgent() && !isset($skipAct[Context::get('act')]))
+		$db_info = Context::getDBInfo();
+		if($type == "view" && $this->module_info->use_mobile == "Y" && Mobile::isMobileCheckByAgent()  && $db_info->use_mobile_view == "Y" && !isset($skipAct[Context::get('act')]))
 		{
 			global $lang;
 			$header = '<style>div.xe_mobile{opacity:0.7;margin:1em 0;padding:.5em;background:#333;border:1px solid #666;border-left:0;border-right:0}p.xe_mobile{text-align:center;margin:1em 0}a.xe_mobile{color:#ff0;font-weight:bold;font-size:24px}@media only screen and (min-width:500px){a.xe_mobile{font-size:15px}}</style>';


### PR DESCRIPTION
'모바일에서 최적화된 화면으로 보기' 를 출력하는 부분에서 각 모듈의 '모바일뷰'설정만 고려하고, 실제 사이트 전체의  '일반->설정' 부분에서의 '모바일뷰' 사용을 고려하지 않아 생기는 버그
 
 
