### PR TITLE
#1927 안드로이드 기본 브라우저에서 다운로드 파일명 문제 수정

### DIFF
--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -308,15 +308,22 @@ class fileController extends file
 
 		$file_size = $file_obj->file_size;
 		$filename = $file_obj->source_filename;
-				if(preg_match('#(?:Chrome|Edge)/(\d+)\.#', $_SERVER['HTTP_USER_AGENT'], $matches) && $matches[1] >= 11)
+		
+		if(preg_match('#(?:Chrome|Edge)/(\d+)\.#', $_SERVER['HTTP_USER_AGENT'], $matches) && $matches[1] >= 11)
 		{
-			$filename_param = "filename*=UTF-8''" . rawurlencode($filename) . '; filename="' . rawurlencode($filename) . '"';
+			if($is_android && preg_match('#\bwv\b|(?:Version|Browser)/\d+#', $_SERVER['HTTP_USER_AGENT']))
+			{
+				$filename_param = 'filename="' . $filename . '"';
+			}
+			else
+			{
+				$filename_param = "filename*=UTF-8''" . rawurlencode($filename) . '; filename="' . rawurlencode($filename) . '"';
+			}
 		}
 		elseif(preg_match('#(?:Firefox|Safari|Trident)/(\d+)\.#', $_SERVER['HTTP_USER_AGENT'], $matches) && $matches[1] >= 6)
 		{
 			$filename_param = "filename*=UTF-8''" . rawurlencode($filename) . '; filename="' . rawurlencode($filename) . '"';
 		}
-		// Filename encoding for browsers that do not support RFC 5987
 		elseif(strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE)
 		{
 			$filename = rawurlencode($filename);


### PR DESCRIPTION
#1927 안드로이드 기본 브라우저와 크롬을 구분하고, 크롬이 아닌 경우 RFC5987 인코딩을 사용하지 않도록 변경합니다.
