### PR TITLE
CK에디터 모바일에서 툴바줄이기를 기본으로

### DIFF
--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -68,7 +68,7 @@
 			settings.loadXeComponent = false;
 		<!--@endif-->
 
-		<!--@if($module_type === 'comment')-->
+		<!--@if($module_type === 'comment'||Mobile::isMobileCheckByAgent())-->
 			settings.ckeconfig.toolbarStartupExpanded = false;
 		<!--@endif-->
 		


### PR DESCRIPTION
모바일에서 CK에디터를 사용할경우
![30584f0f47f1b3e660cd20ab9acff836](https://cloud.githubusercontent.com/assets/1341628/8549570/7a5bf14e-2506-11e5-8d2b-5d5abda7dd8a.png)

다음과 같은 현상이 일어나므로 기본으로 툴바를 감추게 표시하게 했습니다.
