### PR TITLE
Fix #1680 회원모듈에서 기본에디터 설정을 따르도록 수정

### DIFF
--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -159,6 +159,7 @@ class memberAdminView extends member
 
 		// get an editor
 		$option = new stdClass();
+		$option->skin = $oEditorModel->getEditorConfig()->editor_skin;
 		$option->primary_key_name = 'temp_srl';
 		$option->content_key_name = 'agreement';
 		$option->allow_fileupload = false;
@@ -259,6 +260,7 @@ class memberAdminView extends member
 		Context::set('editor_skin_list', $oEditorModel->getEditorSkinList());
 
 		// get an editor
+		$option->skin = $oEditorModel->getEditorConfig()->editor_skin;
 		$option->primary_key_name = 'temp_srl';
 		$option->content_key_name = 'agreement';
 		$option->allow_fileupload = false;
@@ -352,6 +354,7 @@ class memberAdminView extends member
 		{
 			$oEditorModel = getModel('editor');
 			$option = new stdClass();
+			$option->skin = $oEditorModel->getEditorConfig()->editor_skin;
 			$option->primary_key_name = 'member_srl';
 			$option->content_key_name = 'signature';
 			$option->allow_fileupload = false;


### PR DESCRIPTION
이 PR을 적용하면 에디터 모듈에서 CKEditor가 아닌 다른 에디터를 기본값으로 설정해 놓은 경우 회원가입, 회원정보관리 페이지에도 그대로 적용됩니다. 지금까지는 무조건 CKEditor가 적용되었습니다.
