### PR TITLE
제목 없이도 RSS를 비활성화 할 수 있도록 하는 수정 등 PR

### DIFF
--- a/modules/rss/rss.admin.view.php
+++ b/modules/rss/rss.admin.view.php
@@ -55,6 +55,7 @@ class rssAdminView extends rss
 			}
 		}
 		if(!$total_config->feed_document_count) $total_config->feed_document_count = 15;
+		$total_config->url = $oRssModel->getModuleFeedUrl(NULL, '', 'rss');
 
 		Context::set('feed_config', $feed_config);
 		Context::set('total_config', $total_config);

--- a/modules/rss/rss.view.php
+++ b/modules/rss/rss.view.php
@@ -172,7 +172,7 @@ class rssView extends rss
 			$info->id = $proctcl.$_SERVER['HTTP_HOST'].$info->id;
 		}
 
-		$info->language = Context::getLangType();
+		$info->language = str_replace('jp','ja',Context::getLangType());
 		// Set the variables used in the RSS output
 		Context::set('info', $info);
 		Context::set('feed_config', $config);

--- a/modules/rss/ruleset/insertRssConfig.xml
+++ b/modules/rss/ruleset/insertRssConfig.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset version="1.5.0">
-    <customrules>
+	<customrules>
 		<rule name="boolean" type="enum" test="Y,N" />
-    </customrules>
-    <fields>
+	</customrules>
+	<fields>
 		<field name="module" required="true" default="rss" />
 		<field name="act" required="true" default="procRssAdminInsertConfig" />
 		<field name="use_total_feed" required="true" default="Y" rule="boolean" />
-		<field name="feed_title" required="true">
+		<field name="feed_title">
 			<title xml:lang="ko">피드(Feed) 제목</title>
 			<title xml:lang="en">Feed Title</title>
 		</field>

--- a/modules/rss/tpl/rss_admin_index.html
+++ b/modules/rss/tpl/rss_admin_index.html
@@ -12,7 +12,7 @@
 		<input type="hidden" name="xe_validator_id" value="modules/rss/tpl/rss_admin_index/1" />
 		<div class="x_control-group">
 			<div class="x_control-label">{$lang->url}</div>
-			<div class="x_controls" style="padding-top:5px"><a href="{getFullSiteUrl()}rss" target="_blank">{getFullSiteUrl()}rss</a></div>
+			<div class="x_controls" style="padding-top:5px"><a href="{$total_config->url}" target="_blank">{$total_config->url}</a></div>
 		</div>
 		<div class="x_control-group">
 			<label class="x_control-label">{$lang->total_feed}</label>


### PR DESCRIPTION
- RSS 모듈의 관리자 페이지 개선 ( 리라이트 모드가 아닐 때 RSS 피드 주소를 잘못 표시하던 문제 개선 )
- 제목이 없이도 RSS 미사용 할 수 있게 개선 ( RSS 통합 피드 비활성화 https://github.com/xpressengine/xe-core/issues/1573 )
- RSS 내 언어 표시를 표준에 맞게 표시되도록 수정 ( 일본어에 대한 표기 문제 )
