### PR TITLE
질문/답변을 통한 계정 찾기를 금지하는 옵션 추가

### DIFF
--- a/modules/member/lang/lang.xml
+++ b/modules/member/lang/lang.xml
@@ -2378,6 +2378,14 @@
 		<value xml:lang="zh-CN"><![CDATA[请登录后更改密码。]]></value>
 		<value xml:lang="tr"><![CDATA[Giriş yaptıktan sonra şifrenizi değiştirin.]]></value>
 	</item>
+	<item name="msg_question_not_allowed">
+		<value xml:lang="ko"><![CDATA[질문/답변을 통한 비밀번호 찾기는 허용되지 않습니다.]]></value>
+		<value xml:lang="en"><![CDATA[The administrator has disabled this function.]]></value>
+		<value xml:lang="jp"><![CDATA[質問/回答を通じたパスワードを忘れたことはできません。]]></value>
+		<value xml:lang="zh-TW"><![CDATA[问题/通过回答密码是不允许的。]]></value>
+		<value xml:lang="zh-CN"><![CDATA[問題/通過回答密碼是不允許的。]]></value>
+		<value xml:lang="tr"><![CDATA[Sorular / Cevaplar aracılığıyla Şifre izin verilmez.]]></value>
+	</item>
 	<item name="msg_question_not_exists">
 		<value xml:lang="ko"><![CDATA[등록한 비밀번호 찾기 질문/답변이 없습니다.]]></value>
 		<value xml:lang="en"><![CDATA[You haven`t set your question for a temporary password.]]></value>

--- a/modules/member/lang/lang.xml
+++ b/modules/member/lang/lang.xml
@@ -475,6 +475,17 @@
 		<value xml:lang="tr"><![CDATA[E-posta Doğrulaması]]></value>
 		<value xml:lang="vi"><![CDATA[Xác nhận qua Email]]></value>
 	</item>
+	<item name="enable_find_account_question">
+		<value xml:lang="ko"><![CDATA[질문/답변 인증 사용]]></value>
+		<value xml:lang="en"><![CDATA[Account recovery using question/answer]]></value>
+		<value xml:lang="jp"><![CDATA[秘密質問/回答認証を使用]]></value>
+		<value xml:lang="zh-CN"><![CDATA[使用问题/答案认证]]></value>
+		<value xml:lang="zh-TW"><![CDATA[使用問題/答案認證]]></value>
+		<value xml:lang="fr"><![CDATA[Utiliser Authentification par question et réponse]]></value>
+		<value xml:lang="ru"><![CDATA[Активация по вопроса и ответа]]></value>
+		<value xml:lang="tr"><![CDATA[Soru ve cevap ile kimlik doğrulamasını kullanmak]]></value>
+		<value xml:lang="vi"><![CDATA[Xác nhận qua câu hỏi và câu trả lời]]></value>
+	</item>
 	<item name="enable_ssl">
 		<value xml:lang="ko"><![CDATA[SSL 기능 사용]]></value>
 		<value xml:lang="en"><![CDATA[Enable SSL]]></value>
@@ -2008,6 +2019,17 @@
 		<value xml:lang="es"><![CDATA[입력된 메일 주소로 인증 메일을 보내 회원 가입을 확인합니다]]></value>
 		<value xml:lang="tr"><![CDATA[Yeni üyelerin hesaplarını e-posta yoluyla etkinleştirmelerini istiyorsanız lütfen işaretleyiniz.]]></value>
 		<value xml:lang="vi"><![CDATA[Gửi Email xác nhận sau khi đăng kí.]]></value>
+	</item>
+	<item name="about_enable_find_account_question">
+		<value xml:lang="ko"><![CDATA[질문/답변을 통한 비밀번호 찾기를 허용합니다. 허용하지 않을 경우 메일을 통한 비밀번호 리셋만 허용됩니다.]]></value>
+		<value xml:lang="en"><![CDATA[Check if you want to allow members to recover their accounts using a security question and answer.]]></value>
+		<value xml:lang="jp"><![CDATA[質問/回答を通じたパスワードを忘れたを許可します。許可しない場合は、メールを介してリセットのみが許可されます。]]></value>
+		<value xml:lang="zh-CN"><![CDATA[允许使用成员答问恢复帐户。如果不允许，会员可以通过电子邮件恢复。]]></value>
+		<value xml:lang="zh-TW"><![CDATA[允許使用成員答問恢復帳戶。如果不允許，會員可以通過電子郵件恢復。]]></value>
+		<value xml:lang="fr"><![CDATA[Vérifiez si vous voulez permettre aux membres de récupérer leurs comptes en utilisant une question et réponse de sécurité.]]></value>
+		<value xml:lang="es"><![CDATA[Compruebe si desea permitir a los miembros a recuperar sus cuentas utilizando una pregunta y respuesta de seguridad.]]></value>
+		<value xml:lang="tr"><![CDATA[Eğer üye bir güvenlik sorusu ve cevabı kullanarak hesaplarını kurtarmak için izin istiyorum kontrol edin.]]></value>
+		<value xml:lang="vi"><![CDATA[Kiểm tra nếu bạn muốn cho phép các thành viên để phục hồi tài khoản của họ bằng cách sử dụng một câu hỏi bảo mật và câu trả lời.]]></value>
 	</item>
 	<item name="about_enable_ssl">
 		<value xml:lang="ko"><![CDATA[서버에서 보안접속(SSL) 지원이 될 경우 회원가입, 정보수정, 로그인 등의 개인정보가 서버로 보내질 때 SSL(https)을 이용하도록 할 수 있습니다.]]></value>

--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -157,6 +157,7 @@ class memberAdminController extends member
 		$args = Context::gets(
 			'enable_join',
 			'enable_confirm',
+			'enable_find_account_question',
 			'webmaster_name',
 			'webmaster_email',
 			'password_strength',

--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -255,7 +255,7 @@ class memberAdminController extends member
 		global $lang;
 		$signupForm = array();
 		$items = array('user_id', 'password', 'user_name', 'nick_name', 'email_address', 'find_account_question', 'homepage', 'blog', 'birthday', 'signature', 'profile_image', 'image_name', 'image_mark', 'profile_image_max_width', 'profile_image_max_height', 'image_name_max_width', 'image_name_max_height', 'image_mark_max_width', 'image_mark_max_height');
-		$mustRequireds = array('email_address', 'nick_name', 'password', 'find_account_question');
+		$mustRequireds = array('email_address', 'nick_name', 'password');
 		$extendItems = $oMemberModel->getJoinFormList();
 		foreach($list_order as $key)
 		{
@@ -409,9 +409,9 @@ class memberAdminController extends member
 		$extendItems = $oMemberModel->getJoinFormList();
 
 		$items = array('user_id', 'password', 'user_name', 'nick_name', 'email_address', 'find_account_question', 'homepage', 'blog', 'birthday', 'signature', 'profile_image', 'image_name', 'image_mark');
-		$mustRequireds = array('email_address', 'nick_name','password', 'find_account_question');
-		$orgRequireds = array('email_address', 'password', 'find_account_question', 'user_id', 'nick_name', 'user_name');
-		$orgUse = array('email_address', 'password', 'find_account_question', 'user_id', 'nick_name', 'user_name', 'homepage', 'blog', 'birthday');
+		$mustRequireds = array('email_address', 'nick_name', 'password');
+		$orgRequireds = array('email_address', 'password', 'user_id', 'nick_name', 'user_name');
+		$orgUse = array('email_address', 'password', 'user_id', 'nick_name', 'user_name', 'homepage', 'blog', 'birthday');
 		$list_order = array();
 
 		foreach($items as $key)

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1048,6 +1048,10 @@ class memberController extends member
 	{
 		$oMemberModel = getModel('member');
 		$config = $oMemberModel->getMemberConfig();
+		if($config->enable_find_account_question != 'Y')
+		{
+			return new Object(-1, 'msg_question_not_allowed');
+		}
 
 		$email_address = Context::get('email_address');
 		$user_id = Context::get('user_id');

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -526,6 +526,7 @@ class memberView extends member
 		$config = $this->member_config;
 
 		Context::set('identifier', $config->identifier);
+		Context::set('enable_find_account_question', $config->enable_find_account_question);
 
 		$this->setTemplateFile('find_member_account');
 	}

--- a/modules/member/skins/default/find_member_account.html
+++ b/modules/member/skins/default/find_member_account.html
@@ -18,8 +18,8 @@
 		</span>
 	</form>
 </section>
-<hr>
-<section cond="count($lang->find_account_question_items)>1">
+<hr cond="count($lang->find_account_question_items)>1 && $enable_find_account_question == 'Y'">
+<section cond="count($lang->find_account_question_items)>1 && $enable_find_account_question == 'Y'">
 	<h1>{$lang->cmd_find_member_account_with_email_question}</h1>
 	<p>{$lang->about_find_account_question}</p>
 	<div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/member/skin/default/find_member_account/2'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">

--- a/modules/member/tpl/default_config.html
+++ b/modules/member/tpl/default_config.html
@@ -21,6 +21,14 @@
 		</div>
 	</div>
 	<div class="x_control-group">
+		<div class="x_control-label">{$lang->enable_find_account_question}</div>
+		<div class="x_controls">
+			<label class="x_inline" for="enable_find_account_question_yes"><input type="radio" name="enable_find_account_question" id="enable_find_account_question_yes" value="Y" checked="checked"|cond="$config->enable_find_account_question == 'Y'" /> {$lang->cmd_yes}</label>
+			<label class="x_inline" for="enable_find_account_question_no"><input type="radio" name="enable_find_account_question" id="enable_find_account_question_no" value="N" checked="checked"|cond="$config->enable_find_account_question != 'Y'"/> {$lang->cmd_no}</label>
+			<p class="x_help-block">{$lang->about_enable_find_account_question}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
 		<div class="x_control-label">{$lang->cmd_config_password_strength}</div>
 		<div class="x_controls">
 			<label class="x_inline" for="password_strength1"><input type="radio" name="password_strength" id="password_strength1" value="low" checked="checked"|cond="$config->password_strength == 'low'" /> {$lang->password_strength_low}({$lang->about_password_strength['low']})</label><br>

--- a/modules/member/tpl/js/signup_config.js
+++ b/modules/member/tpl/js/signup_config.js
@@ -66,6 +66,7 @@ jQuery(function($){
 
 	suForm.find(':checkbox[name="usable_list[]"]').each(function(){
 		var $i = $(this);
+		if($i.val() == 'find_account_question') return;
 
 		$i.change(function(){
 			changeTable($i);


### PR DESCRIPTION
@misol

며칠 전 뉴스에 따르면 [구글이 '보안 질문' 기능을 없앤다고 합니다.](http://news.naver.com/main/read.nhn?mode=LSD&mid=sec&oid=001&aid=0007611541&sid1=001) 답을 짐작하기가 너무 쉽기 때문인데요... XE로 사이트를 운영하시는 분들 중에도 아마 보안상 이 기능을 꺼버리고 싶은 분들이 있을 것 같습니다. 그러나 현재는 비번찾기 질문/답변 항목이 필수로 하드코딩되어 있어서 쉽게 건드리기가 어렵습니다.

이 PR은 비번찾기 질문/답변 기능 사용 여부를 관리자가 선택할 수 있도록 합니다.
- 회원가입 설정에서 비번찾기 질문/답변 항목의 사용 여부 및 필수 여부를 선택할 수 있습니다.
- 질문/답변을 통한 계정 찾기를 허용하지 않도록 설정할 수 있습니다.
- 허용하지 않도록 설정할 경우 ID/PW 찾기 화면에 해당 폼이 나타나지도 않고, 억지로 해당 act를 호출하더라도 작동하지 않습니다.
- 허용하지 않더라도 여전히 메일을 통한 비번 리셋을 요청할 수 있고, 메일에 포함된 링크를 클릭하면 비번이 리셋됩니다.
- 허용하지 않는 것이 기본값입니다.
