### PR TITLE
fix #1659 확장변수 반환 포맷이 달라질 수 있는 문제 수정

### DIFF
--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -296,7 +296,7 @@ class ExtraItem
 	 */
 	function getValue()
 	{	
-		return $this->_getTypeValue($this->type, $this->value);
+		return htmlspecialchars($this->value, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
 	}
 
 	/**


### PR DESCRIPTION
기존까지 값이 그대로 반환되던 것이 array 등으로 바뀌면서 생기는 문제를 수정합니다.
getValueHTML() 함수를 사용하던 스킨은 이상이 없었으나, getValue() 함수를 사용하는 경우 문제가 있었습니다.
