### PR TITLE
HTML 사용 권한이 반영되지 않는 문제 수정

### DIFF
--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -69,6 +69,10 @@
 		<!--@if($module_type === 'comment')-->
 			settings.ckeconfig.toolbarStartupExpanded = false;
 		<!--@endif-->
+		
+		<!--@if(!$html_mode)-->
+			settings.ckeconfig.removeButtons = 'Save,Preview,Print,Cut,Copy,Paste,Source';
+		<!--@endif-->
 
 		<!--@if($css_content)-->CKEDITOR.addCss('{$css_content}');<!--@end-->
 


### PR DESCRIPTION
기존 XpressEditor에서는 HTML 사용 권한을 조절함으로 소스보기 기능을 제어할 수 있었으나 CKEditor에서는 불가능했습니다. 이를 고치는 PR입니다.
