### PR TITLE
모듈 에러 메시지에 HTTP 상태 코드를 표시하도록 하는 PR

### DIFF
--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -195,12 +195,12 @@ class ModuleObject extends Object
 			{
 				case 'root' :
 				case 'manager' :
-					$this->stop('msg_is_not_administrator');
+					$this->stop('msg_is_not_administrator', 403);
 					return;
 				case 'member' :
 					if(!$is_logged)
 					{
-						$this->stop('msg_not_permitted_act');
+						$this->stop('msg_not_permitted_act', 401);
 						return;
 					}
 					break;
@@ -222,9 +222,10 @@ class ModuleObject extends Object
 	/**
 	 * set the stop_proc and approprate message for msg_code
 	 * @param string $msg_code an error code
+	 * @param integer $http_code HTTP status codes
 	 * @return ModuleObject $this
 	 * */
-	function stop($msg_code)
+	function stop($msg_code, $http_code = 200)
 	{
 		// flag setting to stop the proc processing
 		$this->stop_proc = TRUE;
@@ -237,6 +238,10 @@ class ModuleObject extends Object
 		$oMessageObject->setError(-1);
 		$oMessageObject->setMessage($msg_code);
 		$oMessageObject->dispMessage();
+		if($http_code !== 200 && is_int($http_code))
+		{
+			$this->httpStatusCode = $http_code;
+		}
 
 		$this->setTemplatePath($oMessageObject->getTemplatePath());
 		$this->setTemplateFile($oMessageObject->getTemplateFile());
@@ -408,7 +413,7 @@ class ModuleObject extends Object
 			// Check permissions
 			if($this->module_srl && !$this->grant->access)
 			{
-				$this->stop("msg_not_permitted_act");
+				$this->stop("msg_not_permitted_act", 403);
 				return FALSE;
 			}
 

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -22,7 +22,7 @@ class adminAdminController extends admin
 		$logged_info = $oMemberModel->getLoggedInfo();
 		if($logged_info->is_admin != 'Y')
 		{
-			return $this->stop("msg_is_not_administrator");
+			return $this->stop("msg_is_not_administrator", 403);
 		}
 	}
 
@@ -35,7 +35,7 @@ class adminAdminController extends admin
 		$menuSrl = Context::get('menu_srl');
 		if(!$menuSrl)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		$oMenuAdminController = getAdminController('menu');

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -50,7 +50,7 @@ class adminAdminView extends admin
 		$logged_info = $oMemberModel->getLoggedInfo();
 		if($logged_info->is_admin != 'Y')
 		{
-			return $this->stop("msg_is_not_administrator");
+			return $this->stop("msg_is_not_administrator", 403);
 		}
 
 		// change into administration layout

--- a/modules/adminlogging/adminlogging.controller.php
+++ b/modules/adminlogging/adminlogging.controller.php
@@ -23,7 +23,7 @@ class adminloggingController extends adminlogging
 		$logged_info = $oMemberModel->getLoggedInfo();
 		if($logged_info->is_admin != 'Y')
 		{
-			return $this->stop("msg_is_not_administrator");
+			return $this->stop("msg_is_not_administrator", 403);
 		}
 	}
 

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -408,7 +408,7 @@ class autoinstallAdminView extends autoinstall
 
 		if(!$updateDate)
 		{
-			return $this->stop('msg_connection_fail');
+			return $this->stop('msg_connection_fail', 400);
 		}
 
 		$oModel = getModel('autoinstall');
@@ -528,13 +528,13 @@ class autoinstallAdminView extends autoinstall
 
 		if(!$type || $type == "core")
 		{
-			return $this->stop("msg_invalid_request");
+			return $this->stop("msg_invalid_request", 400);
 		}
 
 		$config_file = $oModel->getConfigFilePath($type);
 		if(!$config_file)
 		{
-			return $this->stop("msg_invalid_request");
+			return $this->stop("msg_invalid_request", 400);
 		}
 
 		$output = $oAdminModel->checkUseDirectModuleInstall($installedPackage);
@@ -568,7 +568,7 @@ class autoinstallAdminView extends autoinstall
 		}
 		else
 		{
-			return $this->stop('msg_connection_fail');
+			return $this->stop('msg_connection_fail', 400);
 		}
 	}
 

--- a/modules/autoinstall/autoinstall.class.php
+++ b/modules/autoinstall/autoinstall.class.php
@@ -76,7 +76,7 @@ class autoinstall extends ModuleObject
 		$config = $oModuleModel->getModuleConfig('autoinstall');
 		if($config->downloadServer != _XE_DOWNLOAD_SERVER_)
 		{
-			$this->stop('msg_not_match_server');
+			$this->stop('msg_not_match_server', 400);
 		}
 	}
 

--- a/modules/board/board.admin.view.php
+++ b/modules/board/board.admin.view.php
@@ -39,7 +39,7 @@ class boardAdminView extends board {
 			}
 		}
 
-		if($module_info && $module_info->module != 'board') return $this->stop("msg_invalid_request");
+		if($module_info && $module_info->module != 'board') return $this->stop("msg_invalid_request", 400);
 
 		// get the module category list
 		$module_category = $oModuleModel->getModuleCategories();

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -147,7 +147,7 @@ class boardView extends board
 		 **/
 		if(!$this->grant->access || !$this->grant->list)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		/**
@@ -261,7 +261,7 @@ class boardView extends board
 				// if the module srl is not consistent
 				if($oDocument->get('module_srl')!=$this->module_info->module_srl )
 				{
-					return $this->stop('msg_invalid_request');
+					return $this->stop('msg_invalid_request', 400);
 				}
 
 				// check the manage grant
@@ -291,7 +291,7 @@ class boardView extends board
 			{
 				// if the document is not existed, then alert a warning message
 				Context::set('document_srl','',true);
-				$this->alertMessage('msg_not_founded');
+				$this->alertMessage('msg_not_founded', 404);
 			}
 
 		/**
@@ -312,7 +312,7 @@ class boardView extends board
 			{
 				$oDocument = $oDocumentModel->getDocument(0);
 				Context::set('document_srl','',true);
-				$this->alertMessage('msg_not_permitted');
+				$this->alertMessage('msg_not_permitted', 403);
 			}
 			else
 			{
@@ -354,7 +354,7 @@ class boardView extends board
 		 **/
 		if(!$this->grant->access)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// check document view grant
