### PR TITLE
Hotfix/editor/components/image link

### DIFF
--- a/modules/editor/components/image_link/image_link.class.php
+++ b/modules/editor/components/image_link/image_link.class.php
@@ -63,13 +63,28 @@ class image_link extends EditorHandler
 		if(substr($src, 0,2)=='./') $src = Context::getRequestUri().substr($src, 2);
 		else if(substr($src , 0, 1)=='/')
 		{
-			if($_SERVER['HTTPS']=='on') $http_src = 'https://';
-			else $http_src = 'http://';
-			$src = $http_src.$_SERVER['HTTP_HOST'].$src;
+			$dbInfo = Context::getInstance()->db_info;
+			if($_SERVER['HTTPS']=='on') {
+				$http_src = 'https://';
+
+
+				$port = ':'.trim($dbInfo->https_port);
+				if($port == 443 || $port == ':')
+					$port = '';
+			}
+			else {
+				$parsedDefaultUrl = parse_url($dbInfo->default_url);
+				$port = ':'.trim($parsedDefaultUrl['port']);
+
+				if($port == ':80' || $port == ':')
+					$port = '';
+
+				$http_src = 'http://';
+			}
+			$src = $http_src.$_SERVER['HTTP_HOST'].$port.$src;
 		}
 		else if(!strpos($temp_src[0],':') && $src) $src = Context::getRequestUri().$src;
 
-		$attr_output = array();
 		$attr_output = array("src=\"".$src."\"");
 		$attr_output[] = "alt=\"".$alt."\"";
 

--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -1609,7 +1609,11 @@ class menuAdminController extends menu
 		//if now page is https...
 		if(strpos($url, 'https') !== false)
 		{
-			$args->url = str_replace('https'.substr($dbInfo->default_url, 4), '', $url);
+			$parsedRequestUrl = parse_url($url);
+			$parsedRequestUrl['scheme'];
+
+			$parsedDefaultUrl = parse_url($dbInfo->default_url);
+			$args->url = str_replace('https://'.$parsedDefaultUrl['host'].':'.$parsedRequestUrl['port'].$parsedDefaultUrl['path'], '', $url);
 		}
 		else
 		{


### PR DESCRIPTION
비정규 HTTPS 포트인 사이트에서, 이미지 콤포넌트로 업로드한 이미지 주소가 잘못 수정되는 문제 수정