### PR TITLE
Update file.controller.php

### DIFF
--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -336,7 +336,7 @@ class fileController extends file
 		header("Content-Transfer-Encoding: binary\n");
 
 		// if file size is lager than 10MB, use fread function (#18675748)
-		if(filesize($uploaded_filename) > 1024 * 1024)
+		if($file_size > 1024 * 1024)
 		{
 			while(!feof($fp)) echo fread($fp, 1024);
 			fclose($fp);


### PR DESCRIPTION
32비트 환경에서 2GB가 넘는 파일을 다운로드할 경우 filesize() 함수가 잘못된 값을 반환하기 때문에 다운로드가 제대로 되지 않는 문제를 수정