### PR TITLE
반복된 setcookie() 호출 제거

### DIFF
--- a/classes/mobile/Mobile.class.php
+++ b/classes/mobile/Mobile.class.php
@@ -123,13 +123,13 @@ class Mobile
 					setcookie("mobile", 'true', 0, $xe_web_path);
 				}
 			}
-			elseif($_COOKIE['mobile'] != 'false')
+			elseif($this->isMobileCheckByAgent() && $_COOKIE['mobile'] != 'false')
 			{
 				$_COOKIE['mobile'] = 'false';
 				setcookie("mobile", 'false', 0, $xe_web_path);
 			}
 
-			if($_COOKIE['user-agent'] != md5($_SERVER['HTTP_USER_AGENT']))
+			if(isset($_COOKIE['user-agent']) && $_COOKIE['user-agent'] != md5($_SERVER['HTTP_USER_AGENT']))
 			{
 				setcookie("user-agent", md5($_SERVER['HTTP_USER_AGENT']), 0, $xe_web_path);
 			}

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1836,7 +1836,8 @@ class memberController extends member
 		$_SESSION['ipaddress'] = $_SERVER['REMOTE_ADDR'];
 		$_SESSION['member_srl'] = $this->memberInfo->member_srl;
 		$_SESSION['is_admin'] = '';
-		setcookie('xe_logged', 'true', 0, '/');
+		if(empty($_COOKIE['xe_logged']) || $_COOKIE['xe_logged'] != 'true')
+			setcookie('xe_logged', 'true', 0, '/');
 		// Do not save your password in the session jiwojum;;
 		//unset($this->memberInfo->password);
 		// User Group Settings


### PR DESCRIPTION
쿠키가 이미 설정되어있는데도 계속 `Set-Cookie`헤더가 붙어있길래 살펴보니 `SetCooke()`가 이미 호출되었는데도 반복적으로 다시 호출되고 있습니다.

`Set-Cooke` 헤더는 캐시 서버의 캐싱을 방해하는 원인중에 하나입니다.