### PR TITLE
FileHandler::getRemoteFile() 에서 파일 다운로드 도중 메모리 제한을 초과하는 문제 수정

### DIFF
--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -1574,6 +1574,12 @@ function stripEmbedTagForAdmin(&$content, $writer_member_srl)
  */
 function requirePear()
 {
+	static $required = false;
+	if($required)
+	{
+		return;
+	}
+
 	if(version_compare(PHP_VERSION, "5.3.0") < 0)
 	{
 		set_include_path(_XE_PATH_ . "libs/PEAR" . PATH_SEPARATOR . get_include_path());
@@ -1582,6 +1588,8 @@ function requirePear()
 	{
 		set_include_path(_XE_PATH_ . "libs/PEAR.1.9.5" . PATH_SEPARATOR . get_include_path());
 	}
+
+	$required = true;
 }
 
 function checkCSRF()

--- a/libs/PEAR.1.9.5/HTTP/Request2/Observer/Download.php
+++ b/libs/PEAR.1.9.5/HTTP/Request2/Observer/Download.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Download a file to disk instead of buffering it in memory.
+ * 
+ * Source: https://pear.php.net/manual/en/package.http.http-request2.observers.php
+ */
+class HTTP_Request2_Observer_Download implements SplObserver
+{
+	protected $filename;
+	protected $fp;
+
+	public function __construct($filename)
+	{
+		$this->filename = $filename;
+	}
+
+	public function update(SplSubject $subject)
+	{
+		$event = $subject->getLastEvent();
+
+		switch($event['name'])
+		{
+			case 'receivedHeaders':
+				$this->fp = @fopen($this->filename, 'wb');
+				if(!$this->fp)
+				{
+					throw new Exception("Cannot open target file '{$filename}'");
+				}
+				break;
+
+			case 'receivedBodyPart':
+			case 'receivedEncodedBodyPart':
+				fwrite($this->fp, $event['data']);
+				break;
+
+			case 'receivedBody':
+				fclose($this->fp);
+		}
+	}
+}


### PR DESCRIPTION
참고: https://www.xetown.com/lakepark/307634

동영상을 GIF로 변환한 수십MB짜리 "움짤" 이미지가 점점 늘어나고 있는 추세여서, 움짤 공유가 활발한 사이트에서는 자기도 모르게 사이트를 마비시키는 문제가 일어날 수 있습니다. (실제 사례입니다.) 악의적인 공격의 수단으로 사용될 수도 있고요.

용량이 큰 GIF 이미지라도 실제 가로세로 픽셀 수는 얼마 안 되기 때문에, GD 라이브러리로 섬네일을 생성하는 과정에서는 문제가 발생하지 않습니다. 다운로드 과정에서만 문제가 발생합니다.

예제: 100MB짜리 파일 다운로드 시도 (타임아웃을 넉넉하게 주어야 합니다.)

```
$filename = 'http://speedtest.tokyo.linode.com/100MB-tokyo.bin';
$target_filename = './files/testfile.bin';
$result = FileHandler::getRemoteFile($filename, $target_filename, null, 300);
echo 'Downloaded file size: ' . filesize(FileHandler::getRealPath($target_filename)) . PHP_EOL;
echo 'Maximum memory usage: ' . memory_get_peak_usage() . PHP_EOL;
```

XE 1.8.21에서 결과: 파일 용량의 2배에 해당하는 메모리를 사용

```
Downloaded file size: 104857600
Maximum memory usage: 216538144
```

패치 내역:
- HTTP_Request2 라이브러리의 `store_body` 설정과 Observer 기능을 사용하여, 다운로드한 파일 내용을 메모리에 적재하지 않고 디스크로 직접 스트리밍하도록 변경 ([참고 소스](https://pear.php.net/manual/en/package.http.http-request2.observers.php))
- 위의 기능을 사용하기 위해 FileHandler::getRemoteResource() 메소드 일부 수정
- requirePear() 함수를 여러 번 호출해도 중복으로 인클루드되지 않도록 수정

패치 적용 후 결과: 메모리를 거의 사용하지 않음

```
Downloaded file size: 104857600
Maximum memory usage: 8274848
```
