### PR TITLE
게시판 스킨의 loop로 인한 불필요한 쿼리 발생 방지

### DIFF
--- a/modules/board/skins/default/_comment.html
+++ b/modules/board/skins/default/_comment.html
@@ -4,7 +4,8 @@
 		<h2>{$lang->comment} <em>{$oDocument->getCommentcount()}</em></h2>
 	</div>
 	<ul cond="$oDocument->getCommentcount()" class="fbList">
-		<li loop="$oDocument->getComments()=>$key,$comment" class="fbItem"|cond="!$comment->get('depth')" class="fbItem indent indent{($comment->get('depth'))}"|cond="$comment->get('depth')" id="comment_{$comment->comment_srl}">
+		{@ $oDocumentComments = $oDocument->getComments()}
+		<li loop="$oDocumentComments=>$key,$comment" class="fbItem"|cond="!$comment->get('depth')" class="fbItem indent indent{($comment->get('depth'))}"|cond="$comment->get('depth')" id="comment_{$comment->comment_srl}">
 			<div class="fbMeta">
 				<img cond="$comment->getProfileImage()" src="{$comment->getProfileImage()}" alt="Profile" class="profile" />
 				<span cond="!$comment->getProfileImage()" class="profile"></span>
@@ -30,7 +31,8 @@
 			<div cond="$comment->hasUploadedFiles()" class="fileList">
 				<button type="button" class="toggleFile" onclick="jQuery(this).next('ul.files').toggle();">{$lang->uploaded_file} [<strong>{$comment->get('uploaded_count')}</strong>]</button>
 				<ul class="files">
-					<li loop="$comment->getUploadedFiles()=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
+					{@ $commentUploadedFiles = $comment->getUploadedFiles()}
+					<li loop="$commentUploadedFiles=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
 				</ul>
 			</div>
 			<p class="action">

--- a/modules/board/skins/default/_read.html
+++ b/modules/board/skins/default/_read.html
@@ -22,7 +22,8 @@
 	<!-- Extra Output -->
 	<div class="exOut" cond="$oDocument->isExtraVarsExists() && (!$oDocument->isSecret() || $oDocument->isGranted())">
 		<table border="1" cellspacing="0" summary="Extra Form Output">
-			<tr loop="$oDocument->getExtraVars() => $key,$val">
+			{@ $oDocumentExtraVars = $oDocument->getExtraVars()}
+			<tr loop="$oDocumentExtraVars => $key,$val">
 				<th scope="row">{$val->name}</th>
 				<td>{$val->getValueHTML()}&nbsp;</td>
 			</tr>
@@ -50,7 +51,8 @@
 		<div cond="$oDocument->hasUploadedFiles()" class="fileList">
 			<button type="button" class="toggleFile" onclick="jQuery(this).next('ul.files').toggle();">{$lang->uploaded_file} [<strong>{$oDocument->get('uploaded_count')}</strong>]</button>
 			<ul class="files">
-				<li loop="$oDocument->getUploadedFiles()=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
+				{@ $oDocumentUploadedFiles = $oDocument->getUploadedFiles()}
+				<li loop="$oDocumentUploadedFiles=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
 			</ul>
 		</div>
 		<div class="tns">

--- a/modules/board/skins/default/_trackback.html
+++ b/modules/board/skins/default/_trackback.html
@@ -5,7 +5,8 @@
 		<p class="trackbackURL"><a href="{$oDocument->getTrackbackUrl()}" onclick="return false;">{$oDocument->getTrackbackUrl()}</a></p>
 	</div>
 	<ul cond="$oDocument->getTrackbackCount()" class="fbList">
-		<li class="fbItem" loop="$oDocument->getTrackbacks()=>$key,$val" id="trackback_{$val->trackback_srl}">
+		{@ $oDocumentTrackbacks = $oDocument->getTrackbacks()}
+		<li class="fbItem" loop="$oDocumentTrackbacks=>$key,$val" id="trackback_{$val->trackback_srl}">
 			<div class="fbMeta">
 				<h3 class="author"><a href="{$val->url}" title="{htmlspecialchars($val->blog_name)}">{htmlspecialchars($val->blog_name)}</a></h3>
 				<p class="time">{zdate($val->regdate, "Y.m.d H:i")}</p>

--- a/modules/board/skins/xedition/_comment.html
+++ b/modules/board/skins/xedition/_comment.html
@@ -4,7 +4,8 @@
 		<h2><i class="xi-comment"></i> {$lang->comment} <em>{$oDocument->getCommentcount()}</em></h2>
 	</div>
 	<ul cond="$oDocument->getCommentcount()" class="fbList">
-		<li loop="$oDocument->getComments()=>$key,$comment" class="fbItem"|cond="!$comment->get('depth')" class="fbItem indent indent{($comment->get('depth'))}"|cond="$comment->get('depth')" id="comment_{$comment->comment_srl}">
+		{@ $oDocumentComments = $oDocument->getComments()}
+		<li loop="$oDocumentComments=>$key,$comment" class="fbItem"|cond="!$comment->get('depth')" class="fbItem indent indent{($comment->get('depth'))}"|cond="$comment->get('depth')" id="comment_{$comment->comment_srl}">
 			<div class="fbMeta">
 				<img cond="$comment->getProfileImage()" src="{$comment->getProfileImage()}" alt="Profile" class="profile" />
 				<span cond="!$comment->getProfileImage()" class="profile"></span>
