### PR TITLE
개선된 Cache

### DIFF
--- a/classes/cache/CacheApc.class.php
+++ b/classes/cache/CacheApc.class.php
@@ -16,13 +16,13 @@ class CacheApc extends CacheBase
 	 * @param void $opt Not used
 	 * @return CacheApc instance of CacheApc
 	 */
-	function getInstance($opt = null)
+	function getInstance($target = 'default')
 	{
-		if(!$GLOBALS['__CacheApc__'])
+		if(!$GLOBALS['__CacheApc__'][$target])
 		{
-			$GLOBALS['__CacheApc__'] = new CacheApc();
+			$GLOBALS['__CacheApc__'][$target] = new CacheApc($target);
 		}
-		return $GLOBALS['__CacheApc__'];
+		return $GLOBALS['__CacheApc__'][$target];
 	}
 
 	/**
@@ -30,8 +30,9 @@ class CacheApc extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheApc()
+	function CacheApc($target = 'default')
 	{
+		$this->target = 'default';
 	}
 
 	/**
@@ -42,6 +43,16 @@ class CacheApc extends CacheBase
 	function isSupport()
 	{
 		return self::$isSupport;
+	}
+
+	/**
+	 * Return cache type
+	 *
+	 * @return string apc
+	 */
+	function getType()
+	{
+		return 'apc';
 	}
 
 	/**

--- a/classes/cache/CacheFile.class.php
+++ b/classes/cache/CacheFile.class.php
@@ -131,7 +131,7 @@ class CacheFile extends CacheBase
 
 		if(file_exists($cache_file))
 		{
-			if($modified_time > 0 && filemtime($cache_file) < $modified_timed)
+			if($modified_time > 0 && filemtime($cache_file) < $modified_time)
 			{
 				FileHandler::removeFile($cache_file);
 				return false;

--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -207,7 +207,7 @@ class CacheHandler extends Handler
 	 */
 	function put($key, $obj, $valid_time = 0)
 	{
-		if(!$this->handler && !$key)
+		if(!$this->handler || !$key)
 		{
 			return false;
 		}

--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -205,7 +205,7 @@ class CacheHandler extends Handler
 	 * 							If no ttl is supplied, use the default valid time.
 	 * @return bool|void Returns true on success or false on failure. If use CacheFile, returns void.
 	 */
-	function put($key, $obj, $valid_time = 0)
+	function put($key, $obj, $valid_time = 0, $params = null)
 	{
 		if(!$this->handler || !$key)
 		{
@@ -214,7 +214,7 @@ class CacheHandler extends Handler
 
 		$key = $this->getCacheKey($key);
 
-		return $this->handler->put($key, $obj, $valid_time);
+		return $this->handler->put($key, $obj, $valid_time, $params);
 	}
 
 	/**

--- a/classes/cache/CacheMemcache.class.php
+++ b/classes/cache/CacheMemcache.class.php
@@ -20,13 +20,13 @@ class CacheMemcache extends CacheBase
 	 * @param string $url url of memcache
 	 * @return CacheMemcache instance of CacheMemcache
 	 */
-	function getInstance($url)
+	function getInstance($target, $url)
 	{
-		if(!$GLOBALS['__CacheMemcache__'])
+		if(!$GLOBALS['__CacheMemcache__'][$target])
 		{
-			$GLOBALS['__CacheMemcache__'] = new CacheMemcache($url);
+			$GLOBALS['__CacheMemcache__'][$target] = new CacheMemcache($target, $url);
 		}
-		return $GLOBALS['__CacheMemcache__'];
+		return $GLOBALS['__CacheMemcache__'][$target];
 	}
 
 	/**
@@ -36,11 +36,12 @@ class CacheMemcache extends CacheBase
 	 * @param string $url url of memcache
 	 * @return void
 	 */
-	function CacheMemcache($url)
+	function CacheMemcache($target, $url)
 	{
 		//$config['url'] = array('memcache://localhost:11211');
 		$config['url'] = is_array($url) ? $url : array($url);
 		$this->Memcache = new Memcache;
+		$this->target = $target;
 
 		foreach($config['url'] as $url)
 		{
@@ -71,6 +72,16 @@ class CacheMemcache extends CacheBase
 		}
 
 		return $GLOBALS['XE_MEMCACHE_SUPPORT'];
+	}
+
+	/**
+	 * Return cache type
+	 *
+	 * @return string memcache
+	 */
+	function getType()
+	{
+		return 'memcache';
 	}
 
 	/**

--- a/classes/cache/CacheWincache.class.php
+++ b/classes/cache/CacheWincache.class.php
@@ -18,13 +18,13 @@ class CacheWincache extends CacheBase
 	 * @param void $opt Not used
 	 * @return CacheWincache instance of CacheWincache
 	 */
-	function getInstance($opt = null)
+	function getInstance($target = 'default')
 	{
-		if(!$GLOBALS['__CacheWincache__'])
+		if(!$GLOBALS['__CacheWincache__'][$target])
 		{
-			$GLOBALS['__CacheWincache__'] = new CacheWincache();
+			$GLOBALS['__CacheWincache__'][$target] = new CacheWincache($target);
 		}
-		return $GLOBALS['__CacheWincache__'];
+		return $GLOBALS['__CacheWincache__'][$target];
 	}
 
 	/**
@@ -32,8 +32,9 @@ class CacheWincache extends CacheBase
 	 *
 	 * @return void
 	 */
-	function CacheWincache()
+	function CacheWincache($target = 'default')
 	{
+		$this->target = $target;
 	}
 
 	/**
@@ -44,6 +45,16 @@ class CacheWincache extends CacheBase
 	function isSupport()
 	{
 		return self::$isSupport;
+	}
+
+	/**
+	 * Return cache type
+	 *
+	 * @return string wincache
+	 */
+	function getType()
+	{
+		return 'wincache';
 	}
 
 	/**


### PR DESCRIPTION
#1629 에서 갈라져나왔습니다. 이 패치는 #1629 에 포함되어있습니다.
- `$target`이 `object`와 `template`일 경우에는 기존의 방식 그대로 실행됩니다.
- `$target`이 `object` 혹은 `template`가 아닌 경우는
  - 저장할 값이 `array/object` 경우에는 `object`처럼 `serialize()`되어 저장되며
  - 일반 텍스트로 저장할 경우 (컴파일된 `php` 혹은 일반 텍스트 모두 포함) 일반 텍스트로 저장됩니다.
- 값을 다시 불러오기 위해 `get()`을 쓰면 `object`일 경우에는 기존 방식처럼 `unserialize()`를, 일반 텍스트일 경우에는 `php`인지 아닌지 자동 판별하여, `php`인 경우에는 `include`후 `unserialize()`, 일반 텍스트이면 `file_get_contents()`
- 특별히 캐시된 파일 이름만 얻고싶은 경우에는 `get($key, 0, true)`를 호출하면 캐싱된 파일 이름만 가져옵니다.
- 인스턴스는 지정된 `$target`별로 각각 만들어집니다.
## 실제 사용 례

``` php
<?php
...
$rss = Cache::getInstance("RSS");
$url = "http://foobar.com/atom.rss";
....

$key = md5($url);
if($rss->isValid($key, $mtime_or_ttl))
{
  $fetched = $rss->get($key);
}
else
{
  // real job
...
  $fetched = $http->get($key);
..
  $rss->put($key, $fetched);
}
```
