### PR TITLE
Fix #1577 서양 언어 사용시 getRegdateDT() 등이 잘못된 포맷을 반환

### DIFF
--- a/modules/comment/comment.item.php
+++ b/modules/comment/comment.item.php
@@ -377,9 +377,9 @@ class commentItem extends Object
 		return $content;
 	}
 
-	function getRegdate($format = 'Y.m.d H:i:s')
+	function getRegdate($format = 'Y.m.d H:i:s', $conversion = TRUE)
 	{
-		return zdate($this->get('regdate'), $format);
+		return zdate($this->get('regdate'), $format, $conversion);
 	}
 
 	function getRegdateTime()
@@ -396,12 +396,12 @@ class commentItem extends Object
 
 	function getRegdateGM()
 	{
-		return $this->getRegdate('D, d M Y H:i:s') . ' ' . $GLOBALS['_time_zone'];
+		return $this->getRegdate('D, d M Y H:i:s', FALSE) . ' ' . $GLOBALS['_time_zone'];
 	}
 
-	function getUpdate($format = 'Y.m.d H:i:s')
+	function getUpdate($format = 'Y.m.d H:i:s', $conversion = TRUE)
 	{
-		return zdate($this->get('last_update'), $format);
+		return zdate($this->get('last_update'), $format, $conversion);
 	}
 
 	function getPermanentUrl()

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -551,9 +551,9 @@ class documentItem extends Object
 		return $content;
 	}
 
-	function getRegdate($format = 'Y.m.d H:i:s')
+	function getRegdate($format = 'Y.m.d H:i:s', $conversion = TRUE)
 	{
-		return zdate($this->get('regdate'), $format);
+		return zdate($this->get('regdate'), $format, $conversion);
 	}
 
 	function getRegdateTime()
@@ -570,17 +570,17 @@ class documentItem extends Object
 
 	function getRegdateGM()
 	{
-		return $this->getRegdate('D, d M Y H:i:s').' '.$GLOBALS['_time_zone'];
+		return $this->getRegdate('D, d M Y H:i:s', FALSE).' '.$GLOBALS['_time_zone'];
 	}
 
 	function getRegdateDT()
 	{
-		return $this->getRegdate('Y-m-d').'T'.$this->getRegdate('H:i:s').substr($GLOBALS['_time_zone'],0,3).':'.substr($GLOBALS['_time_zone'],3,2);
+		return $this->getRegdate('Y-m-d', FALSE).'T'.$this->getRegdate('H:i:s', FALSE).substr($GLOBALS['_time_zone'],0,3).':'.substr($GLOBALS['_time_zone'],3,2);
 	}
 
-	function getUpdate($format = 'Y.m.d H:i:s')
+	function getUpdate($format = 'Y.m.d H:i:s', $conversion = TRUE)
 	{
-		return zdate($this->get('last_update'), $format);
+		return zdate($this->get('last_update'), $format, $conversion);
 	}
 
 	function getUpdateTime()
@@ -601,7 +601,7 @@ class documentItem extends Object
 
 	function getUpdateDT()
 	{
-		return $this->getUpdate('Y-m-d').'T'.$this->getUpdate('H:i:s').substr($GLOBALS['_time_zone'],0,3).':'.substr($GLOBALS['_time_zone'],3,2);
+		return $this->getUpdate('Y-m-d', FALSE).'T'.$this->getUpdate('H:i:s', FALSE).substr($GLOBALS['_time_zone'],0,3).':'.substr($GLOBALS['_time_zone'],3,2);
 	}
 
 	function getPermanentUrl()


### PR DESCRIPTION
내부적으로 `zdate()` 함수를 호출하면서 `$conversion` 인자가 누락되는 바람에, 특정한 포맷의 결과가 필요한 경우에도 무조건 현재 locale의 포맷을 반환하고 있습니다.

`getRegDateGM()`, `getRegdateDT()`, `getUpdateDT()` 등 특정한 포맷의 결과가 필요한 경우에는 `$conversion = FALSE`로 지정하여 locale과 관계없이 정확한 결과가 나오도록 했습니다.
