### PR TITLE
#574 회원 그룹의 이미지 마크 설정 해제를 가능하게 합니다

### DIFF
--- a/modules/member/tpl/group_list.html
+++ b/modules/member/tpl/group_list.html
@@ -92,6 +92,13 @@
 		<h1>{$lang->group_image_mark} {$lang->cmd_setup}</h1>
 	</div>
 	<div class="x_modal-body">
+		<div class="_useImageMark x_control-group" style="display:none">
+			<p>{$lang->use_group_image_mark}</p>
+			<label for="useImageMark" class="x_inline"><input id="useImageMark" type="radio" name="useImageMark" value="Y" />
+			{$lang->use}</label>
+			<label for="noImageMark" class="x_inline"><input id="noImageMark" type="radio" name="useImageMark" value="N" />
+			{$lang->notuse}</label>
+		</div>
 		<block cond="$fileBoxList">
 			<p>{$lang->usable_group_image_mark_list}</p>
 			<div class="filebox_list">


### PR DESCRIPTION
1363af7c23f61e8bf9e26165a7584d1f8fac00f9 (이전 google code svn 기준 r11778) 이후 해당 부분이 삭제되었습니다.

`<block cond="$fileBoxList">`윗부분에

``` html
<div class="_useImageMark x_control-group" style="display:none">
    <p>{$lang->use_group_image_mark}</p>
    <label for="useImageMark" class="x_inline"><input id="useImageMark" type="radio" name="useImageMark" value="Y" />
    {$lang->use}</label>
    <label for="noImageMark" class="x_inline"><input id="noImageMark" type="radio" name="useImageMark" value="N" />
    {$lang->notuse}</label>
</div>
```

를 넣으면 다시 정상적으로 그룹 아이콘 삭제가 가능합니다.
![image](https://cloud.githubusercontent.com/assets/5893514/7964678/03ef914a-0a54-11e5-97d9-434915d144d5.png)

이는 js파일에 해당 부분을 처리하는 코드가 남아 있기 때문으로, 아마

``` html
<span class="x_pull-right" style="position:relative;top:7px">
    {$lang->use_group_image_mark}: 
    <label for="yes" class="x_inline"><input type="radio" name="group_image_mark" id="yes" value="Y" checked="checked"|cond="$config->group_image_mark == 'Y'" /> {$lang->cmd_yes}</label>
    <label for="no" class="x_inline"><input type="radio" name="group_image_mark" id="no" value="N" checked="checked"|cond="$config->group_image_mark != 'Y'" /> {$lang->cmd_no}</label>
</span>
```

이 코드와 중복되는 것으로 오인되어 삭제된 것 같으나 확실하지는 않습니다.

이 PR은 사라진 부분을 다시 복원해 줍니다. 
