### PR TITLE
Cannot redeclare class HTTP_Request

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -520,7 +520,7 @@ class FileHandler
 		try
 		{
 			requirePear();
-			require_once('HTTP/Request.php');
+			if(!class_exists('HTTP_Request')) require_once('HTTP/Request.php');
 
 			$parsed_url = parse_url(__PROXY_SERVER__);
 			if($parsed_url["host"])


### PR DESCRIPTION
한번에 RSS 를 두번 불러오거나 할 경우, 
Cannot redeclare class HTTP_Request in /home/web/mshop/libs/PEAR.1.9.5/HTTP/Request.php
형태의 에러가 발생하는데,
class 가 중복선언되지 않도록 수정

content 위젯등에서 rss 대상을 복수개 기재한 경우 
또는  rss 를 불러들이는 content 위젯 여러개를 배치하는 경우 발생
