### PR TITLE
fix #1673 누락된 확장자 필터 메세지 추가

### DIFF
--- a/common/lang/lang.xml
+++ b/common/lang/lang.xml
@@ -3734,6 +3734,10 @@
 			<value xml:lang="vi"><![CDATA[Định dạng của %s không hợp lệ. Chỉ sử dụng các chữ số]]></value>
 			<value xml:lang="mn"><![CDATA[%s-ын хэлбэр буруу байна. Зөвхөн тоогоор оруулах ёстой.]]></value>
 		</item>
+		<item name="invalid_extension">
+			<value xml:lang="ko"><![CDATA[%s의 형식이 잘못되었습니다. *.* 나 *.jpg;*.gif; 처럼 입력해야 합니다.]]></value>
+			<value xml:lang="en"><![CDATA[The format of %s is invalid. e.g.) *.* or *.jpg;*.gif;.]]></value>
+		</item>
 	</item>
 	<item name="security_invalid_session">
 			<value xml:lang="ko"><![CDATA[바르지 않은 접근입니다. 인증을 위해 다시 로그인해야 합니다.]]></value>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| 사소한 변경 | 예 |
| 버그 수정 | 예 |
| 새로운 기능 | 아니오 |
| 호환성 깨짐 | 아니오 |
| 수정하는 이슈 | #1673 |

확장자 필터 메세지가 누락되어 있습니다. 따라서 허용 확장자 등 확장자 형태의 입력을 받을 때 잘못 입력하면 `invalid_extension`로만 표시됩니다. 이를 다른 필터처럼 올바른 메세지가 표시되도록 고칩니다. 업데이트 이후 캐시파일을 재생성해야 룰셋 파일이 재생성되며 메세지가 변경됩니다.

p.s.)위 표의 코드는

```
| Q | A
| ------------- | ---
| 사소한 변경 | 예/아니오
| 버그 수정 | 예/아니오
| 새로운 기능 | 예/아니오
| 호환성 깨짐 | 예/아니오
| 수정하는 이슈 | #(이슈번호)
```

입니다.
