### PR TITLE
삭제된 그룹이 포인트/레벨/그룹 연동에 포함되는 것을 방지

### DIFF
--- a/modules/point/point.admin.controller.php
+++ b/modules/point/point.admin.controller.php
@@ -65,6 +65,7 @@ class pointAdminController extends point
 
 			$oMemberModel = getModel('member');
 			$group_list = $oMemberModel->getGroups();
+			$config->point_group = array();
 
 			// Per-level group configurations
 			foreach($group_list as $group)
@@ -88,10 +89,6 @@ class pointAdminController extends point
 						$args->{'point_group_'.$group_srl} = 1;
 					}
 					$config->point_group[$group_srl] = $args->{'point_group_'.$group_srl};
-				}
-				else
-				{
-					unset($config->point_group[$group_srl]);
 				}
 			}
 


### PR DESCRIPTION
### 문제 재현 방법
- 포인트 모듈을 아래와 같이 설정
  - 레벨 10 도달시 그룹 A
  - 레벨 20 도달시 그룹 B
  - 레벨 30 도달시 그룹 C
  - 다른 그룹은 초기화하도록 설정
- 관리자가 그룹 B를 삭제함
- 회원이 레벨 20 도달시 그룹 B에 추가되고 기존 그룹은 초기화됨 (그룹 A에서 제외됨)
- 그러나 그룹 B는 존재하지 않으므로
- A에도 B에도 소속되지 않은 상태가 됨 (기본 그룹만 남음)
- 포인트/레벨/그룹 연동 설정을 다시 저장해도 소용없음 (존재하지 않는 그룹은 설정을 변경할 수도 없고 삭제할 수도 없음)
### 패치 방법
- 포인트/레벨/그룹 연동 설정 저장시 존재하지 않는 그룹에 대한 설정이 남지 않도록 변경했습니다.
- 문제가 발생하더라도 포인트 모듈 설정을 한 번 저장해 주면 해결됩니다.
- 포인트 모듈 설정을 저장해 주지 않아도 자동 적용되도록 하려면 두 가지 방법이 있겠는데요...
  - 포인트/레벨/그룹 연동 시점에 실제로 그룹이 존재하는지 확인하는 방법
    - 단점: 불필요한 처리가 많이 발생할 수 있습니다.
  - 그룹 삭제시 포인트 모듈의 point_group 설정을 업데이트해 주는 방법
    - 단점: 그룹 조작 액션에는 트리거가 없습니다.
### 참고

rhymix/rhymix#552
