### PR TITLE
EXIF 정보를 기준으로 이미지 회전하기

### DIFF
--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -675,6 +675,33 @@ class fileController extends file
 		{
 			$path = sprintf("./files/attach/images/%s/%s", $module_srl,getNumberingPath($upload_target_srl,3));
 
+			if(preg_match("/\.(jpe?g)$/i", $file_info['name']))
+			{
+				@ini_set('memory_limit', '512M');
+				$filename = $file_info['tmp_name'];
+				$exif = exif_read_data($filename);
+
+				@$image = imagecreatefromjpeg($filename);
+				 
+				$exif = exif_read_data($filename);
+				 
+				if(!empty($exif['Orientation'])) {
+					switch($exif['Orientation']) {
+						case 8:
+							$image = imagerotate($image,90,0);
+							break;
+						case 3:
+							$image = imagerotate($image,180,0);
+							break;
+						case 6:
+							$image = imagerotate($image,-90,0);
+							break;
+					}
+				}
+				imagejpeg($image,$filename);
+				imagedestroy($image);
+			}
+
 			// special character to '_'
 			// change to random file name. because window php bug. window php is not recognize unicode character file name - by cherryfilter
 			$ext = substr(strrchr($file_info['name'],'.'),1);


### PR DESCRIPTION
스마트폰으로 촬영된 이미지를 업로드 할 경우 이미지가 돌아가는 문제가 있습니다.

이를 EXIF 정보로 이미지를 회전시켜 문제를 해결할 수 있습니다.

사용된 코드의 출처는 http://ncube.net/10668 입니다.