### PR TITLE
그룹 관리의 누락된 폼 아이디 추가

### DIFF
--- a/modules/member/tpl/group_list.html
+++ b/modules/member/tpl/group_list.html
@@ -15,7 +15,7 @@
 <div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/member/tpl/1'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
 	<p>{$XE_VALIDATOR_MESSAGE}</p>
 </div>
-<form action="" method="post" ruleset="insertGroupConfig">
+<form action="" method="post" id="fo_member_group" ruleset="insertGroupConfig">
 	<input type="hidden" name="module" value="member" />
 	<input type="hidden" name="act" value="procMemberAdminGroupConfig" />
 	<input type="hidden" name="xe_validator_id" value="modules/member/tpl/1" />


### PR DESCRIPTION
UI 테스트시 아이디가 없어 테스트가 곤란함으로 추가합니다.
