### PR TITLE
FileHandler에서 존재하지 않는 메소드 호출 수정

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -527,7 +527,6 @@ class FileHandler
 			{
 				$oRequest = new HTTP_Request(__PROXY_SERVER__);
 				$oRequest->setMethod('POST');
-				$oRequest->_timeout = $timeout;
 				$oRequest->addPostData('arg', serialize(array('Destination' => $url, 'method' => $method, 'body' => $body, 'content_type' => $content_type, "headers" => $headers, "post_data" => $post_data)));
 			}
 			else
@@ -571,7 +570,15 @@ class FileHandler
 				if($body)
 					$oRequest->setBody($body);
 			}
-			$oRequest->setConfig('timeout', $timeout);
+			
+			if(method_exists($oRequest, 'setConfig'))
+			{
+				$oRequest->setConfig('timeout', $timeout);
+			}
+			elseif(property_exists($oRequest, '_timeout'))
+			{
+				$oRequest->_timeout = $timeout;
+			}
 
 			$oResponse = $oRequest->sendRequest();
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "codeception/codeception": "~2.0",


### PR DESCRIPTION
#1409 에서 timeout 설정을 반영하면서 PEAR 버전과 무관하게 항상 `setConfig()` 메소드를 호출하도록 코드가 작성되었으나, PEAR 버전에 따라 `HTTP_Request` 클래스에 이 메소드가 존재하지 않는 경우가 있습니다. (현재 XE에는 이 메소드가 존재하는 버전과 조재하지 않는 버전이 모두 포함되어 있습니다.)

그래서 이 메소드가 존재하지 않는 경우 기존의 방식대로 `_timeout` 속성을 사용하도록 수정했습니다.

참고: https://www.xpressengine.com/qna/23018863