### PR TITLE
php7 환경에서 발생하는 오류 수정

### DIFF
--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -215,16 +215,18 @@ class DB
 	 */
 	function getEnableList()
 	{
-		if(!$this->supported_list)
+		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		
+		if(!$self->supported_list)
 		{
 			$oDB = new DB();
-			$this->supported_list = $oDB->_getSupportedList();
+			$self->supported_list = $oDB->_getSupportedList();
 		}
 
 		$enableList = array();
-		if(is_array($this->supported_list))
+		if(is_array($self->supported_list))
 		{
-			foreach($this->supported_list AS $key => $value)
+			foreach($self->supported_list AS $key => $value)
 			{
 				if($value->enable)
 				{
@@ -242,16 +244,18 @@ class DB
 	 */
 	function getDisableList()
 	{
-		if(!$this->supported_list)
+		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		
+		if(!$self->supported_list)
 		{
 			$oDB = new DB();
-			$this->supported_list = $oDB->_getSupportedList();
+			$self->supported_list = $oDB->_getSupportedList();
 		}
 
 		$disableList = array();
-		if(is_array($this->supported_list))
+		if(is_array($self->supported_list))
 		{
-			foreach($this->supported_list AS $key => $value)
+			foreach($self->supported_list AS $key => $value)
 			{
 				if(!$value->enable)
 				{

--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -215,7 +215,7 @@ class DB
 	 */
 	function getEnableList()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		is_a($this, 'DB') ? $self = $this : $self = self::getInstance();
 		
 		if(!$self->supported_list)
 		{
@@ -244,7 +244,7 @@ class DB
 	 */
 	function getDisableList()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		is_a($this, 'DB') ? $self = $this : $self = self::getInstance();
 		
 		if(!$self->supported_list)
 		{


### PR DESCRIPTION
| Q | A |
| --- | --- |
| 사소한 변경 | 예 |
| 버그 수정 | 예 |
| 새로운 기능 | 아니오 |
| 호환성 깨짐 | 아니오 |
| 수정하는 이슈 | (없음) |

PHP7 이상에서 XE 설치시 발생하는 `$this` 관련 오류를 수정합니다.
