### PR TITLE
등록된 슬라이더 이미지가 없는 경우 데모 슬라이더를 대신 보여주도록 수정

### DIFF
--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -294,16 +294,9 @@
 	<div cond="$layout_info->layout_type === 'main' && $_enable_slide" class="visual">
 			<!-- 슬라이드 -->
 			<div class="camera_wrap">
-			<!--@if($_sample_slide)-->
+			<!--@if($_sample_slide || !$layout_info->slide_img1)-->
 				<include target="./demo/slide.html" />
 			<!--@else-->
-				<div data-src="{$layout_info->slide_img1}">
-					<div class="camera_caption fadeIn">
-						<div class="camera_caption_wrap">
-							설정되지 않음
-						</div>
-					</div>
-				</div>
 				<div cond="$layout_info->slide_img1" data-src="{$layout_info->slide_img1}">
 					<div cond="$layout_info->slide_text1" class="camera_caption fadeIn">
 						<div class="camera_caption_wrap">


### PR DESCRIPTION
등록된 슬라이더 이미지가 없는 경우(첫번째 이미지가 비어 있는 경우) 데모 슬라이더를 대신 보여주도록 수정하였습니다.
추가로 하드코딩된 "설정되지 않음"을 삭제하였습니다(이것 때문에 첫번째 슬라이더가 두번 보이는 문제점이 있습니다)