### PR TITLE
autoloader에서 누락된 클래스 추가

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -296,6 +296,7 @@ if(!defined('__XE_LOADED_CLASS__'))
 	}
 
 	$GLOBALS['__xe_autoload_file_map'] = array_change_key_case(array(
+		'CacheBase' => 'classes/cache/CacheHandler.class.php',
 		'CacheHandler' => 'classes/cache/CacheHandler.class.php',
 		'Context' => 'classes/context/Context.class.php',
 		'DB' => 'classes/db/DB.class.php',
@@ -330,6 +331,7 @@ if(!defined('__XE_LOADED_CLASS__'))
 		'XMLDisplayHandler' => 'classes/display/XMLDisplayHandler.php',
 		'EditorHandler' => 'classes/editor/EditorHandler.class.php',
 		'ExtraVar' => 'classes/extravar/Extravar.class.php',
+		'ExtraItem' => 'classes/extravar/Extravar.class.php',
 		'FileHandler' => 'classes/file/FileHandler.class.php',
 		'FileObject' => 'classes/file/FileObject.class.php',
 		'FrontEndFileHandler' => 'classes/frontendfile/FrontEndFileHandler.class.php',


### PR DESCRIPTION
한 파일에서 2개 이상의 클래스를 선언할 경우, 오토로더에 첫 번째 클래스만 등록되었습니다.

그래서 두 번째 클래스를 먼저 호출할 경우 클래스가 존재하지 않는다는 에러가 발생합니다.
#1513 이슈를 해결합니다.
