### PR TITLE
템플리트에서 include를 프리프로세싱 외

### DIFF
--- a/classes/cache/CacheApc.class.php
+++ b/classes/cache/CacheApc.class.php
@@ -16,13 +16,13 @@ class CacheApc extends CacheBase
 	 * @param void $opt Not used
 	 * @return CacheApc instance of CacheApc
 	 */
-	function getInstance($opt = null)
+	function getInstance($target = 'default')
 	{
-		if(!$GLOBALS['__CacheApc__'])
+		if(!$GLOBALS['__CacheApc__'][$target])
 		{
-			$GLOBALS['__CacheApc__'] = new CacheApc();
+			$GLOBALS['__CacheApc__'][$target] = new CacheApc($target);
 		}
-		return $GLOBALS['__CacheApc__'];
+		return $GLOBALS['__CacheApc__'][$target];
 	}
 
 	/**
@@ -30,8 +30,9 @@ class CacheApc extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheApc()
+	function CacheApc($target = 'default')
 	{
+		$this->target = 'default';
 	}
 
 	/**
@@ -42,6 +43,16 @@ class CacheApc extends CacheBase
 	function isSupport()
 	{
 		return self::$isSupport;
+	}
+
+	/**
+	 * Return cache type
+	 *
+	 * @return string apc
+	 */
+	function getType()
+	{
+		return 'apc';
 	}
 
 	/**

--- a/classes/cache/CacheFile.class.php
+++ b/classes/cache/CacheFile.class.php
@@ -131,7 +131,7 @@ class CacheFile extends CacheBase
 
 		if(file_exists($cache_file))
 		{
-			if($modified_time > 0 && filemtime($cache_file) < $modified_timed)
+			if($modified_time > 0 && filemtime($cache_file) < $modified_time)
 			{
 				FileHandler::removeFile($cache_file);
 				return false;

--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -207,7 +207,7 @@ class CacheHandler extends Handler
 	 */
 	function put($key, $obj, $valid_time = 0)
 	{
-		if(!$this->handler && !$key)
+		if(!$this->handler || !$key)
 		{
 			return false;
 		}

--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -205,7 +205,7 @@ class CacheHandler extends Handler
 	 * 							If no ttl is supplied, use the default valid time.
 	 * @return bool|void Returns true on success or false on failure. If use CacheFile, returns void.
 	 */
-	function put($key, $obj, $valid_time = 0)
+	function put($key, $obj, $valid_time = 0, $params = null)
 	{
 		if(!$this->handler || !$key)
 		{
@@ -214,7 +214,7 @@ class CacheHandler extends Handler
 
 		$key = $this->getCacheKey($key);
 
-		return $this->handler->put($key, $obj, $valid_time);
+		return $this->handler->put($key, $obj, $valid_time, $params);
 	}
 
 	/**

--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -105,6 +105,11 @@ class CacheHandler extends Handler
 				{
 					$type = 'wincache';
 				}
+				else
+				{
+					// always use file type for template
+					$type = 'file';
+				}
 			}
 			else
 			{

--- a/classes/cache/CacheMemcache.class.php
+++ b/classes/cache/CacheMemcache.class.php
@@ -20,13 +20,13 @@ class CacheMemcache extends CacheBase
 	 * @param string $url url of memcache
 	 * @return CacheMemcache instance of CacheMemcache
 	 */
-	function getInstance($url)
+	function getInstance($target, $url)
 	{
-		if(!$GLOBALS['__CacheMemcache__'])
+		if(!$GLOBALS['__CacheMemcache__'][$target])
 		{
-			$GLOBALS['__CacheMemcache__'] = new CacheMemcache($url);
+			$GLOBALS['__CacheMemcache__'][$target] = new CacheMemcache($target, $url);
 		}
-		return $GLOBALS['__CacheMemcache__'];
+		return $GLOBALS['__CacheMemcache__'][$target];
 	}
 
 	/**
@@ -36,11 +36,12 @@ class CacheMemcache extends CacheBase
 	 * @param string $url url of memcache
 	 * @return void
 	 */
-	function CacheMemcache($url)
+	function CacheMemcache($target, $url)
 	{
 		//$config['url'] = array('memcache://localhost:11211');
 		$config['url'] = is_array($url) ? $url : array($url);
 		$this->Memcache = new Memcache;
+		$this->target = $target;
 
 		foreach($config['url'] as $url)
 		{
@@ -71,6 +72,16 @@ class CacheMemcache extends CacheBase
 		}
 
 		return $GLOBALS['XE_MEMCACHE_SUPPORT'];
+	}
+
+	/**
+	 * Return cache type
+	 *
+	 * @return string memcache
+	 */
+	function getType()
+	{
+		return 'memcache';
 	}
 
 	/**

--- a/classes/cache/CacheWincache.class.php
+++ b/classes/cache/CacheWincache.class.php
@@ -18,13 +18,13 @@ class CacheWincache extends CacheBase
 	 * @param void $opt Not used
 	 * @return CacheWincache instance of CacheWincache
 	 */
-	function getInstance($opt = null)
+	function getInstance($target = 'default')
 	{
-		if(!$GLOBALS['__CacheWincache__'])
+		if(!$GLOBALS['__CacheWincache__'][$target])
 		{
-			$GLOBALS['__CacheWincache__'] = new CacheWincache();
+			$GLOBALS['__CacheWincache__'][$target] = new CacheWincache($target);
 		}
-		return $GLOBALS['__CacheWincache__'];
+		return $GLOBALS['__CacheWincache__'][$target];
 	}
 
 	/**
@@ -32,8 +32,9 @@ class CacheWincache extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheWincache()
+	function CacheWincache($target = 'default')
 	{
+		$this->target = $target;
 	}
 
 	/**
@@ -44,6 +45,16 @@ class CacheWincache extends CacheBase
 	function isSupport()
 	{
 		return self::$isSupport;
+	}
+
+	/**
+	 * Return cache type
+	 *
+	 * @return string wincache
+	 */
+	function getType()
+	{
+		return 'wincache';
 	}
 
 	/**

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -2156,7 +2156,6 @@ class Context
 				}
 			}
 			$validator = new Validator($file);
-			$validator->setCacheDir('files/cache');
 			$file = $validator->getJsPath();
 		}
 

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -150,7 +150,12 @@ class TemplateHandler
 		else
 		{
 			$buff = $this->parse();
-			$oCacheHandler->put($this->file, $buff);
+			$params = array();
+			if(!empty($this->deps))
+			{
+				$params['depends'] = $this->deps;
+			}
+			$oCacheHandler->put($this->file, $buff, 0, $params);
 			$output = $this->_fetch($buff);
 		}
 
@@ -266,12 +271,7 @@ class TemplateHandler
 		}
 
 		// prevent from calling directly before writing into file
-		$header = '<'.'?php if(!defined("__XE__"))exit;';
-		if(count($this->deps))
-		{
-			$header .= "\n".'$depends = '.var_export($this->deps, TRUE).";\n";
-		}
-		$buff = $header . '?' . '>' . $buff;
+		$buff = '<?php if(!defined("__XE__"))exit;?>' . $buff;
 
 		// remove php script reopening
 		$buff = preg_replace(array('/(\n|\r\n)+/', '/(;)?( )*\?\>\<\?php([\n\t ]+)?/'), array("\n", ";\n"), $buff);

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -266,12 +266,12 @@ class TemplateHandler
 		}
 
 		// prevent from calling directly before writing into file
-		$header = '<'.'?php if(!defined("__XE__"))exit;' . "\n";
+		$header = '<'.'?php if(!defined("__XE__"))exit;';
 		if(count($this->deps))
 		{
-			$header .= '$depends = '.var_export($this->deps, TRUE).';';
+			$header .= "\n".'$depends = '.var_export($this->deps, TRUE).";\n";
 		}
-		$buff = $header . '?' . ">\n" . $buff;
+		$buff = $header . '?' . '>' . $buff;
 
 		// remove php script reopening
 		$buff = preg_replace(array('/(\n|\r\n)+/', '/(;)?( )*\?\>\<\?php([\n\t ]+)?/'), array("\n", ";\n"), $buff);

--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -537,7 +537,6 @@ class memberAdminController extends member
 		unset($xml_buff);
 
 		$validator   = new Validator($xml_file);
-		$validator->setCacheDir('files/cache');
 		$validator->getJsPath();
 	}
 
@@ -565,7 +564,6 @@ class memberAdminController extends member
 		Filehandler::writeFile($xml_file, $xml_buff);
 
 		$validator   = new Validator($xml_file);
-		$validator->setCacheDir('files/cache');
 		$validator->getJsPath();
 	}
 
@@ -596,7 +594,6 @@ class memberAdminController extends member
 		Filehandler::writeFile($xml_file, $xml_buff);
 
 		$validator   = new Validator($xml_file);
-		$validator->setCacheDir('files/cache');
 		$validator->getJsPath();
 	}
 

--- a/modules/widget/widget.class.php
+++ b/modules/widget/widget.class.php
@@ -14,7 +14,6 @@ class widget extends ModuleObject
 	{
 		// Create cache directory used by widget
 		FileHandler::makeDir('./files/cache/widget');
-		FileHandler::makeDir('./files/cache/widget_cache');
 		// Add this widget compile the trigger for the display.after
 		$oModuleController = getController('module');
 		$oModuleController->insertTrigger('display', 'widget', 'controller', 'triggerWidgetCompile', 'before');

--- a/tests/unit/classes/template/TemplateHandlerTest.php
+++ b/tests/unit/classes/template/TemplateHandlerTest.php
@@ -98,12 +98,12 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             // #include
             array(
                 '<dummy /><!--#include("sample.html")--><div>This is another dummy</div>',
-                '?><dummy /><?php $__tpl=TemplateHandler::getInstance();echo $__tpl->compile(\'tests/unit/classes/template\',\'sample.html\') ?><div>This is another dummy</div>'
+                PHP_EOL.'$depends = array ('.PHP_EOL.'  0 => \'tests/unit/classes/template/sample.html\','.PHP_EOL.');'.PHP_EOL.'?><dummy />'.PHP_EOL.'<?php if($__Context->has_blog){ ?><a href="http://mygony.com">Taggon\'s blog</a><?php } ?>'.PHP_EOL.'<!--#Meta://external.host/js.js--><?php $__tmp=array(\'//external.host/js.js\',\'\',\'\',\'\');Context::loadFile($__tmp);unset($__tmp); ?>'.PHP_EOL.'<div>This is another dummy</div>'
             ),
             // <include target="file">
             array(
                 '<dummy /><include target="../sample.html" /><div>This is another dummy</div>',
-                '?><dummy /><?php $__tpl=TemplateHandler::getInstance();echo $__tpl->compile(\'tests/unit/classes\',\'sample.html\') ?><div>This is another dummy</div>'
+                PHP_EOL.'$depends = array ('.PHP_EOL.'  0 => \'tests/unit/classes/sample.html\','.PHP_EOL.');'.PHP_EOL.'?><dummy />'.PHP_EOL.'<div>This is another dummy</div>'
             ),
             // <load target="../../modules/page/lang/lang.xml">
             array(

--- a/tests/unit/classes/template/TemplateHandlerTest.php
+++ b/tests/unit/classes/template/TemplateHandlerTest.php
@@ -98,12 +98,12 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             // #include
             array(
                 '<dummy /><!--#include("sample.html")--><div>This is another dummy</div>',
-                PHP_EOL.'$depends = array ('.PHP_EOL.'  0 => \'tests/unit/classes/template/sample.html\','.PHP_EOL.');'.PHP_EOL.'?><dummy />'.PHP_EOL.'<?php if($__Context->has_blog){ ?><a href="http://mygony.com">Taggon\'s blog</a><?php } ?>'.PHP_EOL.'<!--#Meta://external.host/js.js--><?php $__tmp=array(\'//external.host/js.js\',\'\',\'\',\'\');Context::loadFile($__tmp);unset($__tmp); ?>'.PHP_EOL.'<div>This is another dummy</div>'
+                '?><dummy />'.PHP_EOL.'<?php if($__Context->has_blog){ ?><a href="http://mygony.com">Taggon\'s blog</a><?php } ?>'.PHP_EOL.'<!--#Meta://external.host/js.js--><?php $__tmp=array(\'//external.host/js.js\',\'\',\'\',\'\');Context::loadFile($__tmp);unset($__tmp); ?>'.PHP_EOL.'<div>This is another dummy</div>'
             ),
             // <include target="file">
             array(
                 '<dummy /><include target="../sample.html" /><div>This is another dummy</div>',
-                PHP_EOL.'$depends = array ('.PHP_EOL.'  0 => \'tests/unit/classes/sample.html\','.PHP_EOL.');'.PHP_EOL.'?><dummy />'.PHP_EOL.'<div>This is another dummy</div>'
+                '?><dummy />'.PHP_EOL.'<div>This is another dummy</div>'
             ),
             // <load target="../../modules/page/lang/lang.xml">
             array(


### PR DESCRIPTION
XE 템플릿 엔진에서 `<include ...>` 혹은 `<!-- include ...>`를 사용하는 경우 `Context::compile()`을 호출시키고 있습니다. 이 방식의 문제점은
- 컴파일된 결과물이 `compile()`을 또 수행하게 됨. 즉 단 한번의 `compile()`만 수행되는 것이 아니라 `include`된 템플릿 때문에 최소 두차례 `compile()`이 호출됨.
- 딱 한번 컴파일하고, 그 뒤에는 `include()`하면 되는 일반적 템플릿 컴파일의 방식과 차이가 있고 느림. (`compile()`은 파싱을 하기때문에 비교적 느린 작업.
- `1-pass` 처리로 모든게 완료되지 않음.

또한 `include` 뿐만 아니라 `load/unload` 등도 `1-pass` 컴파일을 방해하는 요소가 되고 있습니다.
- 이 패치는 `include`를 `preprocessing`해서 `include`가 해당 템플릿을 읽어들입니다. 이렇게 하여 다시 `compile`이 호출되는 것을 막습니다.
- `include`한 템플릿이 다른 템플릿을 `include`하는 경우가 있습니다. 세차례까지 `include`를 기본적으로 지원하도록 하고 무한 루프에 빠지지 않도록 막습니다.

기타,
- `CacheFile` 클래스를 개선하여 `TemplateHandler`에서 별도로 컴파일 결과를 저장하고 있는 코드 중복을 제거합니다.
- `Cachefile` 클래스의 mtime 체크 버그를 수정하였습니다. (typo 버그)
- `CacheHander` 클래스의 `handler` 체크 버그를 수정하였습니다.
- Unit 테스트도 이에 맞게 수정하였습니다.
