### PR TITLE
사이트 메뉴 관리/사이트 디자인 관리 쉬운설치 인증 체크에 직접 쓰기 체크 추가

### DIFF
--- a/modules/autoinstall/autoinstall.admin.model.php
+++ b/modules/autoinstall/autoinstall.admin.model.php
@@ -164,18 +164,28 @@ class autoinstallAdminModel extends autoinstall
 	 */
 	function getAutoinstallAdminIsAuthed()
 	{
+		$oAdminModel = getAdminModel('autoinstall');
+		$package = $oAdminModel->getInstallInfo(Context::get('package_srl'));
+		
 		$is_authed = 0;
-
-		$ftp_info = Context::getFTPInfo();
-		if(!$ftp_info->ftp_root_path)
+		$output = $oAdminModel->checkUseDirectModuleInstall($package);
+		if($output->toBool()==TRUE)
 		{
-			$is_authed = -1;
+			$is_authed = 1;
 		}
 		else
 		{
-			$is_authed = (int) isset($_SESSION['ftp_password']);
+			$ftp_info = Context::getFTPInfo();
+			if(!$ftp_info->ftp_root_path)
+			{
+				$is_authed = -1;
+			}
+			else
+			{
+				$is_authed = (int) isset($_SESSION['ftp_password']);
+			}
 		}
-
+		
 		$this->add('is_authed', $is_authed);
 	}
 

--- a/modules/menu/tpl/sitemap.html
+++ b/modules/menu/tpl/sitemap.html
@@ -3797,7 +3797,9 @@ jQuery(function($){
 	function installPackage(sPackageSrl, sPackageType, $item){
 
 		//act=getAutoinstallAdminIsAuthed
-		$.exec_json("admin.getAutoinstallAdminIsAuthed", {}, function(htData){
+		var params = {};
+		params.package_srl = sPackageSrl;
+		$.exec_json("admin.getAutoinstallAdminIsAuthed", params, function(htData){
 			// FTP 비밀번호 뿐만 아니라 정보가 전혀 없을 경우?
 			switch(htData.is_authed){
 				case -1:


### PR DESCRIPTION
사이트 메뉴 관리/사이트 디자인 관리에서 서드파티 자료 다운로드시 직접 쓰기 방식으로 설치가 불가능한 문제를 해결합니다.