@@ -374,7 +374,7 @@ class boardView extends board
 
 		if(is_array($file_module_config->download_grant) && $downloadGrantCount>0)
 		{
-			if(!Context::get('is_logged')) return $this->stop('msg_not_permitted_download');
+			if(!Context::get('is_logged')) return $this->stop('msg_not_permitted_download', 403);
 			$logged_info = Context::get('logged_info');
 			if($logged_info->is_admin != 'Y')
 			{
@@ -397,7 +397,7 @@ class boardView extends board
 							break;
 						}
 					}
-					if(!$is_permitted) return $this->stop('msg_not_permitted_download');
+					if(!$is_permitted) return $this->stop('msg_not_permitted_download', 403);
 				}
 			}
 		}
@@ -597,7 +597,7 @@ class boardView extends board
 		// check if there is not grant fot view list, then alert an warning message
 		if(!$this->grant->list)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// generate the tag module model object
@@ -639,7 +639,7 @@ class boardView extends board
 		// check grant
 		if(!$this->grant->write_document)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		$oDocumentModel = getModel('document');
@@ -711,7 +711,7 @@ class boardView extends board
 			{
 				if( !$logged_info )
 				{
-					return $this->dispBoardMessage('msg_not_permitted');
+					return $this->dispBoardMessage('msg_not_permitted', 403);
 				}
 				else if (($oPointModel->getPoint($logged_info->member_srl) + $pointForInsert )< 0 )
 				{
@@ -774,7 +774,7 @@ class boardView extends board
 		// check grant
 		if(!$this->grant->write_document)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// get the document_srl from request
@@ -824,7 +824,7 @@ class boardView extends board
 		// check grant
 		if(!$this->grant->write_comment)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// get the document information
@@ -868,7 +868,7 @@ class boardView extends board
 		// check grant
 		if(!$this->grant->write_comment)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// get the parent comment ID
@@ -928,7 +928,7 @@ class boardView extends board
 		// check grant
 		if(!$this->grant->write_comment)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// get the document_srl and comment_srl
@@ -977,7 +977,7 @@ class boardView extends board
 		// check grant
 		if(!$this->grant->write_comment)
 		{
-			return $this->dispBoardMessage('msg_not_permitted');
+			return $this->dispBoardMessage('msg_not_permitted', 403);
 		}
 
 		// get the comment_srl to be deleted
@@ -1050,23 +1050,37 @@ class boardView extends board
 
 	/**
 	 * @brief display board message
+	 * @param string $msg_code an error code
+	 * @param integer $http_code HTTP status codes
 	 **/
-	function dispBoardMessage($msg_code)
+	function dispBoardMessage($msg_code, $http_code = 200)
 	{
 		$msg = Context::getLang($msg_code);
 		if(!$msg) $msg = $msg_code;
 		Context::set('message', $msg);
 		$this->setTemplateFile('message');
+
+		if($http_code !== 200 && is_int($http_code))
+		{
+			$this->httpStatusCode = $http_code;
+		}
 	}
 
 	/**
 	 * @brief the method for displaying the warning messages
 	 * display an error message if it has not  a special design
+	 * @param string $msg_code an error code
+	 * @param integer $http_code HTTP status codes
 	 **/
-	function alertMessage($message)
+	function alertMessage($message, $http_code = 200)
 	{
 		$script =  sprintf('<script> jQuery(function(){ alert("%s"); } );</script>', Context::getLang($message));
 		Context::addHtmlFooter( $script );
+
+		if($http_code !== 200 && is_int($http_code))
+		{
+			$this->httpStatusCode = $http_code;
+		}
 	}
 
 }

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -56,7 +56,7 @@ class commentAdminController extends comment
 		$cart = Context::get('cart');
 		if(!$cart)
 		{
-			return $this->stop('msg_cart_is_null');
+			return $this->stop('msg_cart_is_null', 400);
 		}
 		if(!is_array($cart))
 		{
@@ -197,7 +197,7 @@ class commentAdminController extends comment
 		$cart = Context::get('cart');
 		if(!$cart)
 		{
-			return $this->stop('msg_cart_is_null');
+			return $this->stop('msg_cart_is_null', 400);
 		}
 		if(!is_array($cart))
 		{
@@ -210,7 +210,7 @@ class commentAdminController extends comment
 		$comment_count = count($comment_srl_list);
 		if(!$comment_count)
 		{
-			return $this->stop('msg_cart_is_null');
+			return $this->stop('msg_cart_is_null', 400);
 		}
 
 		$oCommentController = getController('comment');
@@ -355,7 +355,7 @@ class commentAdminController extends comment
 		$oCommentController = getController('comment');
 		$oComment = $oCommentModel->getComment($comment_srl, false);
 
-		if(!$oComment->isGranted()) return $this->stop('msg_not_permitted');
+		if(!$oComment->isGranted()) return $this->stop('msg_not_permitted', 403);
 
 		$message_content = "";
 		$this->_moveCommentToTrash(array($comment_srl), $oCommentController, $oDB, $message_content);

--- a/modules/communication/communication.mobile.php
+++ b/modules/communication/communication.mobile.php
@@ -41,13 +41,13 @@ class communicationMobile extends communicationView
 		// Error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');
 		if(!array_key_exists('dispCommunicationMessages', $logged_info->menu_list))
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		// Set the variables
@@ -72,21 +72,21 @@ class communicationMobile extends communicationView
 				case 'R':
 					if($message->receiver_srl != $logged_info->member_srl)
 					{
-						return $this->stop('msg_invalid_request');
+						return $this->stop('msg_invalid_request', 400);
 					}
 					break;
 
 				case 'S':
 					if($message->sender_srl != $logged_info->member_srl)
 					{
-						return $this->stop('msg_invalid_request');
+						return $this->stop('msg_invalid_request', 400);
 					}
 					break;
 
 				case 'T':
 					if($message->receiver_srl != $logged_info->member_srl && $message->sender_srl != $logged_info->member_srl)
 					{
-						return $this->stop('msg_invalid_request');
+						return $this->stop('msg_invalid_request', 400);
 					}
 					break;
 			}
@@ -140,7 +140,7 @@ class communicationMobile extends communicationView
 		// Error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');
@@ -150,13 +150,13 @@ class communicationMobile extends communicationView
 		$receiver_srl = Context::get('receiver_srl');
 		if(!$receiver_srl)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		// check receiver and sender are same
 		if($logged_info->member_srl == $receiver_srl)
 		{
-			return $this->stop('msg_cannot_send_to_yourself');
+			return $this->stop('msg_cannot_send_to_yourself', 400);
 		}
 
 		// get message_srl of the original message if it is a reply
@@ -175,7 +175,7 @@ class communicationMobile extends communicationView
 		$receiver_info = $oMemberModel->getMemberInfoByMemberSrl($receiver_srl);
 		if(!$receiver_info)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		Context::set('receiver_info', $receiver_info);

--- a/modules/communication/communication.view.php
+++ b/modules/communication/communication.view.php
@@ -53,14 +53,14 @@ class communicationView extends communication
 		// Error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');
 
 		if(!array_key_exists('dispCommunicationMessages', $logged_info->menu_list))
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		// Set the variables
@@ -86,21 +86,21 @@ class communicationView extends communication
 				case 'R':
 					if($message->receiver_srl != $logged_info->member_srl)
 					{
-						return $this->stop('msg_invalid_request');
+						return $this->stop('msg_invalid_request', 403);
 					}
 					break;
 
 				case 'S':
 					if($message->sender_srl != $logged_info->member_srl)
 					{
-						return $this->stop('msg_invalid_request');
+						return $this->stop('msg_invalid_request', 403);
 					}
 					break;
 
 				case 'T':
 					if($message->receiver_srl != $logged_info->member_srl && $message->sender_srl != $logged_info->member_srl)
 					{
-						return $this->stop('msg_invalid_request');
+						return $this->stop('msg_invalid_request', 403);
 					}
 					break;
 			}
@@ -141,7 +141,7 @@ class communicationView extends communication
 		// Error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');
@@ -180,7 +180,7 @@ class communicationView extends communication
 		// Error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');
@@ -190,13 +190,13 @@ class communicationView extends communication
 		$receiver_srl = Context::get('receiver_srl');
 		if(!$receiver_srl)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		// check receiver and sender are same
 		if($logged_info->member_srl == $receiver_srl)
 		{
-			return $this->stop('msg_cannot_send_to_yourself');
+			return $this->stop('msg_cannot_send_to_yourself', 400);
 		}
 
 		// get message_srl of the original message if it is a reply
@@ -215,7 +215,7 @@ class communicationView extends communication
 		$receiver_info = $oMemberModel->getMemberInfoByMemberSrl($receiver_srl);
 		if(!$receiver_info)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		Context::set('receiver_info', $receiver_info);
@@ -249,7 +249,7 @@ class communicationView extends communication
 		// Error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$oCommunicationModel = getModel('communication');
@@ -308,7 +308,7 @@ class communicationView extends communication
 		// error appears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');
@@ -316,7 +316,7 @@ class communicationView extends communication
 
 		if(!$target_srl)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		// get information of the member
@@ -326,7 +326,7 @@ class communicationView extends communication
 
 		if($communication_info->member_srl != $target_srl)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 403);
 		}
 
 		Context::set('target_info', $communication_info);
