### PR TITLE
#1787 IE+XpressEditor에서 업로드가 되지 않는 문제점 수정

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -410,8 +410,8 @@ class ModuleHandler extends Handler
 
 		$logged_info = Context::get('logged_info');
 
-		// check CSRF for admin actions
-		if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && !checkCSRF()) {
+		// check CSRF for POST actions
+		if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && $this->act !== 'procFileUpload' && !checkCSRF()) {
 			$this->error = 'msg_invalid_request';
 			$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
 			$oMessageObject->setError(-1);


### PR DESCRIPTION
IE+SwfUploader 사용시 `procFileUpload`가 호출될 때 referer가 포함되지 않아, 업로드가 되지 않는 문제점을 수정합니다. `procFileUpload` act 한정으로 CSRF 검사를 하지 않습니다. 
