### PR TITLE
PHP 5.4 이상에서는 magic_quotes_gpc 상태를 체크하지 않음

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1380,7 +1380,7 @@ class Context
 			{
 				$result[$k] = $v;
 
-				if($do_stripslashes && version_compare(PHP_VERSION, '5.9.0', '<') && get_magic_quotes_gpc())
+				if($do_stripslashes && version_compare(PHP_VERSION, '5.4.0', '<') && get_magic_quotes_gpc())
 				{
 					$result[$k] = stripslashes($result[$k]);
 				}

--- a/classes/db/DBCubrid.class.php
+++ b/classes/db/DBCubrid.class.php
@@ -116,7 +116,7 @@ class DBCubrid extends DB
 	 */
 	function addQuotes($string)
 	{
-		if(version_compare(PHP_VERSION, "5.9.0", "<") &&
+		if(version_compare(PHP_VERSION, "5.4.0", "<") &&
 				get_magic_quotes_gpc())
 		{
 			$string = stripslashes(str_replace("\\", "\\\\", $string));

--- a/classes/db/DBMssql.class.php
+++ b/classes/db/DBMssql.class.php
@@ -99,7 +99,7 @@ class DBMssql extends DB
 	 */
 	function addQuotes($string)
 	{
-		if(version_compare(PHP_VERSION, "5.9.0", "<") && get_magic_quotes_gpc())
+		if(version_compare(PHP_VERSION, "5.4.0", "<") && get_magic_quotes_gpc())
 		{
 			$string = stripslashes(str_replace("\\", "\\\\", $string));
 		}

--- a/classes/db/DBMysql.class.php
+++ b/classes/db/DBMysql.class.php
@@ -131,7 +131,7 @@ class DBMysql extends DB
 	 */
 	function addQuotes($string)
 	{
-		if(version_compare(PHP_VERSION, "5.9.0", "<") && get_magic_quotes_gpc())
+		if(version_compare(PHP_VERSION, "5.4.0", "<") && get_magic_quotes_gpc())
 		{
 			$string = stripslashes(str_replace("\\", "\\\\", $string));
 		}

--- a/classes/db/DBMysqli.class.php
+++ b/classes/db/DBMysqli.class.php
@@ -87,7 +87,7 @@ class DBMysqli extends DBMysql
 	 */
 	function addQuotes($string)
 	{
-		if(version_compare(PHP_VERSION, "5.9.0", "<") && get_magic_quotes_gpc())
+		if(version_compare(PHP_VERSION, "5.4.0", "<") && get_magic_quotes_gpc())
 		{
 			$string = stripslashes(str_replace("\\", "\\\\", $string));
 		}

--- a/classes/db/DBMysqli_innodb.class.php
+++ b/classes/db/DBMysqli_innodb.class.php
@@ -145,7 +145,7 @@ class DBMysqli_innodb extends DBMysql
 	 */
 	function addQuotes($string)
 	{
-		if(version_compare(PHP_VERSION, "5.9.0", "<") && get_magic_quotes_gpc())
+		if(version_compare(PHP_VERSION, "5.4.0", "<") && get_magic_quotes_gpc())
 		{
 			$string = stripslashes(str_replace("\\", "\\\\", $string));
 		}

--- a/modules/module/module.admin.controller.php
+++ b/modules/module/module.admin.controller.php
@@ -685,7 +685,7 @@ class moduleAdminController extends module
 			$args->value = trim(Context::get($key));
 
 			// if request method is json, strip slashes
-			if(Context::getRequestMethod() == 'JSON' && version_compare(PHP_VERSION, "5.9.0", "<") && get_magic_quotes_gpc())
+			if(Context::getRequestMethod() == 'JSON' && version_compare(PHP_VERSION, "5.4.0", "<") && get_magic_quotes_gpc())
 			{
 				$args->value = stripslashes($args->value);
 			}

--- a/tools/dbxml_validator/connect_wrapper.php
+++ b/tools/dbxml_validator/connect_wrapper.php
@@ -347,7 +347,7 @@ class DBMysqliConnectWrapper extends DBMysqli
 		*/
 	public function addQuotes($string)
 	{
-		if(version_compare(PHP_VERSION, "5.9.0", "<") && get_magic_quotes_gpc())
+		if(version_compare(PHP_VERSION, "5.4.0", "<") && get_magic_quotes_gpc())
 		{
 			$string = stripslashes(str_replace("\\", "\\\\", $string));
 		}


### PR DESCRIPTION
현재 PHP 5.9.0 이상에서 체크하지 않도록 되어 있는데, 그런 버전은 존재하지도 않습니다.

`magic_quotes_gpc`는 PHP 5.4에서 제거된 기능으로, 버전 체크를 정확하게 하면 불필요한 함수 호출을 방지할 수 있겠습니다.
