### PR TITLE
fix #1686 $GLOBALS['HTTP_RAW_POST_DATA'] 버그 수정

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -201,7 +201,10 @@ class Context
 	function init()
 	{
 		if(!isset($GLOBALS['HTTP_RAW_POST_DATA']) && version_compare(PHP_VERSION, '5.6.0', '>=') === true) {
-			if(simplexml_load_string(file_get_contents("php://input")) !== false) $GLOBALS['HTTP_RAW_POST_DATA'] = file_get_contents("php://input");
+			if(file_get_contents("php://input") && (simplexml_load_string(file_get_contents("php://input")) !== false || strpos($_SERVER['CONTENT_TYPE'], 'json') || strpos($_SERVER['HTTP_CONTENT_TYPE'], 'json')))
+			{
+				$GLOBALS['HTTP_RAW_POST_DATA'] = file_get_contents("php://input");
+			}
 		}
 
 		// set context variables in $GLOBALS (to use in display handler)
@@ -211,7 +214,7 @@ class Context
 
 		// 20140429 editor/image_link
 		$this->_checkGlobalVars();
-
+		
 		$this->setRequestMethod('');
 
 		$this->_setXmlRpcArgument();


### PR DESCRIPTION
| Q | A
| ------------- | ---
| 사소한 변경 | 아니오
| 버그 수정 | 예
| 새로운 기능 | 아니오
| 호환성 깨짐 | 아니오
| 수정하는 이슈 | #1686

file_get_contents("php://input")가 XML이 아닐 때 `$GLOBALS['HTTP_RAW_POST_DATA']`가 설정되지 않기에, JSON POST 요청 등이 오작동하는 문제를 해결합니다.

JSON 요청일 경우 `simplexml_load_string` 함수에서 체크를 하지 않고 바로 `$GLOBALS['HTTP_RAW_POST_DATA']` 변수를 설정합니다.