### PR TITLE
가입, 비번변경, 탈퇴 룰셋에 적용되는 비번길이 조건을 일관성있게 고침

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -497,7 +497,7 @@ class memberAdminController extends member
 				}
 				else if($formInfo->name == 'password')
 				{
-					$fields[] = '<field name="password"><if test="$act == \'procMemberInsert\'" attr="required" value="true" /><if test="$act == \'procMemberInsert\'" attr="length" value="4:20" /></field>';
+					$fields[] = '<field name="password"><if test="$act == \'procMemberInsert\'" attr="required" value="true" /><if test="$act == \'procMemberInsert\'" attr="length" value="4:60" /></field>';
 					$fields[] = '<field name="password2"><if test="$act == \'procMemberInsert\'" attr="required" value="true" /><if test="$act == \'procMemberInsert\'" attr="equalto" value="password" /></field>';
 				}
 				else if($formInfo->name == 'find_account_question')

--- a/modules/member/ruleset/leaveMember.xml
+++ b/modules/member/ruleset/leaveMember.xml
@@ -3,6 +3,6 @@
     <customrules>
     </customrules>
     <fields>
-		<field name="password" required="true" length=":20" />
+		<field name="password" required="true" length="1:60" />
     </fields>
 </ruleset>

--- a/modules/member/ruleset/modifyPassword.xml
+++ b/modules/member/ruleset/modifyPassword.xml
@@ -3,8 +3,8 @@
     <customrules>
     </customrules>
     <fields>
-		<field name="current_password" required="true" length="1:50" />
-		<field name="password1" required="true" length="4:20" />
-		<field name="password2" required="true" length="4:20" equalto="password1" />
+		<field name="current_password" required="true" length="1:60" />
+		<field name="password1" required="true" length="4:60" />
+		<field name="password2" required="true" length="4:60" equalto="password1" />
     </fields>
 </ruleset>

--- a/modules/member/ruleset/signup.xml
+++ b/modules/member/ruleset/signup.xml
@@ -4,8 +4,8 @@
     </customrules>
     <fields>
 		<field name="user_id" required="true" length="3:20" />
-		<field name="password1" required="true" length="6:20" />
-		<field name="password2" required="true" length="6:20" equalto="password1" />
+		<field name="password1" required="true" length="4:60" />
+		<field name="password2" required="true" length="4:60" equalto="password1" />
 		<field name="user_name" required="true" length="2:40" />
 		<field name="nick_name" required="true" length="2:40" />
 		<field name="email_address" required="true" length="1:200" rule="email" />


### PR DESCRIPTION
회원 비밀번호의 최대 길이 기준을 일관성있게 고쳤습니다.

현재 가입시에는 4~20자, 탈퇴시에는 1~20자, 비번 변경시에는 기존비번은 1~50자, 새 비번은 4~20자로 되어 있습니다. 비번 변경시에는 다른 CMS에서 데이터를 옮겨온 경우까지 고려하여 최소와 최대 모두 여유를 준 것 같은데, 탈퇴시에는 최소 길이만 고려했네요.

게다가 `MemberAdminController` 클래스의 `_createSignupRuleset()` 메소드에서는 별도로 4~20자 제한을 하드코딩해 두어서, 실제 가입시에는 룰셋에 표기된 제한은 무시되고 이것으로 덮어씌워집니다. (XE로 만들어진 사이트에 랜덤생성한 32자 비번으로 가입하려는데 자꾸만 에러가 나서 원인을 찾다가 이 현상을 발견했습니다. 요즘 해외에서 유행하는 [correct horse battery staple](https://xkcd.com/936/) 방식의 비번은 20자를 넘는 것이 보통입니다.)

이 PR에서는 모든 비번길이 제한을 4~60자로 변경하고, 탈퇴 및 비번변경시의 기존 비번은 4자 미만도 허용하도록 했습니다. (실제 가입시 비번의 최소 길이 및 복잡도는 관리자 화면에서 별도 설정할 수 있지요.) **적용 후 회원가입 설정 페이지에서 "등록"을 한 번 클릭해 줘야 룰셋 캐시가 업데이트됩니다.**

사실 모든 비번은 해싱하여 저장되므로 DB의 필드 길이에 구애받을 필요가 없지만, 비번이 너무 길면 해싱할 때 서버 부하가 지나치게 높아질 수도 있으므로 일단 이용에 큰 지장이 없는 60자까지만 허용해 보았습니다.
