### PR TITLE
짧은 주소 미사용시 회원 가입후 이동할 주소가 잘못 생성되는 문제 수정

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -237,7 +237,8 @@ class memberAdminController extends member
 				return new Object('-1', 'msg_exist_selected_module');
 			}
 
-			$args->redirect_url = Context::getDefaultUrl().$redirectModuleInfo->mid;
+			$args->redirect_mid = $redirectModuleInfo->mid;
+			$args->redirect_url = getNotEncodedFullUrl('','mid',$redirectModuleInfo->mid);
 		}
 
 		$args->profile_image = $args->profile_image ? 'Y' : 'N';

--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -141,7 +141,14 @@ class memberAdminView extends member
 
 		if($config->redirect_url)
 		{
-			$mid = str_ireplace(Context::getDefaultUrl(), '', $config->redirect_url);
+			if(!$config->redirect_mid)
+			{
+				$mid = str_ireplace(Context::getDefaultUrl(), '', $config->redirect_url);
+			}
+			else
+			{
+				$mid = $config->redirect_mid;
+			}
 
 			$siteModuleInfo = Context::get('site_module_info');
 
@@ -149,6 +156,7 @@ class memberAdminView extends member
 			$moduleInfo = $oModuleModel->getModuleInfoByMid($mid, (int)$siteModuleInfo->site_srl);
 
 			$config->redirect_url = $moduleInfo->module_srl;
+
 			Context::set('config', $config);
 		}
 

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -72,6 +72,11 @@ class memberModel extends member
 		if(!$config->signature_editor_skin || $config->signature_editor_skin == 'default') $config->signature_editor_skin = 'ckeditor';
 		if(!$config->sel_editor_colorset) $config->sel_editor_colorset = 'moono';
 
+		if($config->redirect_mid)
+		{
+			$config->redirect_url = getNotEncodedFullUrl('','mid',$config->redirect_mid);
+		}
+
 		$member_config = $config;
 
 		return $config;


### PR DESCRIPTION
https://www.xpressengine.com/qna/23047151

짧은 주소 미사용시에도 회원가입후 이동할 주소는 항상 짧은 주소 형태로 생성되는데, 이것을 설정에 따라 짧은 주소를 사용하지 않은 상태에서도 사용할 수 있도록 변경하였습니다. 기존 설정과의 호환성을 위해 redirect_url 값은 기존 그대로 전체 주소가 들어가며, redirect_mid 값에 이동할 실제 mid값을 저장합니다.
