### PR TITLE
캐시서버를 위한 Cache-Control 헤더 제어

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -325,7 +325,6 @@ class Context
 		}
 
 		$this->set('lang_supported', $lang_supported);
-		$this->setLangType($this->lang_type);
 
 		// load module module's language file according to language setting
 		$this->loadLang(_XE_PATH_ . 'modules/module/lang');
@@ -349,6 +348,8 @@ class Context
 		{
 			Context::setCacheControl();
 		}
+
+		$this->setLangType($this->lang_type);
 
 		// set authentication information in Context and session
 		if(self::isInstalled())

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1076,8 +1076,6 @@ class Context
 
 		$self->lang_type = $lang_type;
 		$self->set('lang_type', $lang_type);
-
-		$_SESSION['lang_type'] = $lang_type;
 	}
 
 	/**

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -340,14 +340,7 @@ class Context
 		}
 
 		self::openSession();
-		if(self::startSession() != self::SESSION_NONE)
-		{
-			Context::setCacheControl('private', true);
-		}
-		else
-		{
-			Context::setCacheControl();
-		}
+		self::startSession();
 
 		$this->setLangType($this->lang_type);
 
@@ -542,26 +535,6 @@ class Context
 		foreach($array as $key => $val)
 		{
 			$_SESSION[$key] = $val;
-		}
-	}
-
-	/**
-	 * set Cache-Control header
-	 *
-	 * @return void
-	 */
-	function setCacheControl($public = 'public', $nocache = false)
-	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
-
-		$public = !empty($public) ? $public.', ' : '';
-		header("Cache-Control: ".$public."must-revalidate, post-check=0, pre-check=0");
-		if ($nocache)
-		{
-			header("Cache-Control: no-store, no-cache, must-revalidate", false);
-			header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-			header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-			header("Pragma: no-cache");
 		}
 	}
 

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -503,39 +503,18 @@ class Context
 	{
 		// get status
 		$status = self::getSessionStatus();
-		if(empty($_SESSION) || $status == self::SESSION_ACTIVE)
+		// no session opened or empty $_SESSION. ignore it.
+		if($status == self::SESSION_ACTIVE || count($_SESSION) == 0)
 		{
 			return;
 		}
+
 		// copy $_SESSION
-		$array = $_SESSION;
-
-		// check not empty variables
-		$not_empty = 0;
-		foreach($array as $key => $val)
-		{
-			if(!empty($val))
-			{
-				$not_empty ++;
-			}
-			else if(is_numeric($val) || is_bool($val))
-			{
-				$not_empty ++;
-			}
-		}
-
-		// no session opened. ignore it.
-		if($not_empty == 0 && $status == self::SESSION_NONE)
-		{
-			return;
-		}
-
+		$temp = $_SESSION;
 		// lazy start session
 		session_start();
-		foreach($array as $key => $val)
-		{
-			$_SESSION[$key] = $val;
-		}
+		// restore $_SESSION
+		$_SESSION = $temp;
 	}
 
 	/**

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -321,11 +321,6 @@ class DisplayHandler extends Handler
 	function _printXMLHeader()
 	{
 		header("Content-Type: text/xml; charset=UTF-8");
-		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-		header("Cache-Control: no-store, no-cache, must-revalidate");
-		header("Cache-Control: post-check=0, pre-check=0", false);
-		header("Pragma: no-cache");
 	}
 
 	/**
@@ -335,11 +330,6 @@ class DisplayHandler extends Handler
 	function _printHTMLHeader()
 	{
 		header("Content-Type: text/html; charset=UTF-8");
-		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-		header("Cache-Control: no-store, no-cache, must-revalidate");
-		header("Cache-Control: post-check=0, pre-check=0", false);
-		header("Pragma: no-cache");
 	}
 
 	/**
@@ -349,11 +339,6 @@ class DisplayHandler extends Handler
 	function _printJSONHeader()
 	{
 		header("Content-Type: text/html; charset=UTF-8");
-		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-		header("Cache-Control: no-store, no-cache, must-revalidate");
-		header("Cache-Control: post-check=0, pre-check=0", false);
-		header("Pragma: no-cache");
 	}
 
 	/**

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -99,6 +99,15 @@ class DisplayHandler extends Handler
 			{
 				$this->_printHTMLHeader();
 			}
+
+			if(Context::getSessionStatus() != Context::SESSION_NONE)
+			{
+				$this->setCacheControl('private', true);
+			}
+			else
+			{
+				$this->setCacheControl();
+			}
 		}
 
 		// debugOutput output
@@ -110,15 +119,6 @@ class DisplayHandler extends Handler
 		if(headers_sent())
 		{
 			$this->gz_enabled = FALSE;
-		}
-
-		if(Context::getSessionStatus() != Context::SESSION_NONE)
-		{
-			$this->setCacheControl('private', true);
-		}
-		else
-		{
-			$this->setCacheControl();
 		}
 
 		// results directly output

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -112,6 +112,15 @@ class DisplayHandler extends Handler
 			$this->gz_enabled = FALSE;
 		}
 
+		if(Context::getSessionStatus() != Context::SESSION_NONE)
+		{
+			$this->setCacheControl('private', true);
+		}
+		else
+		{
+			$this->setCacheControl();
+		}
+
 		// results directly output
 		if($this->gz_enabled)
 		{
@@ -311,6 +320,24 @@ class DisplayHandler extends Handler
 					return;
 				}
 			}
+		}
+	}
+
+	/**
+	 * set Cache-Control header
+	 *
+	 * @return void
+	 */
+	function setCacheControl($public = 'public', $nocache = false)
+	{
+		$public = !empty($public) ? $public.', ' : '';
+		header("Cache-Control: ".$public."must-revalidate, post-check=0, pre-check=0");
+		if ($nocache)
+		{
+			header("Cache-Control: no-store, no-cache, must-revalidate", false);
+			header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+			header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+			header("Pragma: no-cache");
 		}
 	}
 

