### PR TITLE
SSL 선택적 사용시 XEDITION 레이아웃의 로그인 팝업에 SSL이 적용되지 않는 문제 수정

### DIFF
--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -472,6 +472,18 @@ function getFullSiteUrl()
 }
 
 /**
+ * Return the exact url of the current page
+ *
+ * @return string
+ */
+function getCurrentPageUrl()
+{
+	$protocol = $_SERVER['HTTPS'] == 'on' ? 'https://' : 'http://';
+	$url = $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+	return htmlspecialchars($url, ENT_COMPAT, 'UTF-8', FALSE);
+}
+
+/**
  * Return if domain of the virtual site is url type or id type
  *
  * @param string $domain

--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -448,9 +448,9 @@
 			<h1>LOGIN</h1>
 		</div>
 		<div class="login-body">
-			<form action="{getUrl()}" method="post" autocomplete="off">
+			<form action="{getUrl('', 'act', 'procMemberLogin')}" method="post" autocomplete="off">
 				<input type="hidden" name="act" value="procMemberLogin" />
-				<input type="hidden" name="success_return_url" value="{htmlspecialchars(getRequestUriByServerEnviroment(), ENT_COMPAT | ENT_HTML401, 'UTF-8', FALSE)}" />
+				<input type="hidden" name="success_return_url" value="{getCurrentPageUrl()}" />
 				<input type="hidden" name="xe_validator_id" value="layouts/xedition/layout/1" />
 				<fieldset>
 					<legend class="blind">{$lang->cmd_login}</legend>


### PR DESCRIPTION
참고: https://www.xetown.com/lakepark/22982

XEDITION 레이아웃에는`login_info` 위젯과는 별도로 로그인 팝업 위젯이 포함되어 있습니다. 그런데 SSL을 사용하지 않는 페이지에서 이 팝업을 사용하면 로그인 폼의 action 속성이 SSL을 사용하지 않는 주소로 생성됩니다. 그래서 아이디와 비밀번호가 암호화되지 않고 전송됩니다.

한국의 현행법은 로그인 정보 전송시 SSL을 사용하도록 강제하고 있기 때문에, 많은 웹마스터들을 범법자로 만들 수 있는 심각한 문제라고 생각됩니다.

문제의 원인은 `getUrl()` 함수를 호출하면서 `act` `procMemberLogin`을 지정하지 않았기 때문입니다. 이걸 지정해야 코어에서 SSL을 사용하도록 주소를 생성해 주거든요.

일단 이 문제는 `act`를 추가하는 것으로 간단히 해결됩니다. 그러나 이렇게 해 놓으면 한 가지 부작용이 발생하는데요... 로그인 후 반환되는 `success_return_url` 주소가 상대경로이기 때문에 기존의 주소가 아닌 SSL 주소로 돌아오게 됩니다. 개인적으로는 당연히 그래야 한다고 생각합니다만, 외부이미지 등 여러 가지 문제 때문에 SSL을 선택적으로 사용하는 웹마스터들은 로그인 후에도 SSL을 사용하지 않는 주소로 돌아오기를 원하실 것 같습니다.

안타깝게도 현재 XE 코어에는 "현재 페이지의 정확한 절대경로"를 반환하는 함수가 없습니다. 항상 `mid`와 `act`를 조합하여 주소를 생성해야 하죠. 그래서 `getCurrentPageUrl`이라는 함수를 추가해 보았습니다. 현재 페이지의 절대경로에 어떠한 가공도 가하지 않고 그대로 반환하는 함수입니다. 이 함수를 사용하면 로그인 전의 주소로 정확하게 돌려보낼 수 있습니다.