@@ -350,7 +350,7 @@ class communicationView extends communication
 		// error apprears if not logged-in
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$logged_info = Context::get('logged_info');

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -27,10 +27,10 @@ class documentAdminController extends document
 	{
 		// error appears if no doc is selected
 		$cart = Context::get('cart');
-		if(!$cart) return $this->stop('msg_cart_is_null');
+		if(!$cart) return $this->stop('msg_cart_is_null', 400);
 		$document_srl_list= explode('|@|', $cart);
 		$document_count = count($document_srl_list);
-		if(!$document_count) return $this->stop('msg_cart_is_null');
+		if(!$document_count) return $this->stop('msg_cart_is_null', 400);
 		// Delete a doc
 		$oDocumentController = getController('document');
 		for($i=0;$i<$document_count;$i++)

--- a/modules/document/document.view.php
+++ b/modules/document/document.view.php
@@ -154,7 +154,7 @@ class documentView extends document
 
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 401);
 		// Get the saved document (module_srl is set to member_srl instead)
 		$logged_info = Context::get('logged_info');
 		$args = new stdClass();

--- a/modules/file/file.admin.controller.php
+++ b/modules/file/file.admin.controller.php
@@ -62,11 +62,11 @@ class fileAdminController extends file
 	{
 		// An error appears if no document is selected
 		$cart = Context::get('cart');
-		if(!$cart) return $this->stop('msg_file_cart_is_null');
+		if(!$cart) return $this->stop('msg_file_cart_is_null', 400);
 		if(!is_array($cart)) $file_srl_list= explode('|@|', $cart);
 		else $file_srl_list = $cart;
 		$file_count = count($file_srl_list);
-		if(!$file_count) return $this->stop('msg_file_cart_is_null');
+		if(!$file_count) return $this->stop('msg_file_cart_is_null', 400);
 
 		$oFileController = getController('file');
 		// Delete the post

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -46,7 +46,7 @@ class fileController extends file
 
 		$output = $this->insertFile($file_info, $module_srl, $upload_target_srl);
 		Context::setResponseMethod('JSON');
-		if($output->error != '0') $this->stop($output->message);
+		if($output->error != '0') $this->stop($output->message, 400);
 	}
 
 	/**
@@ -172,9 +172,9 @@ class fileController extends file
 		$columnList = array('file_srl', 'sid', 'isvalid', 'source_filename', 'module_srl', 'uploaded_filename', 'file_size', 'member_srl', 'upload_target_srl', 'upload_target_type');
 		$file_obj = $oFileModel->getFile($file_srl, $columnList);
 		// If the requested file information is incorrect, an error that file cannot be found appears
-		if($file_obj->file_srl!=$file_srl || $file_obj->sid!=$sid) return $this->stop('msg_file_not_found');
+		if($file_obj->file_srl!=$file_srl || $file_obj->sid!=$sid) return $this->stop('msg_file_not_found', 404);
 		// Notify that file download is not allowed when standing-by(Only a top-administrator is permitted)
-		if($logged_info->is_admin != 'Y' && $file_obj->isvalid!='Y') return $this->stop('msg_not_permitted_download');
+		if($logged_info->is_admin != 'Y' && $file_obj->isvalid!='Y') return $this->stop('msg_not_permitted_download', 403);
 		// File name
 		$filename = $file_obj->source_filename;
 		$file_module_config = $oFileModel->getFileModuleConfig($file_obj->module_srl);
@@ -223,7 +223,7 @@ class fileController extends file
 				}
 				else $file_module_config->allow_outlink = 'Y';
 			}
-			if($file_module_config->allow_outlink != 'Y') return $this->stop('msg_not_allowed_outlink');
+			if($file_module_config->allow_outlink != 'Y') return $this->stop('msg_not_allowed_outlink', 403);
 		}
 
 		// Check if a permission for file download is granted
@@ -236,7 +236,7 @@ class fileController extends file
 
 		if(is_array($file_module_config->download_grant) && $downloadGrantCount>0)
 		{
-			if(!Context::get('is_logged')) return $this->stop('msg_not_permitted_download');
+			if(!Context::get('is_logged')) return $this->stop('msg_not_permitted_download', 403);
 			$logged_info = Context::get('logged_info');
 			if($logged_info->is_admin != 'Y')
 			{
@@ -265,7 +265,7 @@ class fileController extends file
 		}
 		// Call a trigger (before)
 		$output = ModuleHandler::triggerCall('file.downloadFile', 'before', $file_obj);
-		if(!$output->toBool()) return $this->stop(($output->message)?$output->message:'msg_not_permitted_download');
+		if(!$output->toBool()) return $this->stop(($output->message)?$output->message:'msg_not_permitted_download', 400);
 
 
 		// 다운로드 후 (가상)
@@ -298,12 +298,12 @@ class fileController extends file
 
 		$uploaded_filename = $file_obj->uploaded_filename;
 
-		if(!file_exists($uploaded_filename)) return $this->stop('msg_file_not_found');
+		if(!file_exists($uploaded_filename)) return $this->stop('msg_file_not_found', 404);
 
 		if(!$file_key || $_SESSION[$session_key][$file_srl] != $file_key)
 		{
 			unset($_SESSION[$session_key][$file_srl]);
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		$file_size = $file_obj->file_size;
@@ -324,7 +324,7 @@ class fileController extends file
 		Context::close();
 
 		$fp = fopen($uploaded_filename, 'rb');
-		if(!$fp) return $this->stop('msg_file_not_found');
+		if(!$fp) return $this->stop('msg_file_not_found', 404);
 
 		header("Cache-Control: ");
 		header("Pragma: ");
@@ -645,7 +645,7 @@ class fileController extends file
 
 					if(!in_array($uploaded_ext, $ext))
 					{
-						return $this->stop('msg_not_allowed_filetype');
+						return $this->stop('msg_not_allowed_filetype', 400);
 					}
 				}
 

--- a/modules/install/install.view.php
+++ b/modules/install/install.view.php
@@ -19,7 +19,7 @@ class installView extends install
 		// Specify the template path
 		$this->setTemplatePath($this->module_path.'tpl');
 		// Error occurs if already installed
-		if(Context::isInstalled()) return $this->stop('msg_already_installed');
+		if(Context::isInstalled()) return $this->stop('msg_already_installed', 400);
 		// Install a controller
 		$oInstallController = getController('install');
 		$this->install_enable = $oInstallController->checkInstallEnv();

--- a/modules/layout/layout.admin.controller.php
+++ b/modules/layout/layout.admin.controller.php
@@ -23,7 +23,7 @@ class layoutAdminController extends layout
 	 */
 	function procLayoutAdminInsert()
 	{
-		if(Context::get('layout') == 'faceoff') return $this->stop('not supported');
+		if(Context::get('layout') == 'faceoff') return $this->stop('not supported', 400);
 
 		// Get information to create a layout
 		$site_module_info = Context::get('site_module_info');
@@ -686,7 +686,7 @@ class layoutAdminController extends layout
 	 */
 	function procLayoutAdminUserLayoutImport()
 	{
-		return $this->stop('not supported');
+		return $this->stop('not supported', 400);
 
 		// check upload
 		if(!Context::isUploaded()) exit();
@@ -716,12 +716,12 @@ class layoutAdminController extends layout
 		$sourceArgs = Context::getRequestVars();
 		if($sourceArgs->layout == 'faceoff')
 		{
-			return $this->stop('not supported');
+			return $this->stop('not supported', 400);
 		}
 
 		if(!$sourceArgs->layout_srl)
 		{
-			return $this->stop('msg_empty_origin_layout');
+			return $this->stop('msg_empty_origin_layout', 400);
 		}
 
 		$oLayoutModel = getModel('layout');
@@ -734,7 +734,7 @@ class layoutAdminController extends layout
 
 		if(!is_array($sourceArgs->title) || count($sourceArgs->title) == 0)
 		{
-			return $this->stop('msg_empty_target_layout');
+			return $this->stop('msg_empty_target_layout', 400);
 		}
 
 		$output = $oLayoutModel->getLayoutRawData($sourceArgs->layout_srl, array('extra_vars'));

--- a/modules/layout/layout.admin.model.php
+++ b/modules/layout/layout.admin.model.php
@@ -67,7 +67,7 @@ class layoutAdminModel extends layout
 		// Error appears if there is no layout information is registered
 		if(!$layout_info)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		// Get a menu list

--- a/modules/layout/layout.admin.view.php
+++ b/modules/layout/layout.admin.view.php
@@ -140,11 +140,11 @@ class layoutAdminView extends layout
 		$layout = Context::get('layout');
 
 		if(!in_array($type, array('P', 'M'))) $type = 'P';
-		if(!$layout) return $this->stop('msg_invalid_request');
+		if(!$layout) return $this->stop('msg_invalid_request', 400);
 
 		$oLayoutModel = getModel('layout');
 		$layout_info = $oLayoutModel->getLayoutInfo($layout, null, $type);
-		if(!$layout_info) return $this->stop('msg_invalid_request');
+		if(!$layout_info) return $this->stop('msg_invalid_request', 400);
 
 		Context::set('layout_info', $layout_info);
 
@@ -175,10 +175,10 @@ class layoutAdminView extends layout
 
 		// Get layout info
 		$layout = Context::get('layout');
-		if($layout == 'faceoff') return $this->stop('not supported');
+		if($layout == 'faceoff') return $this->stop('not supported', 400);
 
 		$layout_info = $oModel->getLayoutInfo($layout, null, $type);
-		if(!$layout_info) return $this->stop('msg_invalid_request');
+		if(!$layout_info) return $this->stop('msg_invalid_request', 400);
 
 		// get Menu list
 		$oMenuAdminModel = getAdminModel('menu');

--- a/modules/layout/layout.view.php
+++ b/modules/layout/layout.view.php
@@ -319,7 +319,7 @@ class layoutView extends layout
 		// admin check
 		// this act is admin view but in normal view because do not load admin css/js files
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin != 'Y') return $this->stop('msg_invalid_request');
+		if($logged_info->is_admin != 'Y') return $this->stop('msg_invalid_request', 403);
 
 		$layout_srl = Context::get('layout_srl');
 		$code = Context::get('code');

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -258,7 +258,7 @@ class memberController extends member
 		// Check if an administrator allows a membership
 		if($config->enable_join != 'Y') return $this->stop ('msg_signup_disabled');
 		// Check if the user accept the license terms (only if terms exist)
-		if($config->agreement && Context::get('accept_agreement')!='Y') return $this->stop('msg_accept_agreement');
+		if($config->agreement && Context::get('accept_agreement')!='Y') return $this->stop('msg_accept_agreement', 403);
 
 		// Extract the necessary information in advance
 		$getVars = array();
@@ -422,19 +422,19 @@ class memberController extends member
 	{
 		if($_SESSION['rechecked_password_step'] != 'INPUT_PASSWORD')
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 403);
 		}
 
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$password = Context::get('password');
 
 		if(!$password)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 403);
 		}
 
 		$oMemberModel = getModel('member');