--- a/classes/mobile/Mobile.class.php
+++ b/classes/mobile/Mobile.class.php
@@ -123,13 +123,13 @@ class Mobile
 					setcookie("mobile", 'true', 0, $xe_web_path);
 				}
 			}
-			elseif($_COOKIE['mobile'] != 'false')
+			elseif(isset($_COOKIE['mobile']) && $_COOKIE['mobile'] != 'false')
 			{
 				$_COOKIE['mobile'] = 'false';
 				setcookie("mobile", 'false', 0, $xe_web_path);
 			}
 
-			if($_COOKIE['user-agent'] != md5($_SERVER['HTTP_USER_AGENT']))
+			if(isset($_COOKIE['mobile']) && $_COOKIE['user-agent'] != md5($_SERVER['HTTP_USER_AGENT']))
 			{
 				setcookie("user-agent", md5($_SERVER['HTTP_USER_AGENT']), 0, $xe_web_path);
 			}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -722,15 +722,18 @@ class ModuleHandler extends Handler
 
 			}
 
-			$_SESSION['XE_VALIDATOR_ERROR'] = $error;
-			$_SESSION['XE_VALIDATOR_ID'] = Context::get('xe_validator_id');
+			if($error != 0)
+			{
+				$_SESSION['XE_VALIDATOR_ERROR'] = $error;
+				$_SESSION['XE_VALIDATOR_ID'] = Context::get('xe_validator_id');
+			}
 			if($message != 'success')
 			{
 				$_SESSION['XE_VALIDATOR_MESSAGE'] = $message;
+				$_SESSION['XE_VALIDATOR_MESSAGE_TYPE'] = $messageType;
 			}
-			$_SESSION['XE_VALIDATOR_MESSAGE_TYPE'] = $messageType;
 
-			if(Context::get('xeVirtualRequestMethod') != 'xml')
+			if(Context::get('xeVirtualRequestMethod') != 'xml' && !empty($redirectUrl))
 			{
 				$_SESSION['XE_VALIDATOR_RETURN_URL'] = $redirectUrl;
 			}

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -177,18 +177,18 @@ class addonController extends addon
 			$buff[] = 'if(file_exists($addon_file)){';
 			$buff[] = 'if($rm === \'no_run_selected\'){';
 			$buff[] = 'if(!isset($ml[$_m])){';
