### PR TITLE
SSL 선택적 사용시 글쓰기/댓글수정 후 http로 redirect되도록 변경

### DIFF
--- a/common/js/common.js
+++ b/common/js/common.js
@@ -277,10 +277,15 @@ jQuery(function($) {
 			}
 		}
 
-		re = /http:\/\/([^:\/]+)(:\d+|)/i;
+		re = /https?:\/\/([^:\/]+)(:\d+|)/i;
 		if (bUseSSL && re.test(uri)) {
 			toReplace = 'https://'+RegExp.$1;
 			if (window.https_port && https_port != 443) toReplace += ':' + https_port;
+			uri = uri.replace(re, toReplace);
+		}
+		if (!bUseSSL && re.test(uri)) {
+			toReplace = 'http://'+RegExp.$1;
+			if (window.http_port && http_port != 80) toReplace += ':' + http_port;
 			uri = uri.replace(re, toReplace);
 		}
 


### PR DESCRIPTION
SSL 선택적 사용시 글쓰기/댓글수정 액션에 https를 사용하게 됩니다. 그러나 글쓰기/댓글쓰기 후에 redirect되는 글읽기 페이지 주소에도 마찬가지로 https를 사용하게 되는 문제가 있습니다. (참고: #1932)

원인은 board.js에서 setQuery 함수로 글읽기 페이지 주소를 작성하기 때문입니다. 이 함수는 http 주소에 SSL 액션을 추가하면 자동으로 https로 바꿔주는 기능은 있는데, 반대로 https 주소에 non-SSL 액션을 추가하면 http로 바꿔주는 기능은 없습니다. 그래서 한 번 https로 들어가면 계속 https에 남게 됩니다.

이 패치에서는 SSL 선택적 사용시 setQuery 함수에서 https 주소를 다시 http로 바꿔주는 기능을 추가합니다. 물론 SSL 액션으로 지정된 것은 제외합니다.
