### PR TITLE
Fix #1752 user_lang escaping in menu

### DIFF
--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -547,7 +547,10 @@ class menuAdminController extends menu
 		{
 			$args->name = strip_tags(removeHackTag($args->name));
 		}
-		$args->desc = strip_tags(removeHackTag($args->desc));
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $args->desc))
+		{
+			$args->desc = strip_tags(removeHackTag($args->desc));
+		}
 
 		if($request->module_id && strncasecmp('http', $request->module_id, 4) === 0)
 		{
@@ -739,7 +742,10 @@ debugPrint($request);
 		{
 			$args->name = strip_tags(removeHackTag($args->name));
 		}
-		$args->desc = removeHackTag($args->desc);
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $args->desc))
+		{
+			$args->desc = strip_tags(removeHackTag($args->desc));
+		}
 
 		unset($args->group_srls);
 		$args->open_window = $request->menu_open_window;
@@ -823,7 +829,10 @@ debugPrint($request);
 		{
 			$itemInfo->name = removeHackTag($itemInfo->name);
 		}
-		$itemInfo->desc = removeHackTag($itemInfo->desc);
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $itemInfo->desc))
+		{
+			$itemInfo->desc = removeHackTag($itemInfo->desc);
+		}
 
 		$output = executeQuery('menu.updateMenuItem', $itemInfo);
 

--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -543,9 +543,12 @@ class menuAdminController extends menu
 		if($request->menu_desc) $args->desc = $request->menu_desc;
 		else $args->desc = '';
 
-		$args->name = strip_tags(removeHackTag($args->name));
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $args->name))
+		{
+			$args->name = strip_tags(removeHackTag($args->name));
+		}
 		$args->desc = strip_tags(removeHackTag($args->desc));
-debugPrint($args);
+
 		if($request->module_id && strncasecmp('http', $request->module_id, 4) === 0)
 		{
 			return new Object(-1, 'msg_invalid_request');
@@ -732,7 +735,10 @@ debugPrint($request);
 		if($request->menu_desc) $args->desc = $request->menu_desc;
 		else $args->desc = '';
 
-		$args->name = removeHackTag($args->name);
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $args->name))
+		{
+			$args->name = strip_tags(removeHackTag($args->name));
+		}
 		$args->desc = removeHackTag($args->desc);
 
 		unset($args->group_srls);
@@ -813,7 +819,10 @@ debugPrint($request);
 
 	public function _updateMenuItem($itemInfo)
 	{
-		$itemInfo->name = removeHackTag($itemInfo->name);
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $itemInfo->name))
+		{
+			$itemInfo->name = removeHackTag($itemInfo->name);
+		}
 		$itemInfo->desc = removeHackTag($itemInfo->desc);
 
 		$output = executeQuery('menu.updateMenuItem', $itemInfo);

--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -441,6 +441,11 @@ class moduleController extends module
 
 		unset($output);
 
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $args->browser_title))
+		{
+			$args->browser_title = removeHackTag($args->browser_title);
+		}
+
 		if($isMenuCreate == TRUE)
 		{
 			$menuArgs = new stdClass;
@@ -462,7 +467,7 @@ class moduleController extends module
 				$menuArgs->url = $args->mid;
 				$menuArgs->expand = 'N';
 				$menuArgs->is_shortcut = 'N';
-				$menuArgs->name = removeHackTag($args->browser_title);
+				$menuArgs->name = $args->browser_title;
 				$menuArgs->listorder = $args->menu_item_srl * -1;
 
 				$menuItemOutput = executeQuery('menu.insertMenuItem', $menuArgs);
@@ -478,7 +483,6 @@ class moduleController extends module
 
 		// Insert a module
 		$args->menu_srl = $menuArgs->menu_srl;
-		$args->browser_title = removeHackTag($args->browser_title);
 		$output = executeQuery('module.insertModule', $args);
 		if(!$output->toBool())
 		{
@@ -521,7 +525,11 @@ class moduleController extends module
 			if(!$args->site_srl) $args->site_srl = (int)$module_info->site_srl;
 			if(!$args->browser_title) $args->browser_title = $module_info->browser_title;
 		}
-		$args->browser_title = removeHackTag($args->browser_title);
+
+		if(!preg_match('/^\\$user_lang->[a-zA-Z0-9]+$/', $args->browser_title))
+		{
+			$args->browser_title = removeHackTag($args->browser_title);
+		}
 
 		$output = executeQuery('module.isExistsModuleName', $args);
 		if(!$output->toBool() || $output->data->count)


### PR DESCRIPTION
#1752 다국어메뉴에 사용되는 변수명이 escape 처리되어 버리는 문제를 해결합니다.

`$user_lang->userLang0000000000` 형태의 변수는 escape하지 않도록 하였습니다.
