### PR TITLE
게시물 삭제 페이지에서 Fatal Error 수정

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -788,7 +788,7 @@ class boardView extends board
 		}
 
 		// if the document is not existed, then back to the board content page
-		if(!$oDocument->isExists())
+		if(!$oDocument || !$oDocument->isExists())
 		{
 			return $this->dispBoardContent();
 		}


### PR DESCRIPTION
게시판 모듈의 `dispBoardDeleteDocument` 메소드에서 `$document_srl`이 없는 경우 `$oDocument` 변수가 생성되지 않아 아래와 같이 치명적인 오류가 발생합니다.

```
Call to a member function isExists() on null in board.view.php on line 791
```

변수 존재 여부를 다시 확인하도록 하여 오류 발생을 막는 패치입니다.
