### PR TITLE
fix #1564 템플릿 문법의 변수 replace 부분 escape 문법 추가

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -597,9 +597,9 @@ class TemplateHandler
 				$echo = '';
 				$m[1] = substr($m[1], 1);
 			}
-			elseif(substr($m[1],0,4) == '@ //!//')
+			elseif(substr($m[1],0,7) == '@ //!//')
 			{
-				$m[1] = substr($m[1], 5);
+				$m[1] = substr($m[1], 8);
 				return '<?php ' . $echo . $m[1] . ' ?>';
 			}
 			return '<?php ' . $echo . $this->_replaceVar($m[1]) . ' ?>';

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -592,15 +592,17 @@ class TemplateHandler
 			}
 
 			$echo = 'echo ';
+
+			if(substr($m[1],0,7) == '@ //!//')
+			{
+				$m[1] = substr($m[1], 8);
+				return '<?php ' . $echo . $m[1] . ' ?>';
+			}
+
 			if($m[1]{0} == '@')
 			{
 				$echo = '';
 				$m[1] = substr($m[1], 1);
-			}
-			elseif(substr($m[1],0,7) == '@ //!//')
-			{
-				$m[1] = substr($m[1], 8);
-				return '<?php ' . $echo . $m[1] . ' ?>';
 			}
 			return '<?php ' . $echo . $this->_replaceVar($m[1]) . ' ?>';
 		}

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -581,6 +581,9 @@ class TemplateHandler
 	private function _parseResource($m)
 	{
 		// {@ ... } or {$var} or {func(...)}
+		// or {@ //!//
+		//    ...
+		//    }
 		if($m[1])
 		{
 			if(preg_match('@^(\w+)\(@', $m[1], $mm) && !function_exists($mm[1]))
@@ -593,6 +596,11 @@ class TemplateHandler
 			{
 				$echo = '';
 				$m[1] = substr($m[1], 1);
+			}
+			elseif(substr($m[1],0,4) == '@ //!//')
+			{
+				$m[1] = substr($m[1], 5);
+				return '<?php ' . $echo . $m[1] . ' ?>';
 			}
 			return '<?php ' . $echo . $this->_replaceVar($m[1]) . ' ?>';
 		}


### PR DESCRIPTION
```
{@ //!//
...
}
```
와 같이 변수가 $__Context->varname 으로 컴파일 되는 것을 escape할 수 있습니다.
기존 버전에서도 `//!//` 부분은 주석으로 처리되기에, 기존 버전에서도 오류가 발생되지 않습니다.