### PR TITLE
CK에디터 파일첨부 디자인 변경에 따른 다국어 문구 수정/모바일 툴바수정

### DIFF
--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -68,7 +68,7 @@
 			settings.loadXeComponent = false;
 		<!--@endif-->
 
-		<!--@if($module_type === 'comment')-->
+		<!--@if($module_type === 'comment'||Mobile::isMobileCheckByAgent())-->
 			settings.ckeconfig.toolbarStartupExpanded = false;
 		<!--@endif-->
 		

--- a/modules/editor/skins/ckeditor/lang/lang.xml
+++ b/modules/editor/skins/ckeditor/lang/lang.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <lang>
 	<item name="ckeditor_about_file_drop_area">
-		<value xml:lang="ko"><![CDATA[여기에 파일을 끌어 놓거나 아래 파일 첨부 버튼을 클릭하세요.]]></value>
-		<value xml:lang="en"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
-		<value xml:lang="jp"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
-		<value xml:lang="zh-CN"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
-		<value xml:lang="zh-TW"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
-		<value xml:lang="ru"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
-		<value xml:lang="tr"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
-		<value xml:lang="vi"><![CDATA[Drag and drop your files here, or Click attach files button below.]]></value>
+		<value xml:lang="ko"><![CDATA[여기에 파일을 끌어 놓거나 파일 첨부 버튼을 클릭하세요.]]></value>
+		<value xml:lang="en"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
+		<value xml:lang="jp"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
+		<value xml:lang="zh-CN"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
+		<value xml:lang="zh-TW"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
+		<value xml:lang="ru"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
+		<value xml:lang="tr"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
+		<value xml:lang="vi"><![CDATA[Drag and drop your files here, or Click attach files button.]]></value>
 	</item>
 	<item name="ckeditor_file_uploading">
 		<value xml:lang="ko"><![CDATA[파일 업로드 중...]]></value>


### PR DESCRIPTION
CK 에디터가 이렇게 바뀌어서..

어울리지 않는 문구라 수정합니다.
![default](https://cloud.githubusercontent.com/assets/1341628/8548857/6098eda6-2502-11e5-870f-05e2e3068c04.PNG)
