### PR TITLE
config파일 읽을 때 BOM문자 제거

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -447,7 +447,9 @@ class Context
 		$config_file = $self->getConfigFile();
 		if(is_readable($config_file))
 		{
+			ob_start(); // trash BOM
 			include($config_file);
+			ob_end_clean();
 		}
 
 		// If master_db information does not exist, the config file needs to be updated


### PR DESCRIPTION
`files/config/db.config.php`를 수동으로 편집하는 경우가 있습니다. XE 메뉴얼에도 해당 파일을 편집하라는 가이드가 있죠.

그런데 실수로 BOM문자를 제거하지 않는 경우가 있고, 이 문제때문에 시간을 날리는 경우도 있습니다.

간단히 `include config;` 구문을 `ob_start()` `ob_end_clean();`으로 감싸주는 트릭을 사용합니다.
