### PR TITLE
Magic Hash 취약점으로 인한 무단 로그인 방지

### DIFF
--- a/classes/db/DBMysql.class.php
+++ b/classes/db/DBMysql.class.php
@@ -265,7 +265,7 @@ class DBMysql extends DB
 		$query = sprintf("select password('%s') as password, old_password('%s') as old_password", $this->addQuotes($password), $this->addQuotes($password));
 		$result = $this->_query($query);
 		$tmp = $this->_fetch($result);
-		if($tmp->password == $saved_password || $tmp->old_password == $saved_password)
+		if($tmp->password === $saved_password || $tmp->old_password === $saved_password)
 		{
 			return true;
 		}


### PR DESCRIPTION
취약점 안내) https://blog.whitehatsec.com/magic-hashes/ 

XE 1.8 버전에서는 기존 비밀번호가 mysql_old_password 인 경우에 한해 발생 가능성이 있습니다.
따라서 비밀번호 해시 비교시 동등 연산자(==) 대신 일치 연산자(===)로 수정하였습니다.
