### PR TITLE
디버그 기능 개선과 에러로그 기능을 추가합니다.

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -270,6 +270,17 @@ if(!defined('__PROXY_SERVER__'))
 	define('__PROXY_SERVER__', NULL);
 }
 
+if(!defined('__ERROR_LOG__'))
+{
+	/**
+	 * __ERROR_LOG__ 는 PHP의 에러로그를 출력하는 기능입니다. 개발시 워닝에러이상의 에러부터 잡기 시작합니다.
+	 *
+	 * 0: 사용하지 않음
+	 * 1: 사용함
+	 */
+	define('__ERROR_LOG__', 0);
+}
+
 // Require specific files when using Firebug console output
 if((__DEBUG_OUTPUT__ == 2) && version_compare(PHP_VERSION, '6.0.0') === -1)
 {

--- a/modules/board/board.admin.view.php
+++ b/modules/board/board.admin.view.php
@@ -64,6 +64,7 @@ class boardAdminView extends board {
 	 * @brief display the board module admin contents
 	 **/
 	function dispBoardAdminContent() {
+		$args->asdasd = 'asd'asdaweawe
 		// setup the board module general information
 		$args = new stdClass();
 		$args->sort_index = "module_srl";


### PR DESCRIPTION
라이믹스 만큼은 안되지만, 디버그 기능을 개선하고 에러로그기능을 추가합니다.

기존의  #1872 에서 @kijin 님의 의견에 따라 기존의 error로그 부분에 치명적인 에러도 기록할 수 있도록 개선하고
현재의 가독성이 떨어지는 디버그 항목을 좀 더 개선하여 가독성을 유리하도록 하는것이 목표입니다.

더불어 이 기능이 어디서 어떻게 실행되오는 과정(stack trace)기능을 추가합니다.

`stack trace` 기능의 경우 현재 XE의 필수 설치요건의 PHP버전의 최소값보다 약간 높은 버전에서 사용이 가능한 `debug_backtrace`함수를 이용함으로 이기능은 PHP5.3.6 이상에서만 가능합니다...
PHP 5.3.6 이하의 경우 `debug_backtrace` 내용을 제외한 기능을 추가하는것으로 목표를 잡고 작업을 진행하도록 하겠습니다.

* [ ] 기본 에러 및 치명적인 에러 로그를 debug_message.php 에 함께 추가하도록 개선.
* [ ] debug_backtrace 함수를 이용하여 trace 기능을 추가.
* [ ] debugPrint의 내용들을 가독성있게 출력하도록 개선.