### PR TITLE
회원가입 및 정보수정시 필터링 강화

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -2199,6 +2199,19 @@ class memberController extends member
 			$args->user_id = $orgMemberInfo->user_id;
 		}
 
+		// Check if ID is prohibited
+		if($args->user_id && $oMemberModel->isDeniedID($args->user_id))
+		{
+			return new Object(-1,'denied_user_id');
+		}
+
+		// Check if ID is duplicate
+		$member_srl = $oMemberModel->getMemberSrlByUserID($args->user_id);
+		if($member_srl && $orgMemberInfo->user_id != $args->user_id)
+		{
+			return new Object(-1,'msg_exists_user_id');
+		}
+
 		// Check if nickname is prohibited
 		if($args->nick_name && $oMemberModel->isDeniedNickName($args->nick_name))
 		{

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -2199,6 +2199,11 @@ class memberController extends member
 
 		list($args->email_id, $args->email_host) = explode('@', $args->email_address);
 		// Website, blog, checks the address
+		$args->user_id = htmlspecialchars($args->user_id, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->user_name = htmlspecialchars($args->user_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->nick_name = htmlspecialchars($args->nick_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->homepage = htmlspecialchars($args->homepage, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->blog = htmlspecialchars($args->blog, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
 		if($args->homepage && !preg_match("/^[a-z]+:\/\//is",$args->homepage)) $args->homepage = 'http://'.$args->homepage;
 		if($args->blog && !preg_match("/^[a-z]+:\/\//is",$args->blog)) $args->blog = 'http://'.$args->blog;
 

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -326,7 +326,7 @@ class memberController extends member
 		{
 			if(isset($args->{$val}))
 			{
-				$args->{$val} = preg_replace('/[\pZ\pC]+/', '', $$args->{$val});
+				$args->{$val} = preg_replace('/[\pZ\pC]+/', '', $args->{$val});
 			}
 		}
 		$output = $this->insertMember($args);
@@ -538,7 +538,7 @@ class memberController extends member
 		{
 			if(isset($args->{$val}))
 			{
-				$args->{$val} = preg_replace('/[\pZ\pC]+/', '', $$args->{$val});
+				$args->{$val} = preg_replace('/[\pZ\pC]+/', '', $args->{$val});
 			}
 		}
 

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1985,7 +1985,12 @@ class memberController extends member
 
 		list($args->email_id, $args->email_host) = explode('@', $args->email_address);
 
-		// Website, blog, checks the address
+		// Sanitize user ID, username, nickname, homepage, blog
+		$args->user_id = htmlspecialchars($args->user_id, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->user_name = htmlspecialchars($args->user_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->nick_name = htmlspecialchars($args->nick_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->homepage = htmlspecialchars($args->homepage, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->blog = htmlspecialchars($args->blog, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
 		if($args->homepage && !preg_match("/^[a-z]+:\/\//i",$args->homepage)) $args->homepage = 'http://'.$args->homepage;
 		if($args->blog && !preg_match("/^[a-z]+:\/\//i",$args->blog)) $args->blog = 'http://'.$args->blog;
 
@@ -2042,9 +2047,6 @@ class memberController extends member
 
 		// Insert data into the DB
 		$args->list_order = -1 * $args->member_srl;
-		$args->nick_name = htmlspecialchars($args->nick_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		$args->homepage = htmlspecialchars($args->homepage, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		$args->blog = htmlspecialchars($args->blog, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
 
 		if(!$args->user_id) $args->user_id = 't'.$args->member_srl;
 		if(!$args->user_name) $args->user_name = $args->member_srl;

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -321,13 +321,12 @@ class memberController extends member
 		$args->extra_vars = serialize($extra_vars);
 
 		// remove whitespace
-		$checkInfos = array('user_id', 'nick_name', 'email_address');
-		$replaceStr = array("\r\n", "\r", "\n", " ", "\t", "\xC2\xAD");
+		$checkInfos = array('user_id', 'user_name', 'nick_name', 'email_address');
 		foreach($checkInfos as $val)
 		{
 			if(isset($args->{$val}))
 			{
-				$args->{$val} = str_replace($replaceStr, '', $args->{$val});
+				$args->{$val} = preg_replace('/[\pZ\pC]+/', '', $$args->{$val});
 			}
 		}
 		$output = $this->insertMember($args);
@@ -534,13 +533,12 @@ class memberController extends member
 		$args->extra_vars = serialize($extra_vars);
 
 		// remove whitespace
-		$checkInfos = array('user_id', 'nick_name', 'email_address');
-		$replaceStr = array("\r\n", "\r", "\n", " ", "\t", "\xC2\xAD");
+		$checkInfos = array('user_id', 'user_name', 'nick_name', 'email_address');
 		foreach($checkInfos as $val)
 		{
 			if(isset($args->{$val}))
 			{
-				$args->{$val} = str_replace($replaceStr, '', $args->{$val});
+				$args->{$val} = preg_replace('/[\pZ\pC]+/', '', $$args->{$val});
 			}
 		}
 

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -2168,6 +2168,15 @@ class memberController extends member
 			}
 		}
 
+		// Sanitize user ID, username, nickname, homepage, blog
+		$args->user_id = htmlspecialchars($args->user_id, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->user_name = htmlspecialchars($args->user_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->nick_name = htmlspecialchars($args->nick_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->homepage = htmlspecialchars($args->homepage, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$args->blog = htmlspecialchars($args->blog, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		if($args->homepage && !preg_match("/^[a-z]+:\/\//is",$args->homepage)) $args->homepage = 'http://'.$args->homepage;
+		if($args->blog && !preg_match("/^[a-z]+:\/\//is",$args->blog)) $args->blog = 'http://'.$args->blog;
+
 		// check member identifier form
 		$config = $oMemberModel->getMemberConfig();
 
@@ -2198,15 +2207,6 @@ class memberController extends member
  		if($member_srl && $orgMemberInfo->nick_name != $args->nick_name) return new Object(-1,'msg_exists_nick_name');
 
 		list($args->email_id, $args->email_host) = explode('@', $args->email_address);
-		// Website, blog, checks the address
-		$args->user_id = htmlspecialchars($args->user_id, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		$args->user_name = htmlspecialchars($args->user_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		$args->nick_name = htmlspecialchars($args->nick_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		$args->homepage = htmlspecialchars($args->homepage, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		$args->blog = htmlspecialchars($args->blog, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-		if($args->homepage && !preg_match("/^[a-z]+:\/\//is",$args->homepage)) $args->homepage = 'http://'.$args->homepage;
-		if($args->blog && !preg_match("/^[a-z]+:\/\//is",$args->blog)) $args->blog = 'http://'.$args->blog;
-
 
 		$oDB = &DB::getInstance();
 		$oDB->begin();


### PR DESCRIPTION
회원가입(`insertMember`) 및 정보수정(`updateMember`)시 아이디, 이름, 닉네임 등의 필터링 정책에 일관성이 없어서 태그를 입력하거나 고의로 닉네임 중복을 일으킬 수 있는 문제가 있습니다.
1. DB에 저장할 때는 태그를 필터링하지만, 중복 여부를 체크할 때는 필터링하기 전의 변수값을 비교합니다. 그래서 `<`, `>`, `&` 등의 특수문자를 잘 활용하면 중복체크를 우회할 수 있습니다.
2. 아이디와 닉네임에는 공백이 허용되지 않지만, 유니코드의 다양한 공백 문자 및 컨트롤 문자들을 모두 필터링하지 못하므로 공백을 사용한 닉네임 중복이 가능합니다. (어제 공홈에서 이런 일이 있었죠.)
3. 회원정보 수정시에는 금지된 ID 및 중복 ID 체크가 이루어지지 않습니다. ID는 변경할 수 없다고 가정하는 모양인데, 이걸 우회하는 것도 어렵지 않더군요. 관리자가 직접 회원정보를 수정하다가 실수로 중복을 일으키는 경우도 있겠고요.
4. 모든 변수에 완벽하게 `htmlspecialchars()` 적용이 되지 않아서 일부 회원정보를 이용한 태그 삽입이 가능합니다. 엄격한 길이 제한 때문에 당장 XSS 취약점으로 이어지지는 않으나, 회원들이 멋대로 자기 닉네임을 **진하게** 표시하는 등 귀찮은 일이 생길 수 있습니다.

이 PR에서는 위와 같은 문제들을 해결하고, 앞으로의 유지관리 편의를 위해 관련 루틴들의 코딩 스타일을 XE 코딩규칙에 맞게 다소 손보았습니다. `if`문이 어디서 끝나는지 한 눈에 알기 어려운 곳이 꽤 많더라고요. 실제 코드와 동떨어진 내용의 주석들도 고쳤습니다.
