### PR TITLE
fix #1677 MSSQL 쿼리 구문 오류 해결

### DIFF
--- a/classes/db/DBMssql.class.php
+++ b/classes/db/DBMssql.class.php
@@ -389,7 +389,7 @@ class DBMssql extends DB
 			$size = '';
 		}
 
-		$query = sprintf("alter table %s%s add %s ", $this->prefix, $table_name, $column_name);
+		$query = sprintf("alter table %s%s add \"%s\" ", $this->prefix, $table_name, $column_name);
 		if($size)
 		{
 			$query .= sprintf(" %s(%s) ", $type, $size);
@@ -423,7 +423,7 @@ class DBMssql extends DB
 		{
 			return;
 		}
-		$query = sprintf("alter table %s%s drop %s ", $this->prefix, $table_name, $column_name);
+		$query = sprintf("alter table %s%s drop column \"%s\" ", $this->prefix, $table_name, $column_name);
 		$this->_query($query);
 	}
 


### PR DESCRIPTION
github 어렵습니다 ㅠㅠ
#1677 MSSQL 쿼리 구문 오류 해결

수정내용 : 일부 모듈 등에서 예약어를 칼럼명으로 사용함에 따라 MSSQL에서 인식하지 못하고 뱉어내는 오류를 해결하기 위해 큰따옴표를 추가하였습니다. 이미 배포된 모듈이 많고 향후에도 이런 일이 발생할 수 있기에 PR 올립니다.

SQL Server Express 10.50.2789.0.v1, PHP 5.4.24 환경에서 테스트 되었습니다.
