### PR TITLE
fix #1662 임시 저장글을 삭제할 때에는 포인트 증감 처리를 하지 않도록 수정

### DIFF
--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -187,32 +187,37 @@ class pointController extends point
 	 */
 	function triggerDeleteDocument(&$obj)
 	{
-		$module_srl = $obj->module_srl;
-		$member_srl = $obj->member_srl;
-		// The process related to clearing the post object
-		if(!$module_srl || !$member_srl) return new Object();
-		// Run only when logged in
-		$logged_info = Context::get('logged_info');
-		if(!$logged_info->member_srl) return new Object();
-		// Get the points of the member
-		$oPointModel = getModel('point');
-		$cur_point = $oPointModel->getPoint($member_srl, true);
-		// Get the point module information
-		$oModuleModel = getModel('module');
-		$config = $oModuleModel->getModuleConfig('point');
-		$module_config = $oModuleModel->getModulePartConfig('point', $module_srl);
-
-		$point = $module_config['insert_document'];
-		if(strlen($point) == 0 && !is_int($point)) $point = $config->insert_document;
-		// if the point is set to decrease when writing a document, make sure it does not increase the points when deleting an article
-		if($point < 0) return new Object();
-		$cur_point -= $point;
-		// Add points related to deleting an attachment
-		$point = $module_config['upload_file'];
-		if(strlen($point) == 0 && !is_int($point)) $point = $config->upload_file;
-		if($obj->uploaded_count) $cur_point -= $point * $obj->uploaded_count;
-		// Increase the point
-		$this->setPoint($member_srl,$cur_point);
+		$oDocumentModel = getModel('document');
+		
+		if($obj->status != $oDocumentModel->getConfigStatus('temp'))
+		{
+			$module_srl = $obj->module_srl;
+			$member_srl = $obj->member_srl;
+			// The process related to clearing the post object
+			if(!$module_srl || !$member_srl) return new Object();
+			// Run only when logged in
+			$logged_info = Context::get('logged_info');
+			if(!$logged_info->member_srl) return new Object();
+			// Get the points of the member
+			$oPointModel = getModel('point');
+			$cur_point = $oPointModel->getPoint($member_srl, true);
+			// Get the point module information
+			$oModuleModel = getModel('module');
+			$config = $oModuleModel->getModuleConfig('point');
+			$module_config = $oModuleModel->getModulePartConfig('point', $module_srl);
+	
+			$point = $module_config['insert_document'];
+			if(strlen($point) == 0 && !is_int($point)) $point = $config->insert_document;
+			// if the point is set to decrease when writing a document, make sure it does not increase the points when deleting an article
+			if($point < 0) return new Object();
+			$cur_point -= $point;
+			// Add points related to deleting an attachment
+			$point = $module_config['upload_file'];
+			if(strlen($point) == 0 && !is_int($point)) $point = $config->upload_file;
+			if($obj->uploaded_count) $cur_point -= $point * $obj->uploaded_count;
+			// Increase the point
+			$this->setPoint($member_srl,$cur_point);
+		}
 
 		return new Object();
 	}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| 사소한 변경 | 예 |
| 버그 수정 | 예 |
| 새로운 기능 | 아니오 |
| 호환성 깨짐 | 아니오 |
| 수정하는 이슈 | #1662 |

임시 저장글 작성시에는 포인트가 주어지지 않는데, 글 삭제시에는 임시 저장글 여부와 상관없이 포인트를 차감합니다. 이를 임시글 삭제시에는 차감 처리를 하지 않도록 수정합니다.
