### PR TITLE
회원 상태 를 관리자 회원목록에 출력

### DIFF
--- a/modules/member/tpl/member_list.html
+++ b/modules/member/tpl/member_list.html
@@ -30,6 +30,7 @@
 			<tr>
 				<th scope="col" class="nowr">{$lang->email}</th>
 				<th scope="col" class="nowr" loop="$usedIdentifiers=>$name,$title">{$title}</th>
+				<th scope="col" class="nowr">{$lang->status}</th>
 				<th scope="col" class="nowr"><a href="{getUrl('', 'module', 'admin', 'act', 'dispMemberAdminList', 'sort_index', 'regdate', 'sort_order', ($sort_order == 'asc') ? 'desc' : 'asc')}">{$lang->signup_date}<block cond="$sort_index == 'regdate'"> <em cond="$sort_order=='asc'">▲</em><em cond="$sort_order != 'asc'">▼</em></block></a></th>
 				<th scope="col" class="nowr"><a href="{getUrl('', 'module', 'admin', 'act', 'dispMemberAdminList', 'sort_index', 'last_login', 'sort_order',  ($sort_order == 'asc') ? 'desc' : 'asc')}">{$lang->last_login}<block cond="$sort_index == 'last_login'"> <em cond="$sort_order=='asc'">▲</em><em cond="$sort_order != 'asc'">▼</em></block></a></th>
 				<th scope="col" class="nowr">{$lang->member_group}</th>
@@ -47,6 +48,7 @@
 				</td>
 				{@ $member_info['group_list'] = implode(', ', $member_info['group_list'])}
 				<td class="nowr" loop="$usedIdentifiers=>$name,$title">{$member_info[$name]}</td>
+				<td class="nowr"><!--@if($member_info['denied']=='Y')--><span style="color:red;">{$lang->denied}</span><!--@else-->{$lang->approval}<!--@end--></td>
 				<td class="nowr" title="{zdate($member_info['regdate'], 'Y-m-d H:i:s')}">{zdate($member_info['regdate'], 'Y-m-d')}</td>
 				<td class="nowr" title="{zdate($member_info['last_login'], 'Y-m-d H:i:s')}">{zdate($member_info['last_login'], 'Y-m-d')}</td>
 				<td>{$member_info['group_list']}&nbsp;</td>


### PR DESCRIPTION
메일승인 기능등을 사용하는 경우
회원이 승인 상태인지 , 거부 상태인지를  목록상에서 바로 출력시켜줄 필요가 있다
(비승인 상태인 회원을 정리하기 위해서라도)

목록에 출력되도록 수정
