### PR TITLE
게시판/댓글 모듈의 메일 발송인을 닉네임으로 표시

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -142,7 +142,7 @@ class boardController extends board
 				$oMail = new Mail();
 				$oMail->setTitle($obj->title);
 				$oMail->setContent( sprintf("From : <a href=\"%s\">%s</a><br/>\r\n%s", getFullUrl('','document_srl',$obj->document_srl), getFullUrl('','document_srl',$obj->document_srl), $obj->content));
-				$oMail->setSender($obj->user_name, $obj->email_address);
+				$oMail->setSender($obj->nick_name, $obj->email_address);
 
 				$target_mail = explode(',',$this->module_info->admin_mail);
 				for($i=0;$i<count($target_mail);$i++)

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -127,7 +127,7 @@ class commentAdminController extends comment
 						<br />
 						";
 					$oMail->setContent($mail_content);
-					$oMail->setSender($logged_info->user_name, $logged_info->email_address);
+					$oMail->setSender($logged_info->nick_name, $logged_info->email_address);
 
 					$document_author_email = $oDocument->variables['email_address'];
 


### PR DESCRIPTION
현재 user_id 라는 해당 회원의 숫자값으로 보낸이를 세팅하여 보내주고 있습니다.

이는 알기 어려우므로 기본적으로 닉네임으로 발송인을 지정합니다.


(메일은 게시판 설정중 관리자 E-mail 에 적으면 날라오는 이메일입니다...)

P.S 현재 메일을 보낼때 영문으로 작성된 템플렛에 보내주고 있는데 다국어 지원을 하면 좋을거 같습니다.