### PR TITLE
Fix #1477 프로토콜 상대주소 처리 개선

### DIFF
--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -347,7 +347,7 @@ class FrontEndFileHandler extends Handler
 		}
 		elseif(!strncmp($path, '//', 2))
 		{
-			return $path;
+			return preg_replace('#^//+#', '//', $path);
 		}
 
 		$path = preg_replace('@/\./|(?<!:)\/\/@', '/', $path);


### PR DESCRIPTION
#1290 에서 `//`로 시작하는 프로토콜 상대주소를 사용할 수 있도록 했지만, 여전히 여러 모듈과 애드온들이 예전의 버그를 우회하기 위해 `///`로 시작하는 상대주소를 사용하고 있습니다. 그래서 #1477 과 같은 문제가 발생하고요.

그래서 `///`로 시작하는 예전 방식의 상대주소를 사용할 경우 자동으로 `//`로 변환해 주어 XE 1.8에서도 정상적으로 작동하도록 고쳤습니다.