@@ -477,12 +477,12 @@ class memberController extends member
 	{
 		if(!Context::get('is_logged'))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		if($_SESSION['rechecked_password_step'] != 'INPUT_DATA')
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 403);
 		}
 		unset($_SESSION['rechecked_password_step']);
 
@@ -597,7 +597,7 @@ class memberController extends member
 	 */
 	function procMemberModifyPassword()
 	{
-		if(!Context::get('is_logged')) return $this->stop('msg_not_logged');
+		if(!Context::get('is_logged')) return $this->stop('msg_not_logged', 403);
 		// Extract the necessary information in advance
 		$current_password = trim(Context::get('current_password'));
 		$password = trim(Context::get('password1'));
@@ -637,7 +637,7 @@ class memberController extends member
 	 */
 	function procMemberLeave()
 	{
-		if(!Context::get('is_logged')) return $this->stop('msg_not_logged');
+		if(!Context::get('is_logged')) return $this->stop('msg_not_logged', 403);
 		// Extract the necessary information in advance
 		$password = trim(Context::get('password'));
 		// Get information of logged-in user
@@ -675,17 +675,17 @@ class memberController extends member
 	{
 		// Check if the file is successfully uploaded
 		$file = $_FILES['profile_image'];
-		if(!is_uploaded_file($file['tmp_name'])) return $this->stop('msg_not_uploaded_profile_image');
+		if(!is_uploaded_file($file['tmp_name'])) return $this->stop('msg_not_uploaded_profile_image', 400);
 		// Ignore if member_srl is invalid or doesn't exist.
 		$member_srl = Context::get('member_srl');
-		if(!$member_srl) return $this->stop('msg_not_uploaded_profile_image');
+		if(!$member_srl) return $this->stop('msg_not_uploaded_profile_image', 403);
 
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin != 'Y' && $logged_info->member_srl != $member_srl) return $this->stop('msg_not_uploaded_profile_image');
+		if($logged_info->is_admin != 'Y' && $logged_info->member_srl != $member_srl) return $this->stop('msg_not_uploaded_profile_image', 403);
 		// Return if member module is set not to use an image name or the user is not an administrator ;
 		$oModuleModel = getModel('module');
 		$config = $oModuleModel->getModuleConfig('member');
-		if($logged_info->is_admin != 'Y' && $config->profile_image != 'Y') return $this->stop('msg_not_uploaded_profile_image');
+		if($logged_info->is_admin != 'Y' && $config->profile_image != 'Y') return $this->stop('msg_not_uploaded_profile_image', 403);
 
 		$this->insertProfileImage($member_srl, $file['tmp_name']);
 		// Page refresh
@@ -754,17 +754,17 @@ class memberController extends member
 	{
 		// Check if the file is successfully uploaded
 		$file = $_FILES['image_name'];
-		if(!is_uploaded_file($file['tmp_name'])) return $this->stop('msg_not_uploaded_image_name');
+		if(!is_uploaded_file($file['tmp_name'])) return $this->stop('msg_not_uploaded_image_name', 400);
 		// Ignore if member_srl is invalid or doesn't exist.
 		$member_srl = Context::get('member_srl');
-		if(!$member_srl) return $this->stop('msg_not_uploaded_image_name');
+		if(!$member_srl) return $this->stop('msg_not_uploaded_image_name', 400);
 
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin != 'Y' && $logged_info->member_srl != $member_srl) return $this->stop('msg_not_uploaded_image_name');
+		if($logged_info->is_admin != 'Y' && $logged_info->member_srl != $member_srl) return $this->stop('msg_not_uploaded_image_name', 403);
 		// Return if member module is set not to use an image name or the user is not an administrator ;
 		$oModuleModel = getModel('module');
 		$config = $oModuleModel->getModuleConfig('member');
-		if($logged_info->is_admin != 'Y' && $config->image_name != 'Y') return $this->stop('msg_not_uploaded_image_name');
+		if($logged_info->is_admin != 'Y' && $config->image_name != 'Y') return $this->stop('msg_not_uploaded_image_name',403);
 
 		$this->insertImageName($member_srl, $file['tmp_name']);
 		// Page refresh
@@ -863,17 +863,17 @@ class memberController extends member
 	{
 		// Check if the file is successfully uploaded
 		$file = $_FILES['image_mark'];
-		if(!is_uploaded_file($file['tmp_name'])) return $this->stop('msg_not_uploaded_image_mark');
+		if(!is_uploaded_file($file['tmp_name'])) return $this->stop('msg_not_uploaded_image_mark', 400);
 		// Ignore if member_srl is invalid or doesn't exist.
 		$member_srl = Context::get('member_srl');
-		if(!$member_srl) return $this->stop('msg_not_uploaded_image_mark');
+		if(!$member_srl) return $this->stop('msg_not_uploaded_image_mark', 403);
 
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin != 'Y' && $logged_info->member_srl != $member_srl) return $this->stop('msg_not_uploaded_image_mark');
+		if($logged_info->is_admin != 'Y' && $logged_info->member_srl != $member_srl) return $this->stop('msg_not_uploaded_image_mark', 403);
 		// Membership in the images mark the module using the ban was set by an administrator or return;
 		$oModuleModel = getModel('module');
 		$config = $oModuleModel->getModuleConfig('member');
-		if($logged_info->is_admin != 'Y' && $config->image_mark != 'Y') return $this->stop('msg_not_uploaded_image_mark');
+		if($logged_info->is_admin != 'Y' && $config->image_mark != 'Y') return $this->stop('msg_not_uploaded_image_mark', 403);
 
 		$this->insertImageMark($member_srl, $file['tmp_name']);
 		// Page refresh
@@ -1109,7 +1109,7 @@ class memberController extends member
 
 		if(!$member_srl || !$auth_key)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 403);
 		}
 
 		// Test logs for finding password by user_id and authkey
