### PR TITLE
PHP코드를 열 수 있는 여러 방법을 감지하도록 수정

### DIFF
--- a/classes/security/UploadFileFilter.class.php
+++ b/classes/security/UploadFileFilter.class.php
@@ -23,7 +23,12 @@ class UploadFileFilter
 		while ( ! feof ( $fp ) )
 		{
 			$content = fread ( $fp, 8192 );
-			if (FALSE === $has_php_tag) $has_php_tag = strpos ( $content, '<?' );
+			if (FALSE === $has_php_tag)
+			{
+				$has_php_tag = strpos ( $content, '<?' );
+				$has_php_tag |= strpos ( $content, '<%' );
+				$has_php_tag |= preg_match ( '/<script.*language=.?php.?.*>/', $content );
+			}
 			foreach ( self::$_block_list as $v )
 			{
 				if (FALSE !== $has_php_tag && FALSE !== strpos ( $content, $v ))


### PR DESCRIPTION
PHP 5.6 이하에서는 php.ini에서 asp_tags 옵션이 설정되어 있다면 <%로도 PHP 코드를 열 수 있으며, <script language="php">로도 태그를 열 수 있기 때문에 해당 부분을 감지하도록 수정