### PR TITLE
FileHandler::getRemoteResource() 에서 프록시 서버를 제대로 사용하지 못하는 문제 수정

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -527,8 +527,9 @@ class FileHandler
 			require_once('HTTP/Request.php');
 
 			$parsed_url = parse_url(__PROXY_SERVER__);
-			if($parsed_url["host"])
+			if($parsed_url["host"] && $parsed_url["path"])
 			{
+				// Old style proxy server support (POST payload to proxy script)
 				$oRequest = new HTTP_Request(__PROXY_SERVER__);
 				$oRequest->setMethod('POST');
 				$oRequest->addPostData('arg', serialize(array('Destination' => $url, 'method' => $method, 'body' => $body, 'content_type' => $content_type, "headers" => $headers, "post_data" => $post_data)));
@@ -536,6 +537,16 @@ class FileHandler
 			else
 			{
 				$oRequest = new HTTP_Request($url);
+
+				// New style proxy server support (Use HTTP_Request2 native config format)
+				if($parsed_url['host'])
+				{
+					$request_config['proxy_host'] = $parsed_url['host'];
+					$request_config['proxy_port'] = $parsed_url['port'] ? $parsed_url['port'] : '';
+					$request_config['proxy_user'] = rawurldecode($parsed_url['user'] ? $parsed_url['user'] : '');
+					$request_config['proxy_password'] = rawurldecode($parsed_url['pass'] ? $parsed_url['pass'] : '');
+					$request_config['proxy_type'] = $parsed_url['scheme'] ? $parsed_url['scheme'] : 'http';
+				}
 
 				if(count($request_config) && method_exists($oRequest, 'setConfig'))
 				{

--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -563,6 +563,7 @@ class FileHandler
 						$oRequest->addHeader($key, $val);
 					}
 				}
+				$host = parse_url($url, PHP_URL_HOST);
 				if($cookies[$host])
 				{
 					foreach($cookies[$host] as $key => $val)


### PR DESCRIPTION
XE에서는 `__PROXY_SERVER__` 상수를 사용해서 외부 요청시 경유할 프록시 서버를 지정할 수 있으나, 파일핸들러에서 일반적인 프록시 사용 방식이 아닌 이상한 방식으로 처리하고 있어 사실상 무용지물입니다. 프록시 기능을 제대로 지원하지 않던 구버전 PEAR HTTP_Request 클래스에 맞추어 개발한 후, HTTP_Request 클래스를 업데이트하면서 잊어버린 것 같아요.

특정 URL에 POST하는 기존 방식의 프록시 설정은 호환성 유지를 위해 그대로 두고, `123.45.67.89:8080` 포맷으로 프록시를 지정하면 HTTP_Request 클래스에서 공식 지원하는 설정을 통해 정상 처리하도록 변경해 보았습니다.
