### PR TITLE
ob_gzhandler 대신 zlib.output_compression 사용

### DIFF
--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -28,7 +28,6 @@ class DisplayHandler extends Handler
 		if(
 				(defined('__OB_GZHANDLER_ENABLE__') && __OB_GZHANDLER_ENABLE__ == 1) &&
 				strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== FALSE &&
-				function_exists('ob_gzhandler') &&
 				extension_loaded('zlib') &&
 				$oModule->gzhandler_enable
 		)
@@ -112,16 +111,14 @@ class DisplayHandler extends Handler
 			$this->gz_enabled = FALSE;
 		}
 
-		// results directly output
+		// enable gzip using zlib extension
 		if($this->gz_enabled)
 		{
-			header("Content-Encoding: gzip");
-			print ob_gzhandler($output, 5);
+			ini_set('zlib.output_compression', true);
 		}
-		else
-		{
-			print $output;
-		}
+
+		// results directly output
+		print $output;
 
 		// call a trigger after display
 		ModuleHandler::triggerCall('display', 'after', $output);


### PR DESCRIPTION
참고: https://www.xpressengine.com/forum/23043521

[PHP 매뉴얼](https://secure.php.net/ob_gzhandler)에서도 `ob_gzhandler`보다는 `zlib.output_compression`을 사용하라고 권장하고 있습니다.

> Also note that using zlib.output_compression is preferred over ob_gzhandler().

실제 기능은 똑같지만, `ob_gzhandler`는 경우에 따라 `FALSE`를 반환하는 경우도 있기 때문에 간혹 백지현상의 원인이 되는 게 아닌가 의심이 들기도 합니다. `zlib.output_compression`을 사용하면 이런 문제는 봉쇄되겠지요.
