### PR TITLE
fix #1659 확장변수 반환 포맷이 달라질 수 있는 문제 수정

### DIFF
--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -292,11 +292,11 @@ class ExtraItem
 	/**
 	 * Returns a value for HTML
 	 *
-	 * @return string Returns a value expressed in HTML.
+	 * @return string Returns filtered value
 	 */
 	function getValue()
 	{	
-		return $this->_getTypeValue($this->type, $this->value);
+		return removeHackTag($this->value);
 	}
 
 	/**


### PR DESCRIPTION
`removeHackTag` 함수로 일부 HTML만을 필터링하여 기존 스킨과의 호환성을 유지하면서, XSS 등 취약점이 생길 가능성을 차단합니다.
