### PR TITLE
함수명이 대소문자를 구분하지 않도록 수정

### DIFF
--- a/classes/security/UploadFileFilter.class.php
+++ b/classes/security/UploadFileFilter.class.php
@@ -26,7 +26,7 @@ class UploadFileFilter
 			if (FALSE === $has_php_tag) $has_php_tag = strpos ( $content, '<?' );
 			foreach ( self::$_block_list as $v )
 			{
-				if (FALSE !== $has_php_tag && FALSE !== strpos ( $content, $v ))
+				if (FALSE !== $has_php_tag && FALSE !== strpos ( strtolower($content), $v ))
 				{
 					fclose ( $fp );
 					return FALSE;


### PR DESCRIPTION
PHP의 함수명은 대소문자를 구분하지 않으므로 검사를 우회할 수 있는 문제 수정