### PR TITLE
모바일에서는 파일 첨부 가능 조건을 보이게 수정

### DIFF
--- a/modules/editor/skins/ckeditor/file_upload.html
+++ b/modules/editor/skins/ckeditor/file_upload.html
@@ -10,7 +10,11 @@
 			<input id="xe-fileupload" type="file" class="fileupload-processing " value="{$lang->edit->upload_file}" name="Filedata" data-auto-upload="true" data-editor-sequence="{$editor_sequence}" multiple />
 		</span>
 
+		<!--@if(Mobile::isMobileCheckByAgent())-->
+		<p class="xefu-dropzone-message">{$lang->allowed_filesize} : <span class="allowed_filesize">0MB</span> <span>({$lang->allowed_filetypes} : <span class="allowed_filetypes">*.*</span>)</span></p>
+		<!--@else-->
 		<p class="xefu-dropzone-message">{$lang->ckeditor_about_file_drop_area}</p>
+		<!--@end-->
 
 		<p class="upload_info">{$lang->allowed_filesize} : <span class="allowed_filesize">0MB</span> <span>({$lang->allowed_filetypes} : <span class="allowed_filetypes">*.*</span>)</span></p>
 


### PR DESCRIPTION
모바일에서는 특정상 **여기에 파일을 끌어 놓거나 파일 첨부 버튼을 클릭하세요.** 라는 문구대신에

첨부가능 조건을 보여주는게 상황상 좋겠다고 생각하여 변경했습니다.
