### PR TITLE
비정규 HTTPS 사용 접속 후 관리자 메뉴를 등록할 시 발생하는 문제 해결

### DIFF
--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -1609,7 +1609,11 @@ class menuAdminController extends menu
 		//if now page is https...
 		if(strpos($url, 'https') !== false)
 		{
-			$args->url = str_replace('https'.substr($dbInfo->default_url, 4), '', $url);
+			$parsedRequestUrl = parse_url($url);
+			$parsedRequestUrl['scheme'];
+
+			$parsedDefaultUrl = parse_url($dbInfo->default_url);
+			$args->url = str_replace('https://'.$parsedDefaultUrl['host'].':'.$parsedRequestUrl['port'].$parsedDefaultUrl['path'], '', $url);
 		}
 		else
 		{


### PR DESCRIPTION
- 비정규 HTTPS 포트(443이 아닌 다른 포트) 사용. 로그인 / 관리자 모듈 접속
- 설정->관리자 설정->관리자 메뉴 대시 보드 등록시 정상적으로 등록 안되는 문제
