### PR TITLE
썸네일 생성시 race condition 해소

### DIFF
--- a/modules/comment/comment.item.php
+++ b/modules/comment/comment.item.php
@@ -584,6 +584,9 @@ class commentItem extends Object
 			}
 		}
 
+		// Prevent race condition
+		FileHandler::writeFile($thumbnail_file, '', 'w');
+
 		// Target file
 		$source_file = NULL;
 		$is_tmp_file = FALSE;
@@ -683,12 +686,6 @@ class commentItem extends Object
 		if($output)
 		{
 			return $thumbnail_url;
-		}
-
-		// create an empty file not to attempt to generate the thumbnail afterwards
-		else
-		{
-			FileHandler::writeFile($thumbnail_file, '', 'w');
 		}
 
 		return;

--- a/modules/comment/comment.item.php
+++ b/modules/comment/comment.item.php
@@ -569,10 +569,11 @@ class commentItem extends Object
 		// Define thumbnail information
 		$thumbnail_path = sprintf('files/thumbnails/%s', getNumberingPath($this->comment_srl, 3));
 		$thumbnail_file = sprintf('%s%dx%d.%s.jpg', $thumbnail_path, $width, $height, $thumbnail_type);
+		$thumbnail_lockfile = sprintf('%s%dx%d.%s.lock', $thumbnail_path, $width, $height, $thumbnail_type);
 		$thumbnail_url = Context::getRequestUri() . $thumbnail_file;
 
 		// return false if a size of existing thumbnail file is 0. otherwise return the file path
-		if(file_exists($thumbnail_file))
+		if(file_exists($thumbnail_file) || file_exists($thumbnail_lockfile))
 		{
 			if(filesize($thumbnail_file) < 1)
 			{
@@ -584,8 +585,8 @@ class commentItem extends Object
 			}
 		}
 
-		// Prevent race condition
-		FileHandler::writeFile($thumbnail_file, '', 'w');
+		// Create lockfile to prevent race condition
+		FileHandler::writeFile($thumbnail_lockfile, '', 'w');
 
 		// Target file
 		$source_file = NULL;
@@ -677,15 +678,24 @@ class commentItem extends Object
 
 		$output = FileHandler::createImageFile($source_file, $thumbnail_file, $width, $height, 'jpg', $thumbnail_type);
 
+		// Remove source file if it was temporary
 		if($is_tmp_file)
 		{
 			FileHandler::removeFile($source_file);
 		}
 
-		// return the thumbnail path if successfully generated.
+		// Remove lockfile
+		FileHandler::removeFile($thumbnail_lockfile);
+
+		// Return the thumbnail path if it was successfully generated
 		if($output)
 		{
 			return $thumbnail_url;
+		}
+		// Create an empty file if thumbnail generation failed
+		else
+		{
+			FileHandler::writeFile($thumbnail_file, '','w');
 		}
 
 		return;

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -818,19 +818,28 @@ class documentItem extends Object
 			}
 			$thumbnail_type = $config->thumbnail_type;
 		}
+
 		// Define thumbnail information
 		$thumbnail_path = sprintf('files/thumbnails/%s',getNumberingPath($this->document_srl, 3));
 		$thumbnail_file = sprintf('%s%dx%d.%s.jpg', $thumbnail_path, $width, $height, $thumbnail_type);
+		$thumbnail_lockfile = sprintf('%s%dx%d.%s.lock', $thumbnail_path, $width, $height, $thumbnail_type);
 		$thumbnail_url  = Context::getRequestUri().$thumbnail_file;
+
 		// Return false if thumbnail file exists and its size is 0. Otherwise, return its path
-		if(file_exists($thumbnail_file))
+		if(file_exists($thumbnail_file) || file_exists($thumbnail_lockfile))
 		{
-			if(filesize($thumbnail_file)<1) return false;
-			else return $thumbnail_url;
+			if(filesize($thumbnail_file) < 1)
+			{
+				return FALSE;
+			}
+			else
+			{
+				return $thumbnail_url;
+			}
 		}
 
-		// Prevent race condition
-		FileHandler::writeFile($thumbnail_file, '', 'w');
+		// Create lockfile to prevent race condition
+		FileHandler::writeFile($thumbnail_lockfile, '', 'w');
 
 		// Target File
 		$source_file = null;
@@ -906,9 +915,26 @@ class documentItem extends Object
 		{
 			$output = FileHandler::createImageFile($source_file, $thumbnail_file, $width, $height, 'jpg', $thumbnail_type);
 		}
-		if($is_tmp_file) FileHandler::removeFile($source_file);
-		// Return its path if a thumbnail is successfully genetated
-		if($output) return $thumbnail_url;
+
+		// Remove source file if it was temporary
+		if($is_tmp_file)
+		{
+			FileHandler::removeFile($source_file);
+		}
+
+		// Remove lockfile
+		FileHandler::removeFile($thumbnail_lockfile);
+
+		// Return the thumbnail path if it was successfully generated
+		if($output)
+		{
+			return $thumbnail_url;
+		}
+		// Create an empty file if thumbnail generation failed
+		else
+		{
+			FileHandler::writeFile($thumbnail_file, '','w');
+		}
 
 		return;
 	}

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -829,6 +829,9 @@ class documentItem extends Object
 			else return $thumbnail_url;
 		}
 
+		// Prevent race condition
+		FileHandler::writeFile($thumbnail_file, '', 'w');
+
 		// Target File
 		$source_file = null;
 		$is_tmp_file = false;
@@ -906,8 +909,6 @@ class documentItem extends Object
 		if($is_tmp_file) FileHandler::removeFile($source_file);
 		// Return its path if a thumbnail is successfully genetated
 		if($output) return $thumbnail_url;
-		// Create an empty file not to re-generate the thumbnail
-		else FileHandler::writeFile($thumbnail_file, '','w');
 
 		return;
 	}


### PR DESCRIPTION
썸네일을 생성할 때 의외로 시간이 오래 걸리는 경우가 있습니다. 성능이 좋지 않은 호스팅 서버에서 GD 러이브러리로 큰 이미지를 조작하거나, 외부 이미지의 썸네일을 생성하는 경우가 대표적이죠.

그런데 썸네일을 생성하는 도중에 다른 사용자가 같은 페이지를 요청하면 썸네일 생성 루틴이 또다시 호출됩니다. 로컬 이미지라면 서버 자원을 조금 낭비하고 말겠지만, 외부 이미지라면 또다시 원본 이미지를 불러와야 하고, 그러면 시간이 더 걸리고, 그 사이에 다른 사용자가 또다시 썸네일 생성 루틴을 호출하는 등... 엄청난 자원 낭비를 가져오게 됩니다.

실제로 이 문제 때문에 똑같은 외부이미지를 수십 번씩 불러오느라 불과 며칠 사이 수백GB의 트래픽이 발생하고, 수십 개의 썸네일을 동시에 생성하느라 서버의 메모리를 모두 소진하는 경우를 보았습니다. 외부이미지가 많고 방문자가 많은 사이트라면 언제든지 이런 문제가 생길 수 있습니다.

이 PR은 아주 간단합니다. 썸네일 생성에 실패한 경우 그 자리에 빈 파일을 남겨서 재생성 시도를 하지 않도록 하는 코드를 **썸네일 생성 시도 전**으로 옮겨서, 다른 프로세스가 썸네일을 생성하는 중이라면 같은 썸네일을 다시 생성하지 않도록 변경했습니다. 썸네일 생성에 성공할 경우 빈 파일은 실제 썸네일로 대체됩니다. 실패할 경우에는 빈 파일이 남는다는 점에서 기존 방식과 같습니다.
