### PR TITLE
fix #1564 템플릿 문법에서 `$!varname` 으로 escape 가능하게 수정

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -827,9 +827,23 @@ class TemplateHandler
 		{
 			return '';
 		}
-		return preg_replace('@(?<!::|\\\\|(?<!eval\()\')\$([a-z]|_[a-z0-9])@i', '\$__Context->$1', $php);
+
+		return preg_replace_callback('@(?<!::|\\\\|(?<!eval\()\')\$([a-z!]|_[a-z0-9])@i', array($this,'_checkVar'), $php);
 	}
 
+	/**
+	 * check value name
+	 * @param string $m
+	 * @return string $__Context->varname or $varname
+	 */
+	function _checkVar($m) {
+        if(substr($m[1],0,1) === "!")
+        {
+            return '$' . substr_replace($m[1],"",0,1);
+        }
+        
+        return '$__Context->' . $m[1];
+    }
 }
 /* End of File: TemplateHandler.class.php */
 /* Location: ./classes/template/TemplateHandler.class.php */


### PR DESCRIPTION
`$__Context->varname`으로 replace가 필요치 않은 값은 `$!varname`으로 처리를 우회할 수 있게
변경하였습니다.

다음은 변경전과 변경후 속도 차이를 테스트한 결과입니다.(임의의 문자열을 변환하는 코드 작성후 테스트하였으며, 변환문 이외 다른점은 없습니다. 실행 당시 상태에 따라 값이 달라질 수 있습니다.)

[변경전](http://3v4l.org/smnDn/perf#tabs)
![image](https://cloud.githubusercontent.com/assets/5893514/8322134/7f8c218e-1a6b-11e5-8529-6bb057628f2e.png)

[변경후](http://3v4l.org/dcSgQ/perf#tabs)
![image](https://cloud.githubusercontent.com/assets/5893514/8322118/52ee9760-1a6b-11e5-8cd4-a06325d2198c.png)