-			$buff[] = $addon_include;
 			if($session_used)
 			{
-				$buff[] = 'Context::lazyStartSession(); # lazy check _SESSION';
+				$buff[] = 'if(session_id()=="")session_start(); # force to start session';
 			}
+			$buff[] = $addon_include;
 			$buff[] = '}}else{';
 			$buff[] = 'if(isset($ml[$_m]) || count($ml) === 0){';
-			$buff[] = $addon_include;
 			if($session_used)
 			{
-				$buff[] = 'Context::lazyStartSession(); # lazy check _SESSION';
+				$buff[] = 'if(session_id()=="")session_start(); # force to start session';
 			}
+			$buff[] = $addon_include;
 			$buff[] = '}}}';
 			$buff[] = '$after_time = microtime(true);';
 			$buff[] = '$addon_time_log = new stdClass();';

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -177,18 +177,18 @@ class addonController extends addon
 			$buff[] = 'if(file_exists($addon_file)){';
 			$buff[] = 'if($rm === \'no_run_selected\'){';
 			$buff[] = 'if(!isset($ml[$_m])){';
+			$buff[] = $addon_include;
 			if($session_used)
 			{
-				$buff[] = 'if(session_id()=="")session_start(); # force to start session';
+				$buff[] = 'Context::lazyStartSession(); # lazy check _SESSION';
 			}
-			$buff[] = $addon_include;
 			$buff[] = '}}else{';
 			$buff[] = 'if(isset($ml[$_m]) || count($ml) === 0){';
+			$buff[] = $addon_include;
 			if($session_used)
 			{
-				$buff[] = 'if(session_id()=="")session_start(); # force to start session';
+				$buff[] = 'Context::lazyStartSession(); # lazy check _SESSION';
 			}
-			$buff[] = $addon_include;
 			$buff[] = '}}}';
 			$buff[] = '$after_time = microtime(true);';
 			$buff[] = '$addon_time_log = new stdClass();';

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -18,57 +18,6 @@ class addonController extends addon
 	}
 
 	/**
-	 * Check if the $_SESSION variables are used or not
-	 *
-	 * @param string $addon_file
-	 * @return bool Return true or false
-	 */
-	function checkSessionUsed($addon_path)
-	{
-		$addon = basename($addon_path);
-		$fp = opendir($addon_path);
-		if(!is_resource($fp))
-		{
-			return false;
-		}
-
-		while(($addon_file = readdir($fp)) !== false)
-		{
-			// ignore . and .. dir
-			if($addon_file[0] == '.')
-			{
-				continue;
-			}
-			if(is_dir($addon_path.'/'.$addon_file))
-			{
-				// recursively check old style file
-				$ret = $this->checkSessionUsed($addon_path.'/'.$addon_file);
-				if($ret)
-				{
-					closedir($fp);
-					return true;
-				}
-				continue;
-			}
-			if(!preg_match('@\.(?:php)$@', $addon_file))
-			{
-				continue;
-			}
-			$lines = file($addon_path.'/'.$addon_file);
-			foreach($lines as $line)
-			{
-				if(preg_match('@\$_SESSION\[(?:[^\]]+)\]@', $line))
-				{
-					closedir($fp);
-					return true;
-				}
-			}
-		}
-		closedir($fp);
-		return false;
-	}
-
-	/**
 	 * Returns a cache file path
 	 *
 	 * @param $type pc or mobile
@@ -151,9 +100,6 @@ class addonController extends addon
 				$mid_list = NULL;
 			}
 
-			$addon_root = _XE_PATH_ . 'addons/' . $addon;
-			$session_used = $this->checkSessionUsed($addon_root, true);
-
 			$buff[] = '$before_time = microtime(true);';
 			$buff[] = '$rm = \'' . $extra_vars->xe_run_method . "';";
 			$buff[] = '$ml = array(';
@@ -177,17 +123,9 @@ class addonController extends addon
 			$buff[] = 'if(file_exists($addon_file)){';
 			$buff[] = 'if($rm === \'no_run_selected\'){';
 			$buff[] = 'if(!isset($ml[$_m])){';
-			if($session_used)
-			{
-				$buff[] = 'if(session_id()=="")session_start(); # force to start session';
-			}
 			$buff[] = $addon_include;
 			$buff[] = '}}else{';
 			$buff[] = 'if(isset($ml[$_m]) || count($ml) === 0){';
-			if($session_used)
-			{
-				$buff[] = 'if(session_id()=="")session_start(); # force to start session';
-			}
 			$buff[] = $addon_include;
 			$buff[] = '}}}';
 			$buff[] = '$after_time = microtime(true);';

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -177,7 +177,7 @@ class documentItem extends Object
 
 	function isAccessible()
 	{
-		return $_SESSION['accessible'][$this->document_srl]==true?true:false;
+		return $this->_checkAccessibleFromStatus();
 	}
 
 	function allowComment()
@@ -390,9 +390,6 @@ class documentItem extends Object
 
 		if($this->isSecret() && !$this->isGranted() && !$this->isAccessible()) return Context::getLang('msg_is_secret');
 
-		$result = $this->_checkAccessibleFromStatus();
-		if($result) $_SESSION['accessible'][$this->document_srl] = true;
-
 		$content = $this->get('content');
 		$content = preg_replace_callback('/<(object|param|embed)[^>]*/is', array($this, '_checkAllowScriptAccess'), $content);
 		$content = preg_replace_callback('/<object[^>]*>/is', array($this, '_addAllowScriptAccess'), $content);
