### PR TITLE
XEDITON에서 로고 텍스트 표시

### DIFF
--- a/layouts/xedition/css/layout.css
+++ b/layouts/xedition/css/layout.css
@@ -35,6 +35,8 @@ a:hover,a:active,a:focus{text-decoration:none}
 /* Header */
 .header>h1{float:left;padding:20px 0;margin-right:32px;line-height:60px;}
 .header>h1 img{vertical-align:middle; max-height:40px; }
+.header>.logo-item a{font-size:24px;color:#888}
+.header>.logo-item a:hover{color:#444}
 
 /* Fixed Header */
 .container.fixed_header{padding-top:100px}

--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -453,8 +453,8 @@
 						<p class="error">{$XE_VALIDATOR_MESSAGE}</p>
 					</div>
 					<div class="control-group">
-						<label class="chk_label" for="keepid">
-							<input type="checkbox" name="keep_signed" id="keepid" />
+						<label class="chk_label" for="keepid_opt">
+							<input type="checkbox" name="keep_signed" id="keepid_opt" />
 							<span class="checkbox"></span> {$lang->keep_signed}
 						</label>
 						<div id="warning">

--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -178,7 +178,7 @@
 			<!--// LOGO -->
 			<h1 class="logo-item">
 				{@ $_logo_img = $layout_info->logo_img}
-				<block cond="$_magazine_header && $layout_info->logo_img_magazine">
+				<block cond="$_magazine_header">
 					{@ $_logo_img = $layout_info->logo_img_magazine}
 				</block>
 				<a href="<!--@if($layout_info->logo_url)-->{$layout_info->logo_url}<!--@else-->{getUrl('')}<!--@end-->">
@@ -192,10 +192,14 @@
 							<img src="{$_logo_img}" data-logo="{$layout_info->logo_img}"|cond="$_onepage_header && $layout_info->logo_img_transparent" alt="{$layout_info->logo_text}" />
 						<!--@endif-->
 					<!--@else-->
-						{@ $_logo_img = 'logo.png'}
-						<block cond="$_magazine_header">{@ $_logo_img = 'm_logo.png'}</block>
-						<block cond="$_onepage_header">{@ $_logo_img = 's_logo.png'}</block>
-						<img src="{$layout_info->path}img/{$_logo_img}" data-logo="{$layout_info->path}img/logo.png"|cond="$_onepage_header" alt="XEDITION" />
+						<!--@if($layout_info->logo_text)-->
+							{$layout_info->logo_text}
+						<!--@else-->
+							{@ $_logo_img = 'logo.png'}
+							<block cond="$_magazine_header">{@ $_logo_img = 'm_logo.png'}</block>
+							<block cond="$_onepage_header">{@ $_logo_img = 's_logo.png'}</block>
+							<img src="{$layout_info->path}img/{$_logo_img}" data-logo="{$layout_info->path}img/logo.png"|cond="$_onepage_header" alt="XEDITION" />
+						<!--@endif-->
 					<!--@end-->
 				</a>
 			</h1>

--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -453,8 +453,8 @@
 						<p class="error">{$XE_VALIDATOR_MESSAGE}</p>
 					</div>
 					<div class="control-group">
-						<label class="chk_label" for="keepid_opt">
-							<input type="checkbox" name="keep_signed" id="keepid_opt" />
+						<label class="chk_label" for="keepid">
+							<input type="checkbox" name="keep_signed" id="keepid" />
 							<span class="checkbox"></span> {$lang->keep_signed}
 						</label>
 						<div id="warning">


### PR DESCRIPTION
- 기능 개선 건의

기존 - 사용자가 로고 이미지 지정하지 않은 경우 XEDTION default 로고 이미지 표시

변경 
1. 로고 이미지 없는 경우 -> "사이트 로고 문자"(텍스트)를 표시
1-1. 기본형, 투명형, 매거진형의 메뉴타입에 따른 각 로고 이미지가 없는 경우 -> 사이트 로고 문자를 표시
2. 로고 이미지 및 사이트 로고 문자가 모두 없는 경우 XEDTION default 로고 이미지 표시
