### PR TITLE
다양하게 활용 가능한 암호화 클래스 추가

### DIFF
--- a/classes/security/Crypto.class.php
+++ b/classes/security/Crypto.class.php
@@ -1,0 +1,333 @@
+<?php
+/* Copyright (C) NAVER <http://www.navercorp.com> */
+
+/**
+ * This class makes encryption and digital signing easy to use in XE.
+ * 
+ * The encryption methods use AES-128, and is fully compatible with
+ * https://github.com/defuse/php-encryption
+ * except that it uses base64-encoded keys and ciphertexts.
+ * 
+ * The digital signature methods is based on the same SHA-256 based
+ * key derivation function used by the encryption methods.
+ * 
+ * A key is automatically generated and saved to the files/config directory
+ * when first invoked. The same key will be used for all subsequent
+ * method calls that do not specify a different key.
+ * The key must be a binary string exactly 16 bytes long.
+ * 
+ * @file Crypto.class.php
+ * @author Kijin Sung (kijin@kijinsung.com)
+ * @package /classes/security
+ * @version 1.0
+ */
+class Crypto
+{
+	/**
+	 * @brief Default configuration
+	 */
+	const ENCRYPTION_ALGO = 'aes-128';
+	const ENCRYPTION_MODE = 'cbc';
+	const ENCRYPTION_BLOCK_SIZE = 16;
+	const ENCRYPTION_KEY_SIZE = 16;
+	const ENCRYPTION_KEY_INFO = 'DefusePHP|KeyForEncryption';
+	const ENCRYPTION_MAC_ALGO = 'sha256';
+	const ENCRYPTION_MAC_SIZE = 32;
+	const ENCRYPTION_MAC_INFO = 'DefusePHP|KeyForAuthentication';
+	const SIGNATURE_ALGO = 'sha256';
+	const SIGNATURE_SIZE = '32';
+	
+	/**
+	 * @brief The default key
+	 */
+	protected static $_default_key = null;
+
+	/**
+	 * @brief The currently selected extension
+	 */
+	protected static $_extension = null;
+
+	/**
+	 * @brief Constructor
+	 */
+	public function __construct()
+	{
+		if(function_exists('openssl_encrypt'))
+		{
+			self::$_extension = 'openssl';
+		}
+		elseif(function_exists('mcrypt_encrypt'))
+		{
+			self::$_extension = 'mcrypt';
+		}
+		else
+		{
+			throw new Exception('Crypto class requires openssl or mcrypt extension.');
+		}
+	}
+
+	/**
+	 * @brief Check if cryptography is supported on this server
+	 * @return bool
+	 */
+	public static function isSupported()
+	{
+		return (function_exists('openssl_encrypt') || function_exists('mcrypt_encrypt'));
+	}
+
+	/**
+	 * @brief Encrypt a string
+	 * @param string $plaintext The string to encrypt
+	 * @param string $key Optional key. If empty, default key will be used.
+	 * @return string
+	 */
+	public function encrypt($plaintext, $key = null)
+	{
+		if($key === null || $key === '')
+		{
+			$key = self::_getDefaultKey();
+		}
+
+		// Generate subkey for encryption
+		$enc_key = self::_defuseCompatibleHKDF($key, self::ENCRYPTION_KEY_INFO);
+
+		// Generate IV
+		$iv = self::_createIV();
+
+		// Encrypt the plaintext
+		if(self::$_extension === 'openssl')
+		{
+			$openssl_method = self::ENCRYPTION_ALGO . '-' . self::ENCRYPTION_MODE;
+			$ciphertext = openssl_encrypt($plaintext, $openssl_method, $enc_key, OPENSSL_RAW_DATA, $iv);
+		}
+		else
+		{
+			$mcrypt_method = str_replace('aes', 'rijndael', self::ENCRYPTION_ALGO);
+			$plaintext = self::_applyPKCS7Padding($plaintext, self::ENCRYPTION_BLOCK_SIZE);
+			$ciphertext = mcrypt_encrypt($mcrypt_method, $enc_key, $plaintext, self::ENCRYPTION_MODE, $iv);
+		}
+
+		// Generate MAC
+		$mac_key = self::_defuseCompatibleHKDF($key, self::ENCRYPTION_MAC_INFO);
+		$mac = hash_hmac(self::ENCRYPTION_MAC_ALGO, ($iv . $ciphertext), $mac_key, true);
+
+		// Return the MAC, IV, and ciphertext as a base64 encoded string
+		return base64_encode($mac . $iv . $ciphertext);
+	}
+
+	/**
+	 * @brief Decrypt a string
+	 * @param string $ciphertext The string to decrypt
+	 * @param string $key Optional key. If empty, default key will be used.
+	 * @return string
+	 */
+	public function decrypt($ciphertext, $key = null)
+	{
+		if($key === null || $key === '')
+		{
+			$key = self::_getDefaultKey();
+		}
+		
+		// Base64 decode the ciphertext and check the length
+		$ciphertext = @base64_decode($ciphertext);
+		if(strlen($ciphertext) < (self::ENCRYPTION_MAC_SIZE + (self::ENCRYPTION_BLOCK_SIZE * 2)))
+		{
+			return false;
+		}
+
+		// Extract MAC and IV from the remainder of the ciphertext
+		$mac = substr($ciphertext, 0, self::ENCRYPTION_MAC_SIZE);
+		$iv = substr($ciphertext, self::ENCRYPTION_MAC_SIZE, self::ENCRYPTION_BLOCK_SIZE);
+		$ciphertext = substr($ciphertext, self::ENCRYPTION_MAC_SIZE + self::ENCRYPTION_BLOCK_SIZE);
+
+		// Validate MAC
+		$mac_key = self::_defuseCompatibleHKDF($key, self::ENCRYPTION_MAC_INFO);
+		$mac_compare = hash_hmac(self::ENCRYPTION_MAC_ALGO, ($iv . $ciphertext), $mac_key, true);
+		$oPassword = new Password();
+		if(!$oPassword->strcmpConstantTime($mac, $mac_compare))
+		{
+			return false;
+		}
+
+		// Generate subkey for encryption
+		$enc_key = self::_defuseCompatibleHKDF($key, self::ENCRYPTION_KEY_INFO);
+
+		// Decrypt the ciphertext
+		if (self::$_extension === 'openssl')
+		{
+			$openssl_method = self::ENCRYPTION_ALGO . '-' . self::ENCRYPTION_MODE;
+			$plaintext = openssl_decrypt($ciphertext, $openssl_method, $enc_key, OPENSSL_RAW_DATA, $iv);
+		}
+		else
+		{
+			$mcrypt_method = str_replace('aes', 'rijndael', self::ENCRYPTION_ALGO);
+			$plaintext = @mcrypt_decrypt($mcrypt_method, $enc_key, $ciphertext, self::ENCRYPTION_MODE, $iv);
+			if($plaintext === false)
+			{
+				return false;
+			}
+			$plaintext = self::_stripPKCS7Padding($plaintext, self::ENCRYPTION_BLOCK_SIZE);
+			if($plaintext === false)
+			{
+				return false;
+			}
+		}
+
+		// Return the plaintext
+		return $plaintext;
+	}
+
+	/**
+	 * @brief Create a digital signature of a string
+	 * @param string $plaintext The string to sign
+	 * @param string $key Optional key. If empty, default key will be used.
+	 * @return string
+	 */
+	public function createSignature($plaintext, $key = null)
+	{
+		if($key === null || $key === '')
+		{
+			$key = self::_getDefaultKey();
+		}
+
+		// Generate a signature using HMAC
+		return bin2hex(self::_defuseCompatibleHKDF($plaintext, $key));
+	}
+
+	/**
+	 * @brief Verify a digital signature
+	 * @param string $signature The signature to verify
+	 * @param string $plaintext The string to verify
+	 * @param string $key Optional key. If empty, default key will be used.
+	 * @return bool
+	 */
+	public function verifySignature($signature, $plaintext, $key = null)
+	{
+		if($key === null || $key === '')
+		{
+			$key = self::_getDefaultKey();
+		}
+
+		// Verify the signature using HMAC
+		$oPassword = new Password();
+		$compare = bin2hex(self::_defuseCompatibleHKDF($plaintext, $key));
+		return $oPassword->strcmpConstantTime($signature, $compare);
+	}
+
+	/**
+	 * @brief Get the default key
+	 * @return string
+	 */
+	protected static function _getDefaultKey()
+	{
+		if(self::$_default_key !== null)
+		{
+			return base64_decode(self::$_default_key);
+		}
+		else
+		{
+			$file_name = _XE_PATH_ . 'files/config/crypto.config.php';
+			if(file_exists($file_name) && is_readable($file_name))
+			{
+				$key = (include $file_name);
+			}
+			if(!isset($key) || !is_string($key))
+			{
+				$key = self::_createSecureKey();
+				self::_setDefaultKey($key);
+			}
+			return base64_decode(self::$_default_key = $key);
+		}
+	}
+
+	/**
+	 * @brief Set the default key
+	 * @param string $key The default key
+	 * @return void
+	 */
+	protected static function _setDefaultKey($key)
+	{
+		self::$_default_key = $key = trim($key);
+		$file_name = _XE_PATH_ . 'files/config/crypto.config.php';
+		$file_content = '<?php return ' . var_export($key, true) . ';' . PHP_EOL;
+		FileHandler::writeFile($file_name, $file_content);
+	}
+
+	/**
+	 * @brief Create a secure key
+	 * @return string
+	 */
+	protected static function _createSecureKey()
+	{
+		$oPassword = new Password();
+		return base64_encode($oPassword->createSecureSalt(16, 'binary'));
+	}
+
+	/**
+	 * @brief Create an IV
+	 * @return string
+	 */
+	protected static function _createIV()
+	{
+		$is_windows = (defined('PHP_OS') && strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+		if(function_exists('openssl_random_pseudo_bytes') && (!$is_windows || version_compare(PHP_VERSION, '5.4', '>=')))
+		{
+			return openssl_random_pseudo_bytes(self::ENCRYPTION_BLOCK_SIZE);
+		}
+		elseif(!$is_windows || version_compare(PHP_VERSION, '5.3.7', '>='))
+		{
+			return mcrypt_create_iv(self::ENCRYPTION_BLOCK_SIZE, MCRYPT_DEV_URANDOM);
+		}
+		else
+		{
+			return mcrypt_create_iv(self::ENCRYPTION_BLOCK_SIZE, MCRYPT_RAND);
+		}
+	}
+
+	
+	/**
+	 * @brief Apply PKCS#7 padding to a string
+	 * @param string $str The string
+	 * @param int $block_size The block size
+	 * @return string
+	 */
+	protected static function _applyPKCS7Padding($str, $block_size)
+	{
+		$padding_size = $block_size - (strlen($str) % $block_size);
+		if ($padding_size === 0) $padding_size = $block_size;
+		return $str . str_repeat(chr($padding_size), $padding_size);
+	}
+	
+	/**
+	 * @brief Remove PKCS#7 padding from a string
+	 * @param string $str The string
+	 * @param int $block_size The block size
+	 * @return string
+	 */
+	protected static function _stripPKCS7Padding($str, $block_size)
+	{
+		if (strlen($str) % $block_size !== 0) return false;
+		$padding_size = ord(substr($str, -1));
+		if ($padding_size < 1 || $padding_size > $block_size) return false;
+		if (substr($str, (-1 * $padding_size)) !== str_repeat(chr($padding_size), $padding_size)) return false;
+		return substr($str, 0, strlen($str) - $padding_size);
+	}
+
+	/**
+	 * @brief HKDF function compatible with defuse/php-encryption
+	 * @return string
+	 */
+	protected static function _defuseCompatibleHKDF($key, $info)
+	{
+		$salt = str_repeat("\x00", self::ENCRYPTION_MAC_SIZE);
+		$prk = hash_hmac(self::ENCRYPTION_MAC_ALGO, $key, $salt, true);
+		$t = $last_block = '';
+		for ($block_index = 1; strlen($t) < self::ENCRYPTION_KEY_SIZE; $block_index++)
+		{
+			$t .= $last_block = hash_hmac(self::ENCRYPTION_MAC_ALGO, ($last_block . $info . chr($block_index)), $prk, true);
+		}
+		return substr($t, 0, self::ENCRYPTION_KEY_SIZE);
+	}
+}
+/* End of file : Crypto.class.php */
+/* Location: ./classes/security/Crypto.class.php */

--- a/classes/security/Crypto.class.php
+++ b/classes/security/Crypto.class.php
@@ -295,7 +295,7 @@ class Crypto
 	protected static function _createSecureKey()
 	{
 		$oPassword = new Password();
-		return base64_encode($oPassword->createSecureSalt(16, 'binary'));
+		return base64_encode($oPassword->createSecureSalt(ENCRYPTION_KEY_SIZE, 'binary'));
 	}
 
 	/**
@@ -304,19 +304,8 @@ class Crypto
 	 */
 	protected static function _createIV()
 	{
-		$is_windows = (defined('PHP_OS') && strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
-		if(function_exists('openssl_random_pseudo_bytes') && (!$is_windows || version_compare(PHP_VERSION, '5.4', '>=')))
-		{
-			return openssl_random_pseudo_bytes(self::ENCRYPTION_BLOCK_SIZE);
-		}
-		elseif(!$is_windows || version_compare(PHP_VERSION, '5.3.7', '>='))
-		{
-			return mcrypt_create_iv(self::ENCRYPTION_BLOCK_SIZE, MCRYPT_DEV_URANDOM);
-		}
-		else
-		{
-			return mcrypt_create_iv(self::ENCRYPTION_BLOCK_SIZE, MCRYPT_RAND);
-		}
+		$oPassword = new Password();
+		return $oPassword->createSecureSalt(self::ENCRYPTION_BLOCK_SIZE, 'binary');
 	}
 
 	

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -342,6 +342,7 @@ $GLOBALS['__xe_autoload_file_map'] = array_change_key_case(array(
 	'ModuleObject' => 'classes/module/ModuleObject.class.php',
 	'Object' => 'classes/object/Object.class.php',
 	'PageHandler' => 'classes/page/PageHandler.class.php',
+	'Crypto' => 'classes/security/Crypto.class.php',
 	'EmbedFilter' => 'classes/security/EmbedFilter.class.php',
 	'IpFilter' => 'classes/security/IpFilter.class.php',
 	'Password' => 'classes/security/Password.class.php',


### PR DESCRIPTION
전반적인 보안 개선 PR 제3탄입니다. 아마 이게 마지막이 될 것 같네요 ^^

몇 달 전 비밀번호 암호화 개선 PR이 적용된 후, 패치에 포함된 난수생성기를 활용한 다양한 기능 개선이 있었습니다. 자동로그인 인증키, 아이디/비번찾기 인증키, 비공개 파일의 랜덤 파일명 등을 예측하기가 훨씬 어려워졌죠.

이 PR은 암호화 기능 강화의 연장선상에서, 흔히 사용되는 암호화 관련 기능들을 코어에 포함시키자는 제안입니다. 자료실에 서드파티 [암호화 모듈](https://www.xpressengine.com/index.php?mid=download&package_id=22753617)이 있긴 하지만, 따로 설치해야 하고 설정 방법이 복잡해서 정작 강력한 보안이 필요한 코어 모듈에서는 사용하기 어려운 형편이거든요. 그래서 암호화 모듈을 과감하게 단순화하고, 다양하게 활용할 수 있는 디지털 서명 (digital signature) 기능을 추가했습니다.

개요
------

이 PR의 목표는 아래와 같습니다.

- 자타공인 모범답안이라고 할 수 있는 [defuse/php-encryption](https://github.com/defuse/php-encryption) 라이브러리와 100% 호환되는 AES 알고리듬을 사용하되, PHP 5.4 미만인 서버와 `openssl` 대신 `mcrypt` 모듈이 설치된 서버에서도 사용 가능하도록 구현함
- 마찬가지로 defuse/php-encryption 라이브러리에서 사용하는 SHA-256 기반의 HMAC 알고리듬을 사용하여 디지털 서명 기능 제공
- 모든 암호화 키는 자동으로 생성 및 관리하여 코어의 다른 클래스나 최종 사용자는 전혀 신경쓸 필요가 없도록 함

조금 더 설명드리자면

- 암호화(encryption)는 데이터를 읽을 수 없도록 숨기는 방법입니다. 암호화할 때 사용한 키를 갖고 있는 사람만 복호화(decryption)하여 읽을 수 있습니다. 키를 갖고 있지 않은 사람은 데이터를 읽을 수도 없고 위변조할 수도 없습니다.
- 디지털 서명(digital signature)은 데이터를 숨기지는 않지만 위변조를 막을 수 있는 방법입니다. 예를 들어 어떤 변수를 폼에 넣었다가 다시 받을 때, 디지털 서명을 함께 넣으면 사용자가 브라우저의 개발자도구 등을 사용해서 해당 변수를 위변조하더라도 쉽게 파악할 수 있습니다.

이걸 어디다 쓰냐고요?

- 장기적으로 서드파티 모듈에 의존하지 않고도 코어 자체에서 개인정보 암호화 등의 기능을 구현할 수 있게 됩니다.
- 폼을 통해 전달하는 데이터의 위변조 방지를 위해 현재 세션에 의존하고 있는 부분을 암호화 또는 디지털 서명 방식으로 바꾸면 더이상 세션에 대량의 데이터를 저장할 필요가 없어져서 상당한 성능 향상을 기대할 수 있습니다. 예를 들어 지금은 에디터/업로더가 포함된 페이지를 읽을 때마다 세션에 `upload_info`가 무지막지하게 쌓이는데, 디지털 서명을 하면 이렇게 쌓아둘 필요가 없게 됩니다.
- 그 밖에도 인증키를 메일로 전달한다든지, SSO와 같은 부분의 보안 향상이 가능합니다.

코드 예제
------------

이 PR에 포함된 `Crypto` 클래스는 아래와 같은 기능을 제공합니다.

암호화

    $oCrypto = new Crypto();
    $original_text = 'Meet me at the clock tower at 4:30.';
    $encrypted_text = $oCrypto->encrypt($original_text);

복호화

    $oCrypto = new Crypto();
    $original_text = $oCrypto->decrypt($encrypted_text);
    if ($original_text === false)
    {
        // 복호화 실패! 위변조가 의심됨
    }
    else
    {
        // 정상
    }

서명 작성 (`$data`를 폼에 넣기 전에)

    $oCrypto = new Crypto();
    $data = 'foo=1&bar=2&monkeybutt=red';
    $signature = $oCrypto->createSignature($data);

서명 확인 (`$data`와 `$signature`를 폼에서 돌려받은 후)

    $oCrypto = new Crypto();
    if (!$oCrypto->verifySignature($signature, $data))
    {
        // 서명이 틀림! $data가 위변조되었음
    }
    else
    {
        // 정상
    }

현재 세션에서만 유효한 암호화 또는 서명 작성 (암호화 키의 일부를 세션에 저장하여, 다른 세션에서는 복호화 또는 서명 확인이 불가능하도록 만듬)

    $oCrypto->currentSessionOnly();

그 밖의 기술적 정보
-------------------------

현재 세션에서만 유효한 암호화 키는 각 세션에 저장됩니다. 세션과 무관하게 사이트 전체에서 유효한 암호화 키는 `files/config/crypto.config.php`에 저장됩니다.

암호화 키와 암호화 결과는 base64 인코딩하여 반환합니다. 이것을 `base64_decode()`하면 defuse/php-encryption 라이브러리에서도 복호화가 가능합니다. 마찬가지로, defuse/php-encryption 라이브러리에서 암호화한 결과도 `base64_encode()`만 해주면 이 PR의 `Crypto` 클래스에서 복호화가 가능합니다. **즉, 사실상의 표준인 defuse/php-encryption 라이브러리를 추후 적용하더라도 아무 문제가 없을 예정입니다.**

서버에 `openssl` 모듈이 설치되어 있는 경우 성능이 훨씬 향상됩니다. 그러나 `mcrypt` 모듈로도 동일한 결과를 얻을 수 있습니다. 두 모듈 중 아무 것도 설치되어 있지 않은 경우에는 암호화 클래스 사용이 불가능합니다.
