### PR TITLE
#1532 CKEditor의 언어를 현재 언어로 맞춤

### DIFF
--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -40,7 +40,8 @@
 				skin: '{$colorset}',
 				contentsCss: '{$content_style_path}/editor.css',
 				xe_editor_sequence: {$editor_sequence},
-				toolbarCanCollapse: true
+				toolbarCanCollapse: true,
+				language: "{str_replace('jp','ja',$lang_type)}"
 			},
 			loadXeComponent: true,
 			enableToolbar: true,


### PR DESCRIPTION
XpressEditor와는 달리 CKEditor는 다국어를 지원함에도 XE의 다국어 설정과 연동되어 있지 않습니다.
XE의 다국어 상태에 맞추어 CKEditor의 언어도 바꿔 주는 PR입니다. 다만 XE의 언어코드중 일본어는 표준인 `ja`가 아닌 `jp`로 되어 있기에 이것만 ja로 바꿔 줍니다.( #1458 와 같은 방식입니다)
