### PR TITLE
IPv6 사용시 /48 이상 변경되면 세션을 유지하지 않도록 변경

### DIFF
--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -196,8 +196,17 @@ class memberModel extends member
 			{
 				return true;
 			}
+			elseif(filter_var($_SESSION['ipaddress'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+			{
+				// IPv6: require same /48
+				if(strncmp(inet_pton($_SESSION['ipaddress']), inet_pton($_SERVER['REMOTE_ADDR']), 6) == 0)
+				{
+					return true;
+				}
+			}
 			else
 			{
+				// IPv4: require same /24
 				if(ip2long($_SESSION['ipaddress']) >> 8 == ip2long($_SERVER['REMOTE_ADDR']) >> 8)
 				{
 					return true;


### PR DESCRIPTION
현재 XE는 모바일이 아닌 경우 IPv4 주소의 마지막 자리가 바뀌는 것까지는 봐주지만, 그 이상 변경되면 로그인이 풀리도록 되어 있습니다. 세션을 탈취하더라도 악용하지 못하도록 하는 기능과, 유동IP 사용자의 편의 사이에서 적절한 균형을 잡았다고 보여집니다.

그러나 IPv6 주소는 `ip2long()` 함수에서 `false`를 반환하므로 `false == false`가 되어 항상 합격입니다. 즉, 완전히 엉뚱한 IP에서 접속하더라도 세션이 유지됩니다.

이 패치는 IPv6 주소에도 IPv4와 비슷한 정책을 적용하여, `/48` 이상 변경되면 로그인이 풀리도록 합니다. 일반적인 가정이나 사무실에 배정되는 IPv6 대역이 `/48`~`/64` 사이이므로 이 정도면 적당하지 않을까 싶지만, 만약 그렇지 않다면 적용되는 범위는 얼마든지 조정할 수 있습니다.