@@ -1125,7 +1125,7 @@ class memberController extends member
 				executeQuery('member.deleteAuthMail', $args);
 			}
 
-			return $this->stop('msg_invalid_auth_key');
+			return $this->stop('msg_invalid_auth_key', 403);
 		}
 
 		$args->password = $output->data->new_password;
@@ -1323,14 +1323,14 @@ class memberController extends member
 
 		if(!$memberInfo)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		$newEmail = Context::get('email_address');
 
 		if(!$newEmail)
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		$oMemberModel = getModel('member');
@@ -2146,7 +2146,7 @@ class memberController extends member
 				unset($args->denied);
 			if($logged_info->member_srl != $args->member_srl && $is_admin == false)
 			{
-				return $this->stop('msg_invalid_request');
+				return $this->stop('msg_invalid_request', 403);
 			}
 		}
 
@@ -2445,12 +2445,12 @@ class memberController extends member
 
 	function procMemberModifyEmailAddress()
 	{
-		if(!Context::get('is_logged')) return $this->stop('msg_not_logged');
+		if(!Context::get('is_logged')) return $this->stop('msg_not_logged', 403);
 
 		$member_info = Context::get('logged_info');
 		$newEmail = Context::get('email_address');
 
-		if(!$newEmail) return $this->stop('msg_invalid_request');
+		if(!$newEmail) return $this->stop('msg_invalid_request', 400);
 
 		$oMemberModel = getModel('member');
 		$member_srl = $oMemberModel->getMemberSrlByEmailAddress($newEmail);
@@ -2458,7 +2458,7 @@ class memberController extends member
 
 		if($_SESSION['rechecked_password_step'] != 'INPUT_DATA')
 		{
-			return $this->stop('msg_invalid_request');
+			return $this->stop('msg_invalid_request', 403);
 		}
 		unset($_SESSION['rechecked_password_step']);
 
@@ -2518,7 +2518,7 @@ class memberController extends member
 	{
 		$member_srl = Context::get('member_srl');
 		$auth_key = Context::get('auth_key');
-		if(!$member_srl || !$auth_key) return $this->stop('msg_invalid_request');
+		if(!$member_srl || !$auth_key) return $this->stop('msg_invalid_request', 403);
 
 		// Test logs for finding password by user_id and authkey
 		$args = new stdClass;
@@ -2528,7 +2528,7 @@ class memberController extends member
 		if(!$output->toBool() || $output->data->auth_key != $auth_key)
 		{
 			if(strlen($output->data->auth_key) !== strlen($auth_key)) executeQuery('member.deleteAuthChangeEmailAddress', $args);
-			return $this->stop('msg_invalid_modify_email_auth_key');
+			return $this->stop('msg_invalid_modify_email_auth_key', 403);
 		}
 
 		$newEmail = $output->data->user_id;

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -63,7 +63,7 @@ class memberView extends member
 		$oMemberModel = getModel('member');
 		$logged_info = Context::get('logged_info');
 		// Don't display member info to non-logged user
-		if(!$logged_info->member_srl) return $this->stop('msg_not_permitted');
+		if(!$logged_info->member_srl) return $this->stop('msg_not_permitted', 403);
 
 		$member_srl = Context::get('member_srl');
 		if(!$member_srl && Context::get('is_logged'))
@@ -198,12 +198,12 @@ class memberView extends member
 
 		$oMemberModel = getModel('member');
 		// Get the member information if logged-in
-		if($oMemberModel->isLogged()) return $this->stop('msg_already_logged');
+		if($oMemberModel->isLogged()) return $this->stop('msg_already_logged', 400);
 		// call a trigger (before) 
 		$trigger_output = ModuleHandler::triggerCall('member.dispMemberSignUpForm', 'before', $member_config);
 		if(!$trigger_output->toBool()) return $trigger_output;
 		// Error appears if the member is not allowed to join
-		if($member_config->enable_join != 'Y') return $this->stop('msg_signup_disabled');
+		if($member_config->enable_join != 'Y') return $this->stop('msg_signup_disabled', 403);
 
 		$oMemberAdminView = getAdminView('member');
 		$formTags = $oMemberAdminView->_getMemberInputTag($member_info);
@@ -228,7 +228,7 @@ class memberView extends member
 		$oMemberModel = getModel('member');
 		if(!$oMemberModel->isLogged() || empty($logged_info))
 		{
-			return $this->stop('msg_not_logged');
+			return $this->stop('msg_not_logged', 403);
 		}
 
 		$_SESSION['rechecked_password_step'] = 'INPUT_PASSWORD';
@@ -271,7 +271,7 @@ class memberView extends member
 
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 403);
 
 		$logged_info = Context::get('logged_info');
 		$member_srl = $logged_info->member_srl;
@@ -330,7 +330,7 @@ class memberView extends member
 	{
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 403);
 
 		$logged_info = Context::get('logged_info');
 		$member_srl = $logged_info->member_srl;
@@ -357,7 +357,7 @@ class memberView extends member
 	{
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 403);
 
 		$logged_info = Context::get('logged_info');
 		$args = new stdClass();
@@ -381,7 +381,7 @@ class memberView extends member
 	{
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 403);
 		// Get the saved document(module_srl is set to member_srl instead)
 		$logged_info = Context::get('logged_info');
 		$args = new stdClass();
@@ -439,7 +439,7 @@ class memberView extends member
 	{
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 403);
 
 		$memberConfig = $this->member_config;
 
@@ -471,7 +471,7 @@ class memberView extends member
 	{
 		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged', 403);
 
 		$memberConfig = $this->member_config;
 
@@ -524,7 +524,7 @@ class memberView extends member
 	 */
 	function dispMemberFindAccount()
 	{
-		if(Context::get('is_logged')) return $this->stop('already_logged');
+		if(Context::get('is_logged')) return $this->stop('already_logged', 403);
 
 		$config = $this->member_config;
 
@@ -538,7 +538,7 @@ class memberView extends member
 	 */
 	function dispMemberGetTempPassword()
 	{
-		if(Context::get('is_logged')) return $this->stop('already_logged');
+		if(Context::get('is_logged')) return $this->stop('already_logged', 403);
 
 		$user_id = Context::get('user_id');
 		$temp_password = $_SESSION['xe_temp_password_'.$user_id];
@@ -561,7 +561,7 @@ class memberView extends member
 
 		if(Context::get('is_logged')) 
 		{
-			return $this->stop('already_logged');
+			return $this->stop('already_logged', 403);
 		}
 
 		if($authMemberSrl)

--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -859,7 +859,7 @@ class menuAdminController extends menu
 		$oAdmin = getClass('admin');
 		if($menu_title == $oAdmin->getAdminMenuName() && $itemInfo->parent_srl == 0)
 		{
-			return $this->stop('msg_cannot_delete_for_admin_topmenu');
+			return $this->stop('msg_cannot_delete_for_admin_topmenu', 400);
 		}
 
 		if($itemInfo->parent_srl) $parent_srl = $itemInfo->parent_srl;

--- a/modules/module/module.admin.controller.php
+++ b/modules/module/module.admin.controller.php
@@ -942,7 +942,7 @@ class moduleAdminController extends module
 	{
 		if(!$moduleSrl && !$mid)
 		{
-			return $this->stop(-1, 'msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		$oModuleModel = getModel('module');
@@ -958,7 +958,7 @@ class moduleAdminController extends module
 
 		if(!$moduleInfo)
 		{
-			return $this->stop(-1, 'msg_module_not_exists');
+			return $this->stop('msg_module_not_exists', 400);
 		}
 
 		$skinTargetValue = ($skinType == 'M') ? 'mskin' : 'skin';
@@ -1007,7 +1007,7 @@ class moduleAdminController extends module
 
 		if(!$menuItemSrl)
 		{
-			return $this->stop(-1, 'msg_invalid_request');
+			return $this->stop('msg_invalid_request', 400);
 		}
 
 		$oModuleModel = getModel('module');

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -266,7 +266,7 @@ class moduleModel extends module
 
 		if(!$menuItemSrl)
 		{
-			$this->stop(-1, 'msg_invalid_request');
+			$this->stop('msg_invalid_request', 400);
 			return;
 		}
 

--- a/modules/module/module.view.php
+++ b/modules/module/module.view.php
@@ -25,10 +25,10 @@ class moduleView extends module
 		$skin = Context::get('skin');
 		// Get modules/skin information
 		$module_path = sprintf("./modules/%s/", $selected_module);
-		if(!is_dir($module_path)) $this->stop("msg_invalid_request");
+		if(!is_dir($module_path)) $this->stop("msg_invalid_request", 404);
 
 		$skin_info_xml = sprintf("%sskins/%s/skin.xml", $module_path, $skin);
-		if(!file_exists($skin_info_xml)) $this->stop("msg_invalid_request");
+		if(!file_exists($skin_info_xml)) $this->stop("msg_invalid_request", 404);
 
 		$oModuleModel = getModel('module');
 		$skin_info = $oModuleModel->loadSkinInfo($module_path, $skin);

--- a/modules/page/page.admin.view.php
+++ b/modules/page/page.admin.view.php
@@ -163,7 +163,7 @@ class pageAdminView extends page
 	{
 		if($this->module_info->page_type == 'OUTSIDE')
 		{
-			return $this->stop(-1, 'msg_invalid_request');
+			return $this->stop('msg_invalid_request', 404);
 		}
 
 		if($this->module_srl)

--- a/modules/poll/poll.admin.controller.php
+++ b/modules/poll/poll.admin.controller.php
@@ -44,7 +44,7 @@ class pollAdminController extends poll
 		else $poll_srl_list= explode('|@|', $cart);
 
 		$poll_count = count($poll_srl_list);
-		if(!$poll_count) return $this->stop('msg_cart_is_null');
+		if(!$poll_count) return $this->stop('msg_cart_is_null', 400);
 		// Delete the post
 		for($i=0;$i<$poll_count;$i++)
 		{

--- a/modules/poll/poll.admin.view.php
+++ b/modules/poll/poll.admin.view.php
@@ -137,7 +137,7 @@ class pollAdminView extends poll
 		$args->poll_index_srl = Context::get('poll_index_srl');
 
 		$output = executeQuery('poll.getPoll', $args);
-		if(!$output->data) return $this->stop('msg_poll_not_exists');
+		if(!$output->data) return $this->stop('msg_poll_not_exists', 404);
 
 		$poll = new stdClass();
 		$poll->stop_date = $output->data->stop_date;
@@ -146,7 +146,7 @@ class pollAdminView extends poll
 		$output = executeQuery('poll.getPollTitle', $args);
 		if(!$output->data)
 		{
-			return $this->stop('msg_poll_not_exists');
+			return $this->stop('msg_poll_not_exists', 404);
 		}
 
 		$tmp = &$poll->poll[$args->poll_index_srl];

--- a/modules/widget/widget.admin.view.php
+++ b/modules/widget/widget.admin.view.php
@@ -59,7 +59,7 @@ class widgetAdminView extends widget
 	function dispWidgetAdminAddContent()
 	{
 		$module_srl = Context::get('module_srl');
-		if(!$module_srl) return $this->stop("msg_invalid_request");
+		if(!$module_srl) return $this->stop("msg_invalid_request", 400);
 
 		$document_srl = Context::get('document_srl');
 		$oDocumentModel = getModel('document');


### PR DESCRIPTION
# 모듈 에러 메시지가 HTTP status codes를 반환하게 합니다.
1. HTTP status code를 쉽게 입력할 수 있게 합니다. (ModuleObject class 의 stop method에 http status code를 입력할 수 있게 함)
2. 1의 변경을 활용하여 기본 모듈들의 오류 코드에 HTTP 상태 코드 모두 추가.
3. 게시판 모듈 특유의 오류 반환 코드에서도 같은 방식으로 HTTP 상태 코드 추가.

# Make module errors return HTTP status codes
1. Make it easy to return HTTP status code.
2. Set HTTP status code at each default modules.
3. Return HTTP status codes at Board module.

## 이 PR의 기대 효과
1. 기계가 오류 페이지의 내용을 조금 더 정확히 이해할 수 있음
2. 1을 통한 SEO 개선
3. XE 오류 메시지의 내용을 보완.
4. 개발시 오류 메시지에 HTTP 상태 코드 쉽게 추가 가능.