### PR TITLE
회원 정보 조회/수정폼 오타로 인한 폼 깨짐 현상 해결

### DIFF
--- a/modules/member/skins/default/modify_info.html
+++ b/modules/member/skins/default/modify_info.html
@@ -27,7 +27,7 @@
 		</div>
 	</div>
 	<div class="control-group" loop="$formTags=>$formTag">
-		<label for="" class="control-label">{$formTag->title}</label>
+		<label for="{$formTag->name}" class="control-label">{$formTag->title}</label>
 		<div class="controls" cond="$formTag->name != 'signature'">{$formTag->inputTag}</div>
 		<div class="controls" cond="$formTag->name =='signature'">
 			{$editor}


### PR DESCRIPTION
회원 정보 조회/수정폼 오타로 인한 폼 깨짐 현상 해결