### PR TITLE
프로필 이미지 URL에 filemtime을 추가하여 변경시 캐시 갱신 유도

### DIFF
--- a/addons/member_extra_info/member_extra_info.lib.php
+++ b/addons/member_extra_info/member_extra_info.lib.php
@@ -31,7 +31,7 @@ function memberTransImageName($matches)
 
 		if(file_exists(_XE_PATH_ . $image_name_file))
 		{
-			$_tmp->image_name_file = $image_name_file;
+			$_tmp->image_name_file = $image_name_file . '?' . date('YmdHis', filemtime(_XE_PATH_ . $image_name_file));
 		}
 		else
 		{
@@ -40,7 +40,7 @@ function memberTransImageName($matches)
 
 		if(file_exists(_XE_PATH_ . $image_mark_file))
 		{
-			$_tmp->image_mark_file = $image_mark_file;
+			$_tmp->image_mark_file = $image_mark_file . '?' . date('YmdHis', filemtime(_XE_PATH_ . $image_mark_file));
 		}
 		else
 		{

--- a/addons/member_extra_info/member_extra_info.lib.php
+++ b/addons/member_extra_info/member_extra_info.lib.php
@@ -21,8 +21,14 @@ function memberTransImageName($matches)
 	$oMemberModel = getModel('member');
 	$nick_name = $matches[5];
 
+	// Initialize global variable for cache
+	if(!isset($GLOBALS['_transImageNameList'][$member_srl]))
+	{
+		$GLOBALS['_transImageNameList'][$member_srl] = new stdClass();
+	}
 	$_tmp = &$GLOBALS['_transImageNameList'][$member_srl];
-	// If pre-defined data in the global variablesm return it
+	
+	// If pre-defined data in the global variables, return it
 	if(!$_tmp->cached)
 	{
 		$_tmp->cached = true;
@@ -32,6 +38,7 @@ function memberTransImageName($matches)
 		if(file_exists(_XE_PATH_ . $image_name_file))
 		{
 			$_tmp->image_name_file = $image_name_file . '?' . date('YmdHis', filemtime(_XE_PATH_ . $image_name_file));
+			$image_name_file = $_tmp->image_name_file;
 		}
 		else
 		{
@@ -41,6 +48,7 @@ function memberTransImageName($matches)
 		if(file_exists(_XE_PATH_ . $image_mark_file))
 		{
 			$_tmp->image_mark_file = $image_mark_file . '?' . date('YmdHis', filemtime(_XE_PATH_ . $image_mark_file));
+			$image_mark_file = $_tmp->image_mark_file;
 		}
 		else
 		{

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -885,7 +885,7 @@ class memberModel extends member
 					$info = new stdClass();
 					$info->width = $width;
 					$info->height = $height;
-					$info->src = Context::getRequestUri().$image_name_file;
+					$info->src = Context::getRequestUri().$image_name_file . '?' . date('YmdHis', filemtime($image_name_file));
 					$info->file = './'.$image_name_file;
 					$GLOBALS['__member_info__']['profile_image'][$member_srl] = $info;
 					break;
@@ -910,7 +910,7 @@ class memberModel extends member
 				$info = new stdClass;
 				$info->width = $width;
 				$info->height = $height;
-				$info->src = Context::getRequestUri().$image_name_file;
+				$info->src = Context::getRequestUri().$image_name_file. '?' . date('YmdHis', filemtime($image_name_file));
 				$info->file = './'.$image_name_file;
 				$GLOBALS['__member_info__']['image_name'][$member_srl] = $info;
 			}
@@ -932,7 +932,7 @@ class memberModel extends member
 				list($width, $height, $type, $attrs) = getimagesize($image_mark_file);
 				$info->width = $width;
 				$info->height = $height;
-				$info->src = Context::getRequestUri().$image_mark_file;
+				$info->src = Context::getRequestUri().$image_mark_file . '?' . date('YmdHis', filemtime($image_mark_file));
 				$info->file = './'.$image_mark_file;
 				$GLOBALS['__member_info__']['image_mark'][$member_srl] = $info;
 			}


### PR DESCRIPTION
회원이 프로필 사진을 새로 업로드하더라도 확장자가 같으면 URL이 동일하기 때문에, 일부러 새로고침을 하지 않으면 갱신되지 않는 문제가 있습니다. 웹서버의 `Expires` 설정이나 클라우드플레어 등을 사용하여 장기간 캐싱을 유도하는 경우에는 문제가 더 커집니다.

이 패치는 기존의 XE 코어에서 CSS, JS 파일 변경시 URL에 자동으로 filemtime을 추가하여 캐시 갱신을 유도하는 기능을 회원 프로필 사진에도 똑같이 적용하여, 웹서버의 `Expires` 설정이나 클라우드플레어 등을 사용하는 사이트에서도 회원 프로필 사진이 즉시 업데이트되도록 합니다.
