### PR TITLE
ERROR 워링메세지도 debugMessage파일에 추가.

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -102,7 +102,17 @@ class ModuleHandler extends Handler
 
 		// call a trigger before moduleHandler init
 		ModuleHandler::triggerCall('moduleHandler.init', 'before', $this);
-		set_error_handler(array($this, 'xeErrorLog'), E_WARNING);
+		if(__DEBUG__ == 1 && __DEBUG_OUTPUT__ == 0)
+		{
+			if(__DEBUG_PROTECT__ === 1 && __DEBUG_PROTECT_IP__ == $_SERVER['REMOTE_ADDR'])
+			{
+				set_error_handler(array($this, 'xeErrorLog'), E_WARNING);
+			}
+			else if(__DEBUG_PROTECT__ === 0)
+			{
+				set_error_handler(array($this, 'xeErrorLog'), E_WARNING);
+			}
+		}
 
 		// execute addon (before module initialization)
 		$called_position = 'before_module_init';

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -131,20 +131,12 @@ class ModuleHandler extends Handler
 		{
 			$errorname = 'Warrning!';
 		}
-		$debug_file = _XE_PATH_ . 'files/_debug_message.php';
-		$buff = $errorname . " : ";
+		$buff = "\n".$errorname . " : ";
 		$buff .= $errormassage . "\n";
 		$buff .= "file : " . $errorfile . " line : ";
 		$buff .= $errorline . "\n";
-		$buff = "\n<?php\n" . $buff . "?>\n";
-		$buff = sprintf("[%s]\n%s", date('Y-m-d H:i:s'), print_r($buff, true));
-
-		if(!@file_put_contents($debug_file, $buff, FILE_APPEND | LOCK_EX))
-		{
-			return;
-		}
+		debugPrint($buff);
 		restore_error_handler();
-
 		return true;
 	}
 

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -102,12 +102,40 @@ class ModuleHandler extends Handler
 
 		// call a trigger before moduleHandler init
 		ModuleHandler::triggerCall('moduleHandler.init', 'before', $this);
+		set_error_handler(array($this, 'xeErrorLog'), E_WARNING);
 
 		// execute addon (before module initialization)
 		$called_position = 'before_module_init';
 		$oAddonController = getController('addon');
 		$addon_file = $oAddonController->getCacheFilePath(Mobile::isFromMobilePhone() ? 'mobile' : 'pc');
 		if(file_exists($addon_file)) include($addon_file);
+	}
+
+	function xeErrorLog($errnumber, $errormassage, $errorfile, $errorline, $errorcontext)
+	{
+		if($errnumber != E_WARNING)
+		{
+			return false;
+		}
+		else
+		{
+			$errorname = 'Warrning!';
+		}
+		$debug_file = _XE_PATH_ . 'files/_debug_message.php';
+		$buff = $errorname . " : ";
+		$buff .= $errormassage . "\n";
+		$buff .= "file : " . $errorfile . " line : ";
+		$buff .= $errorline . "\n";
+		$buff = "\n<?php\n" . $buff . "?>\n";
+		$buff = sprintf("[%s]\n%s", date('Y-m-d H:i:s'), print_r($buff, true));
+
+		if(!@file_put_contents($debug_file, $buff, FILE_APPEND | LOCK_EX))
+		{
+			return;
+		}
+		restore_error_handler();
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
현재 XE는 `E_WARNING`메세지에 대해서 전부 무시하고 넘어가도록 되어있습니다.

그래서 간단한 워링 에러의 대해서 개발자들이 모르고 넘어가는 경우가 많습니다.
ex : http://xepushapp.com/board_vxJz62/18675

보통은 5.3 웹호스팅에서 아직도 개발하는 서드개발자들이 있어서, object 들이 선언되지않아 일으키는 문제점을 잘 인지 못하는 경우가 많습니다.

그래서 이 부분을 개발자들에게 debugPrint에 사용되는 files에 넣어 함께 기록하도록 개선했습니다.