@@ -450,9 +447,6 @@ class documentItem extends Object
 		if(!$this->document_srl) return;
 
 		if($this->isSecret() && !$this->isGranted() && !$this->isAccessible()) return Context::getLang('msg_is_secret');
-
-		$result = $this->_checkAccessibleFromStatus();
-		if($result) $_SESSION['accessible'][$this->document_srl] = true;
 
 		$content = $this->get('content');
 		if(!$stripEmbedTagException) stripEmbedTagForAdmin($content, $this->get('member_srl'));

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -203,9 +203,8 @@ class memberModel extends member
 					return true;
 				}
 			}
+			$_SESSION['is_logged'] = false;
 		}
-
-		$_SESSION['is_logged'] = false;
 		return false;
 	}
 


### PR DESCRIPTION
- 캐시 친화적인 `Cache-Control` 헤더
- 로그인사용자는 `cache-control: private`, 그 이외에는 `public`을 사용
- `session_start()`를 로그인 할 경우에만 사용하여 `set-cookie` 사용 최소화

모니위키에서 varnish 캐시서버 지원을 넣었던 경험을 바탕으로 일단 XE에서 최소한의 변경을 가해봤습니다.

모니위키의 경우에 vanish 캐시서버 - 아파치 상태에서 `ab -n 1000 -c 3`을 평균적인 크기의 페이지에 대해 테스트해보면 15000~20000 RPS나 나옵니다. (varnish 캐시 없이는 150~300 RPS)

반면 XE의 경우에는 `Set-Cookie`등의 요인을 제거하면 (이 패치 및 set-cookie 패치)
`ngnix` 웹서버상에서 80 RPS 정도가 나오며, varnish 캐시서버를 쓰면 5000RPS~15000RPS가 나옵니다.
# nginx

```
$ ab -n 500 -c 3 http://localhost:8000/ (nginx)
Requests per second:    82.90 [#/sec] (mean)
Time per request:       36.187 [ms] (mean)
Time per request:       12.062 [ms] (mean, across all concurrent requests)
Transfer rate:          2706.19 [Kbytes/sec] received
...
```
# varnish + nginx

```
$ ab -n 500 -c 3 http://localhost/
...
Requests per second:    6797.36 [#/sec] (mean)
Time per request:       0.441 [ms] (mean)
Time per request:       0.147 [ms] (mean, across all concurrent requests)
Transfer rate:          222706.38 [Kbytes/sec] received
...

$ ab -n 5000 -c 100 http://localhost/
Requests per second:    13301.13 [#/sec] (mean)
Time per request:       7.518 [ms] (mean)
Time per request:       0.075 [ms] (mean, across all concurrent requests)
Transfer rate:          435806.75 [Kbytes/sec] received
...
```
