### PR TITLE
포인트 모듈에서 그룹연동 부분 설정 지워지지 않는 버그 수정 

### DIFF
--- a/modules/point/point.admin.controller.php
+++ b/modules/point/point.admin.controller.php
@@ -68,7 +68,7 @@ class pointAdminController extends point
 			}
 
 			//if group level is lower than 1, change to 1
-			if(($args->{'point_group_'.$group_srl} && $args->{'point_group_'.$group_srl} < 1)
+			if($args->{'point_group_'.$group_srl} && $args->{'point_group_'.$group_srl} < 1)
 			{
 				$args->{'point_group_'.$group_srl} = 1;
 			}

--- a/modules/point/point.admin.controller.php
+++ b/modules/point/point.admin.controller.php
@@ -68,7 +68,7 @@ class pointAdminController extends point
 			}
 
 			//if group level is lower than 1, change to 1
-			if($args->{'point_group_'.$group_srl} < 1)
+			if(($args->{'point_group_'.$group_srl} && $args->{'point_group_'.$group_srl} < 1)
 			{
 				$args->{'point_group_'.$group_srl} = 1;
 			}


### PR DESCRIPTION
포인트 모듈에서,  그룹연동 부분에서 저장을 누르면 무조건  모든 그룹이 1레벨로 설정이 된다.
또한 설정된 레벨을 지우고 저장해도 무조건 1레벨로 저장된다. (삭제가 안 된다)

설정 안 된 모든 그룹이 레벨1로 연결이 되면서
누구든 레벨이 상승하면,  레벨포인트와 그룹연동이 작동해,  결국 비설정된 모든 그룹의 권한을 갖게 되는 버그가 발생

1 이하의 수는 무조건 1로 인식되도록 처리되어있는 부붙을
값이 있는 경우에만 적용되도록 변경
