### PR TITLE
관리자가 회원 수정/생성 할때 그룹을 반드시 선택하게함

### DIFF
--- a/modules/member/tpl/insert_member.html
+++ b/modules/member/tpl/insert_member.html
@@ -104,7 +104,7 @@
 		<label class="x_control-label">{$lang->member_group}</label>
 		<div class="x_controls">
 			<label for="group_{$key}" class="x_inline" loop="$group_list => $key,$val">
-				<input type="checkbox" name="group_srl_list[]" value="{$key}" id="group_{$key}" checked="checked"|cond="$member_info->group_list[$key]" />
+				<input type="checkbox" name="group_srl_list[]" value="{$key}" id="group_{$key}" checked="checked"|cond="$member_info->group_list[$key]" required />
 				{$val->title}
 			</label>
 		</div>

--- a/modules/member/tpl/insert_member.html
+++ b/modules/member/tpl/insert_member.html
@@ -101,7 +101,7 @@
 		</div>
 	</div>
 	<div class="x_control-group">
-		<label class="x_control-label">{$lang->member_group}</label>
+		<label class="x_control-label"><em style="color:red">*</em> {$lang->member_group}</label>
 		<div class="x_controls">
 			<label for="group_{$key}" class="x_inline" loop="$group_list => $key,$val">
 				<input type="checkbox" name="group_srl_list[]" value="{$key}" id="group_{$key}" checked="checked"|cond="$member_info->group_list[$key]" required />


### PR DESCRIPTION
관리자가 회원을 수정 생성할때

회원 그룹을 설정하는 곳에서 아무런 체크도 하지 않고 저장할경우

수정할때는 기존 그룹으로 들어가고 생성할때는 기본 그룹으로 들어가게 되어있는데

이를 변경하려다 놓칠수도 있으므로 무조건 선택하게 하는게 나을지도 모를거라 생각해서 변경한 PR입니다.

기본적으로 그룹을 모두 체크했다는건 그룹을 변경하려다 실수로 까먹었다는게 더 신빙성이 있기 때문입니다.