@@ -30,7 +31,8 @@
 			<div cond="$comment->hasUploadedFiles()" class="fileList">
 				<button type="button" class="toggleFile" onclick="jQuery(this).next('ul.files').toggle();"><i class="xi-diskette"></i> {$lang->uploaded_file} [<strong>{$comment->get('uploaded_count')}</strong>]</button>
 				<ul class="files">
-					<li loop="$comment->getUploadedFiles()=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
+					{@ $commentUploadedFiles = $comment->getUploadedFiles()}
+					<li loop="$commentUploadedFiles=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
 				</ul>
 			</div>
 			<p class="action">

--- a/modules/board/skins/xedition/_read.html
+++ b/modules/board/skins/xedition/_read.html
@@ -26,7 +26,8 @@
 	<!-- Extra Output -->
 	<div class="exOut" cond="$oDocument->isExtraVarsExists() && (!$oDocument->isSecret() || $oDocument->isGranted())">
 		<table border="1" cellspacing="0" summary="Extra Form Output">
-			<tr loop="$oDocument->getExtraVars() => $key,$val">
+			{@ $oDocumentExtraVars = $oDocument->getExtraVars()}
+			<tr loop="$oDocumentExtraVars => $key,$val">
 				<th scope="row">{$val->name}</th>
 				<td>{$val->getValueHTML()}&nbsp;</td>
 			</tr>
@@ -84,7 +85,8 @@
 		<div cond="$oDocument->hasUploadedFiles()" class="fileList">
 			<button type="button" class="toggleFile" onclick="jQuery(this).next('ul.files').toggle();"><i class="xi-diskette"></i> {$lang->uploaded_file} [<strong>{$oDocument->get('uploaded_count')}</strong>]</button>
 			<ul class="files">
-				<li loop="$oDocument->getUploadedFiles()=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
+				{@ $oDocumentUploadedFiles = $oDocument->getUploadedFiles()}
+				<li loop="$oDocumentUploadedFiles=>$key,$file"><a href="{getUrl('')}{$file->download_url}">{$file->source_filename} <span class="fileSize">[File Size:{FileHandler::filesize($file->file_size)}/Download:{number_format($file->download_count)}]</span></a></li>
 			</ul>
 		</div>
 		<div class="tns">

--- a/modules/board/skins/xedition/_trackback.html
+++ b/modules/board/skins/xedition/_trackback.html
@@ -5,7 +5,8 @@
 		<p class="trackbackURL"><a href="{$oDocument->getTrackbackUrl()}" onclick="return false;">{$oDocument->getTrackbackUrl()}</a></p>
 	</div>
 	<ul cond="$oDocument->getTrackbackCount()" class="fbList">
-		<li class="fbItem" loop="$oDocument->getTrackbacks()=>$key,$val" id="trackback_{$val->trackback_srl}">
+		{@ $oDocumentTrackbacks = $oDocument->getTrackbacks()}
+		<li class="fbItem" loop="$oDocumentTrackbacks=>$key,$val" id="trackback_{$val->trackback_srl}">
 			<div class="fbMeta">
 				<h3 class="author"><a href="{$val->url}" title="{htmlspecialchars($val->blog_name)}">{htmlspecialchars($val->blog_name)}</a></h3>
 				<p class="time">{zdate($val->regdate, "Y.m.d H:i")}</p>


### PR DESCRIPTION
`loop` 구문 내에서 함수나 메소드를 호출할 경우, 컴파일된 템플릿에서는 해당 함수나 메소드가 3번씩 호출되는 문제가 있습니다.

예를 들어 게시판 스킨에서 댓글 목록을 불러와서 루프를 돌릴 때 아래와 같은 구문을 사용하는데,

    loop="$oDocument->getComments()=>$key,$comment"

이것을 컴파일하면 아래와 같이 무지막지하게 바뀝니다.

    if($__Context->oDocument->getComments() && count($__Context->oDocument->getComments()))
    foreach($__Context->oDocument->getComments() as $__Context->key=>$__Context->comment)

foreach 루프에서 `getComments()` 메소드를 호출하는 것 자체는 문제가 없습니다. PHP는 상당히 똑똑하기 때문에, 최초 1번만 메소드를 호출합니다. 루프를 돌 때마다 호출하지 않습니다.

문제는 XE의 템플릿 컴파일 방식입니다. 루프를 시작하기 전에 배열이 존재하는지, 그리고 빈 배열이 아닌지 확인하는 과정에서 각각 1번씩 `getComments()` 메소드를 호출합니다. 실제 foreach 루프에서 호출되는 것까지 하면 총 3번 호출되는 거죠.

그래서 프로파일러로 쿼리 목록을 떠보면 댓글 전체 목록, 첨부파일 목록, 트랙백 목록, 확장변수 목록 등을 각각 3번씩 쿼리하는 것을 볼 수 있습니다.

그러나 이 PR에서처럼 루프 시작 전에 변수를 미리 선언하면 1번만 쿼리해도 똑같은 결과를 얻을 수 있습니다. 템플릿이 살짝 지저분해질 뿐이죠.

장기적으로는 템플릿 컴파일 엔진을 손봐야겠지만, 그러려면 임시 변수를 자동으로 생성해야 하는 등 여러가지 고민해야 할 부분이 많습니다. 그래서 많은 분들이 사용하는 기본 게시판 스킨을 우선 수정해 보았습니다. 이 정도만 하더라도 글 한 번 읽을 때마다 10개 이상의 불필요한 쿼리가 사라집니다.
