### PR TITLE
게시물 관리시 쪽지 보내기 기능 보완 및 기능 메시지 기능을 추가하는 PR ( 개선 )

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -2234,9 +2234,10 @@ class documentController extends document
 		{
 			$logged_info = Context::get('logged_info');
 			$message_content = '';
-			if(isset(Context::getLang('default_message_verbs')[$type]) && is_string(Context::getLang('default_message_verbs')[$type]))
+			$default_message_verbs = Context::getLang('default_message_verbs');
+			if(isset($default_message_verbs[$type]) && is_string($default_message_verbs[$type]))
 			{
-				$message_content = sprintf(Context::getLang('default_message_format'), $logged_info->nick_name, Context::getLang('default_message_verbs')[$type]);
+				$message_content = sprintf(Context::getLang('default_message_format'), $logged_info->nick_name, $default_message_verbs[$type]);
 			}
 		}
 		else

--- a/modules/document/lang/lang.xml
+++ b/modules/document/lang/lang.xml
@@ -874,4 +874,66 @@
 		<value xml:lang="jp"><![CDATA[タイトルがないドキュメントです。]]></value>
 		<value xml:lang="zh-TW"><![CDATA[此文章無標題。]]></value>
 	</item>
+	<item name="send_default_message">
+		<value xml:lang="ko"><![CDATA[기본 쪽지 내용으로 보내기]]></value>
+		<value xml:lang="en"><![CDATA[Send the default message]]></value>
+		<value xml:lang="jp"><![CDATA[Send the default message]]></value>
+		<value xml:lang="zh-CN"><![CDATA[Send the default message]]></value>
+		<value xml:lang="zh-TW"><![CDATA[Send the default message]]></value>
+		<value xml:lang="ru"><![CDATA[Send the default message]]></value>
+		<value xml:lang="tr"><![CDATA[Send the default message]]></value>
+		<value xml:lang="vi"><![CDATA[Send the default message]]></value>
+	</item>
+	<item name="default_message_format">
+		<value xml:lang="ko"><![CDATA[%1$s님께서 다음 게시물을 %2$s 합니다.]]></value>
+		<value xml:lang="en"><![CDATA[%1$s %2$s the document below.]]></value>
+		<value xml:lang="jp"><![CDATA[%1$s %2$s the document below.]]></value>
+		<value xml:lang="zh-CN"><![CDATA[%1$s %2$s the document below.]]></value>
+		<value xml:lang="zh-TW"><![CDATA[%1$s %2$s the document below.]]></value>
+		<value xml:lang="ru"><![CDATA[%1$s %2$s the document below.]]></value>
+		<value xml:lang="tr"><![CDATA[%1$s %2$s the document below.]]></value>
+		<value xml:lang="vi"><![CDATA[%1$s %2$s the document below.]]></value>
+	</item>
+	<item name="default_message_verbs" type="array">
+		<item name="move">
+			<value xml:lang="ko"><![CDATA[이동]]></value>
+			<value xml:lang="en"><![CDATA[moves]]></value>
+			<value xml:lang="jp"><![CDATA[moves]]></value>
+			<value xml:lang="zh-CN"><![CDATA[moves]]></value>
+			<value xml:lang="zh-TW"><![CDATA[moves]]></value>
+			<value xml:lang="ru"><![CDATA[moves]]></value>
+			<value xml:lang="tr"><![CDATA[moves]]></value>
+			<value xml:lang="vi"><![CDATA[moves]]></value>
+		</item>
+		<item name="copy">
+			<value xml:lang="ko"><![CDATA[복사]]></value>
+			<value xml:lang="en"><![CDATA[copies]]></value>
+			<value xml:lang="jp"><![CDATA[copies]]></value>
+			<value xml:lang="zh-CN"><![CDATA[copies]]></value>
+			<value xml:lang="zh-TW"><![CDATA[copies]]></value>
+			<value xml:lang="ru"><![CDATA[copies]]></value>
+			<value xml:lang="tr"><![CDATA[copies]]></value>
+			<value xml:lang="vi"><![CDATA[copies]]></value>
+		</item>
+		<item name="delete">
+			<value xml:lang="ko"><![CDATA[삭제]]></value>
+			<value xml:lang="en"><![CDATA[deletes]]></value>
+			<value xml:lang="jp"><![CDATA[deletes]]></value>
+			<value xml:lang="zh-CN"><![CDATA[deletes]]></value>
+			<value xml:lang="zh-TW"><![CDATA[deletes]]></value>
+			<value xml:lang="ru"><![CDATA[deletes]]></value>
+			<value xml:lang="tr"><![CDATA[deletes]]></value>
+			<value xml:lang="vi"><![CDATA[deletes]]></value>
+		</item>
+		<item name="trash">
+			<value xml:lang="ko"><![CDATA[삭제]]></value>
+			<value xml:lang="en"><![CDATA[deletes]]></value>
+			<value xml:lang="jp"><![CDATA[deletes]]></value>
+			<value xml:lang="zh-CN"><![CDATA[deletes]]></value>
+			<value xml:lang="zh-TW"><![CDATA[deletes]]></value>
+			<value xml:lang="ru"><![CDATA[deletes]]></value>
+			<value xml:lang="tr"><![CDATA[deletes]]></value>
+			<value xml:lang="vi"><![CDATA[deletes]]></value>
+		</item>
+	</item>
 </lang>

--- a/modules/document/tpl/checked_list.html
+++ b/modules/document/tpl/checked_list.html
@@ -40,6 +40,7 @@
 			<label class="x_control-label" for="message_content">{$lang->cmd_send_message}</label>
 			<div class="x_controls" style="margin-right:14px">
 				<textarea name="message_content" id="message_content" rows="4" cols="42" style="width:100%"></textarea>
+				<label for="send_default_message" class="x_inline"><input type="checkbox" name="send_default_message" id="send_default_message" value="Y" checked="checked" /> {$lang->send_default_message}</label>
 			</div>
 		</div>
 	</div>
@@ -55,3 +56,19 @@
 	</div>
 	<!--@end-->
 </form>
+<script>
+jQuery(function($){
+	var message_content_area = $('#message_content');
+	if($('#send_default_message').is(':checked'))
+	{
+		message_content_area.prop("disabled", true);
+	}
+	$('#send_default_message').change(function(){
+		if($(this).is(':checked')){
+			message_content_area.prop("disabled", true);
+		} else {
+			message_content_area.prop("disabled", false);
+		}
+	});
+});
+</script>


### PR DESCRIPTION
* 게시글 관리를 이용한 게시글 이동/복사/삭제/휴지통 등의 조작이 실패할 경우 쪽지를 보내지 않음 (실행 순서 변경 - 이동/복사/삭제/휴지통 후에 쪽지 보냄)
* 회원에게 게시글의 상태를 적극적으로 알리기 위해서 기본 메시지 기능 추가. (관리자 누가 어떤 조작을 해서 게시글이 이동/복사/삭제 되었다고 알려줌. - 쪽지 예 "misol님께서 다음 게시물을 이동 합니다."