### PR TITLE
첫번째 슬라이더 이미지가 두번 출력되는 문제 수정

### DIFF
--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -297,13 +297,6 @@
 			<!--@if($_sample_slide)-->
 				<include target="./demo/slide.html" />
 			<!--@else-->
-				<div data-src="{$layout_info->slide_img1}">
-					<div class="camera_caption fadeIn">
-						<div class="camera_caption_wrap">
-							설정되지 않음
-						</div>
-					</div>
-				</div>
 				<div cond="$layout_info->slide_img1" data-src="{$layout_info->slide_img1}">
 					<div cond="$layout_info->slide_text1" class="camera_caption fadeIn">
 						<div class="camera_caption_wrap">


### PR DESCRIPTION
강제로 {$layout_info->slide_img1} 를 불러오는 부분이 있어 첫번째 이미지가 무조건 두번 뜨는 현상을 수정하였습니다.
