### PR TITLE
이미지 파일 업로드시 본문 자동삽입되도록 수정

### DIFF
--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -93,6 +93,7 @@
 				},
 				done: function(e, res) {
 					var result = res.response().result;
+					var temp_code = '';
 
 					if(!result) return;
 
@@ -101,6 +102,12 @@
 					if(!result) return;
 
 					if(result.error == 0) {
+						if(/\.(jpe?g|png|gif)$/i.test(result.source_filename)) {
+							temp_code += '<img src="' + window.request_uri + result.download_url + '" alt="' + result.source_filename + '" editor_component="image_link" data-file-srl="' + result.file_srl + '" />';
+							temp_code += "\r\n<p><br></p>\r\n";
+						}
+
+						_getCkeInstance(settings.formData.editor_sequence).insertHtml(temp_code, "unfiltered_html");
 					} else {
 						alert(result.message);
 					}
@@ -236,7 +243,7 @@
 
 				if(!fileinfo) return;
 
-				if(/\.(jpe?g|png|gif)$/i.test(fileinfo.download_url)) {
+				if(/\.(jpe?g|png|gif)$/i.test(fileinfo.source_filename)) {
 					temp_code += '<img src="' + window.request_uri + fileinfo.download_url + '" alt="' + fileinfo.source_filename + '" editor_component="image_link" data-file-srl="' + fileinfo.file_srl + '" />';
 					temp_code += "\r\n<p><br></p>\r\n";
 				} else {

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -46,6 +46,12 @@ class fileController extends file
 
 		$output = $this->insertFile($file_info, $module_srl, $upload_target_srl);
 		Context::setResponseMethod('JSON');
+		$this->add('file_srl',$output->get('file_srl'));
+		$this->add('file_size',$output->get('file_size'));
+		$this->add('direct_download',$output->get('direct_download'));
+		$this->add('source_filename',$output->get('source_filename'));
+		$this->add('download_url',$output->get('uploaded_filename'));
+		$this->add('upload_target_srl',$output->get('upload_target_srl'));
 		if($output->error != '0') $this->stop($output->message);
 	}
 


### PR DESCRIPTION
이미지 파일(jpg/jpeg/png/gif)을 업로드할때, 본문에 자동으로 삽입되도록 수정합니다.

XE 사용에 익숙하지 않은 사용자가 이미지를 업로드만 하고 본문에 삽입하지 않아 이미지 확인이 어려울 수 있는 문제점 등을 수정합니다.
