### PR TITLE
XEDITON에서 로고 텍스트 표시

### DIFF
--- a/layouts/xedition/css/layout.css
+++ b/layouts/xedition/css/layout.css
@@ -35,6 +35,8 @@ a:hover,a:active,a:focus{text-decoration:none}
 /* Header */
 .header>h1{float:left;padding:20px 0;margin-right:32px;line-height:60px;}
 .header>h1 img{vertical-align:middle; max-height:40px; }
+.header>.logo-item a{font-size:24px;color:#888}  
+.header>.logo-item a:hover{color:#444}  
 
 /* Fixed Header */
 .container.fixed_header{padding-top:100px}

--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -185,16 +185,14 @@
 				<block cond="$_magazine_header && $layout_info->logo_img_magazine">
 					{@ $_logo_img = $layout_info->logo_img_magazine}
 				</block>
+				<block cond="$_onepage_header && $layout_info->logo_img_transparent">
+					{@ $_logo_img = $layout_info->logo_img_transparent}
+				</block>
 				<a href="<!--@if($layout_info->logo_url)-->{$layout_info->logo_url}<!--@else-->{getUrl('')}<!--@end-->">
 					<!--@if($_logo_img)-->
-						<!--@if($_magazine_header)-->
-							<img src="{$layout_info->logo_img_magazine}" alt="{$layout_info->logo_text}" />
-						<!--@else-->
-							<block cond="$_onepage_header && $layout_info->logo_img_transparent">
-								{@ $_logo_img = $layout_info->logo_img_transparent}
-							</block>
-							<img src="{$_logo_img}" data-logo="{$layout_info->logo_img}"|cond="$_onepage_header && $layout_info->logo_img_transparent" alt="{$layout_info->logo_text}" />
-						<!--@endif-->
+						<img src="{$_logo_img}" data-logo="{$layout_info->logo_img}"|cond="$_onepage_header && $layout_info->logo_img_transparent" alt="{$layout_info->logo_text}" />
+					<!--@elseif($layout_info->logo_text)-->
+						{$layout_info->logo_text}
 					<!--@else-->
 						{@ $_logo_img = 'logo.png'}
 						<block cond="$_magazine_header">{@ $_logo_img = 'm_logo.png'}</block>


### PR DESCRIPTION
- 기능 개선 건의

기존 - 사용자가 로고 이미지 지정하지 않은 경우 XEDTION default 로고 이미지 표시

변경 
1. 메뉴 타입별 사용자가 지정한 로고 이미지 있는 경우 -> 그 이미지를 표시
2. 사용자가 지정한 로고 이미지 없는 경우 -> "사이트 로고 문자"(텍스트)를 표시
3. 로고 이미지 및 사이트 로고 문자가 모두 없는 경우 -> XEDTION default 로고 이미지 표시
