### PR TITLE
fixed #1605: $db_info->umask 옵션 추가. chmod() 사용하지 말고 umask()로 제어되게 고침

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -154,8 +154,18 @@ class FileHandler
 			$flags = FILE_APPEND;
 		}
 
+		$info = Context::getDBInfo();
+		// set umask()
+		if(isset($info->umask))
+		{
+			$omask = umask($info->umask);
+		}
+		else
+		{
+			$omask = umask(0002);
+		}
 		@file_put_contents($filename, $buff, $flags|LOCK_EX);
-		@chmod($filename, 0644);
+		umask($omask);
 	}
 
 	/**
@@ -286,8 +296,18 @@ class FileHandler
 
 		if(!ini_get('safe_mode'))
 		{
-			@mkdir($path_string, 0755, TRUE);
-			@chmod($path_string, 0755);
+			$info = Context::getDBInfo();
+			// set umask()
+			if(isset($info->umask))
+			{
+				$omask = umask($info->umask & ~0111);
+			}
+			else
+			{
+				$omask = umask(0000);
+			}
+			@mkdir($path_string, 0775, TRUE);
+			umask($omask);
 		}
 		// if safe_mode is on, use FTP
 		else
@@ -841,6 +861,17 @@ class FileHandler
 		// create directory
 		self::makeDir(dirname($target_file));
 
+		$info = Context::getDBInfo();
+		// set umask()
+		if(isset($info->umask))
+		{
+			$omask = umask($info->umask);
+		}
+		else
+		{
+			$omask = umask(0002);
+		}
+
 		// write into the file
 		$output = NULL;
 		switch($target_type)
@@ -872,6 +903,7 @@ class FileHandler
 				}
 				break;
 		}
+		umask($omask);
 
 		imagedestroy($thumb);
 		imagedestroy($source);
@@ -880,7 +912,6 @@ class FileHandler
 		{
 			return FALSE;
 		}
-		@chmod($target_file, 0644);
 
 		return TRUE;
 	}


### PR DESCRIPTION
- chmod()로 제어할 것이 아니라 umask에 따르도록 고침
- 일반유저로 2777 sgid비트를 세팅한 경우에 건드리지 않음
- 관리자 유저의 경우에 umask=0006, 0066등으로 세팅해서 보안강화 가능
