### PR TITLE
PEAR 로딩시 기존의 include_path 설정을 덮어쓰지 않도록 변경

### DIFF
--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -1549,11 +1549,11 @@ function requirePear()
 {
 	if(version_compare(PHP_VERSION, "5.3.0") < 0)
 	{
-		set_include_path(_XE_PATH_ . "libs/PEAR");
+		set_include_path(_XE_PATH_ . "libs/PEAR" . PATH_SEPARATOR . get_include_path());
 	}
 	else
 	{
-		set_include_path(_XE_PATH_ . "libs/PEAR.1.9.5");
+		set_include_path(_XE_PATH_ . "libs/PEAR.1.9.5" . PATH_SEPARATOR . get_include_path());
 	}
 }
 


### PR DESCRIPTION
XE에 포함된 PEAR 라이브러리를 사용하기 위해 `requirePear()` 함수를 호출하면 기존의 `include_path`에 등록되어 있던 경로들을 모두 삭제하고 PEAR 로딩 경로만 덩그러니 남게 됩니다.

XE 내부적으로는 대체로 절대경로를 사용하여 인클루드하기 때문에 큰 문제가 없지만, 서드파티 프로그램이나 다른 라이브러리들과 연동할 때 문제가 발생할 수 있습니다.

PHP에서 `set_include_path()` 함수를 사용할 때는 반드시 `get_include_path()` 함수를 먼저 호출하여 기존의 경로 목록을 구한 후, 거기에 내가 원하는 경로를 덧붙이는 것이 정석입니다.

https://php.net/set_include_path 예제 참고.
