### PR TITLE
fix #1693 비회원의 글을 메일로 발송시 발송자가 비어 있을수 있는 문제 수정

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -145,7 +145,7 @@ class boardController extends board
 				$oMail = new Mail();
 				$oMail->setTitle($obj->title);
 				$oMail->setContent( sprintf("From : <a href=\"%s\">%s</a><br/>\r\n%s", getFullUrl('','document_srl',$obj->document_srl), getFullUrl('','document_srl',$obj->document_srl), $obj->content));
-				$oMail->setSender($obj->user_name ? $obj->user_name : anonymous, $obj->email_address ? $obj->email_address : $member_config->webmaster_email);
+				$oMail->setSender($obj->user_name ? $obj->user_name : 'anonymous', $obj->email_address ? $obj->email_address : $member_config->webmaster_email);
 
 				$target_mail = explode(',',$this->module_info->admin_mail);
 				for($i=0;$i<count($target_mail);$i++)

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -139,10 +139,13 @@ class boardController extends board
 			// send an email to admin user
 			if($output->toBool() && $this->module_info->admin_mail)
 			{
+				$oModuleModel = getModel('module');
+				$member_config = $oModuleModel->getModuleConfig('member');
+				
 				$oMail = new Mail();
 				$oMail->setTitle($obj->title);
 				$oMail->setContent( sprintf("From : <a href=\"%s\">%s</a><br/>\r\n%s", getFullUrl('','document_srl',$obj->document_srl), getFullUrl('','document_srl',$obj->document_srl), $obj->content));
-				$oMail->setSender($obj->user_name, $obj->email_address);
+				$oMail->setSender($obj->user_name ? $obj->user_name : anonymous, $obj->email_address ? $obj->email_address : $member_config->webmaster_email);
 
 				$target_mail = explode(',',$this->module_info->admin_mail);
 				for($i=0;$i<count($target_mail);$i++)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| 사소한 변경 | 예 |
| 버그 수정 | 예 |
| 새로운 기능 | 아니오 |
| 호환성 깨짐 | 아니오 |
| 수정하는 이슈 | #1693 |

비회원의 글을 메일로 관리자에게 알릴 때, 발송자가 비어 있을수 있는 문제를 수정합니다. 만일 이름 정보가 없다면 `anonymous`가,  이메일 정보가 없다면 웹마스터의 이메일 주소가 대신 사용됩니다.
