### PR TITLE
디버그의 기능을 추가합니다.

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -107,18 +107,12 @@ class ModuleHandler extends Handler
 			if(__DEBUG_PROTECT__ === 1 && __DEBUG_PROTECT_IP__ == $_SERVER['REMOTE_ADDR'])
 			{
 				set_error_handler(array($this, 'xeErrorLog'), 3);
-				if(3 & E_ERROR)
-				{
-					register_shutdown_function(array($this, 'shutdownHandler'));
-				}
+				register_shutdown_function(array($this, 'shutdownHandler'));
 			}
 			else if(__DEBUG_PROTECT__ === 0)
 			{
 				set_error_handler(array($this, 'xeErrorLog'), 3);
-				if(3 & E_ERROR)
-				{
-					register_shutdown_function(array($this, 'shutdownHandler'));
-				}
+				register_shutdown_function(array($this, 'shutdownHandler'));
 			}
 		}
 

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -106,12 +106,12 @@ class ModuleHandler extends Handler
 		{
 			if(__DEBUG_PROTECT__ === 1 && __DEBUG_PROTECT_IP__ == $_SERVER['REMOTE_ADDR'])
 			{
-				set_error_handler(array($this, 'xeErrorLog'), 3);
+				set_error_handler(array($this, 'xeErrorLog'), E_WARNING);
 				register_shutdown_function(array($this, 'shutdownHandler'));
 			}
 			else if(__DEBUG_PROTECT__ === 0)
 			{
-				set_error_handler(array($this, 'xeErrorLog'), 3);
+				set_error_handler(array($this, 'xeErrorLog'), E_WARNING);
 				register_shutdown_function(array($this, 'shutdownHandler'));
 			}
 		}
@@ -123,14 +123,14 @@ class ModuleHandler extends Handler
 		if(file_exists($addon_file)) include($addon_file);
 	}
 
-	function xeErrorLog($errnumber, $errormassage, $errorfile, $errorline, $errorcontext)
+	public static function xeErrorLog($errnumber, $errormassage, $errorfile, $errorline, $errorcontext)
 	{
 		if(($errnumber & 3) == 0 || error_reporting() == 0)
 		{
 			return false;
 		}
 
-		set_error_handler(array($this, 'dummyHandler'), ~0);
+		set_error_handler(function() { }, ~0);
 
 		$debug_file = _XE_PATH_ . 'files/_debug_message.php';
 		$debug_file_exist = file_exists($debug_file);
@@ -140,8 +140,7 @@ class ModuleHandler extends Handler
 		}
 
 		$errorname = self::getErrorType($errnumber);
-		$print[] = '['.date('Y-m-d H:i:s').']';
-		$print[] = $errorname . ' : ' . $errormassage;
+		$print[] = '['.date('Y-m-d H:i:s').'] ' . $errorname . ' : ' . $errormassage;
 		$backtrace_args = defined('DEBUG_BACKTRACE_IGNORE_ARGS') ? \DEBUG_BACKTRACE_IGNORE_ARGS : 0;
 		$backtrace = debug_backtrace($backtrace_args);
 		if(count($backtrace) > 1 && $backtrace[1]['function'] === 'xeErrorLog' && !$backtrace[1]['class'])
@@ -169,7 +168,7 @@ class ModuleHandler extends Handler
 			return false;
 		}
 
-		set_error_handler(array($this, 'dummyHandler'), ~0);
+		set_error_handler(function() { }, ~0);
 
 		$debug_file = _XE_PATH_ . 'files/_debug_message.php';
 		$debug_file_exist = file_exists($debug_file);
@@ -188,13 +187,6 @@ class ModuleHandler extends Handler
 		$print[] = PHP_EOL;
 		@file_put_contents($debug_file, implode(PHP_EOL, $print), FILE_APPEND|LOCK_EX);
 		set_error_handler(array($this, 'dummyHandler'), ~0);
-	}
-
-	/**
-	 * 더미 에러 핸들러.
-	 */
-	public function dummyHandler($errnumber, $errormassage, $errorfile, $errorline, $errorcontext)
-	{
 	}
 
 	public static function getErrorType($errno)

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -270,6 +270,17 @@ if(!defined('__PROXY_SERVER__'))
 	define('__PROXY_SERVER__', NULL);
 }
 
+if(!defined('__ERROR_LOG__'))
+{
+	/**
+	 * __ERROR_LOG__ 는 PHP의 에러로그를 출력하는 기능입니다. 개발시 워닝에러이상의 에러부터 잡기 시작합니다.
+	 *
+	 * 0: 사용하지 않음
+	 * 1: 사용함
+	 */
+	define('__ERROR_LOG__', 0);
+}
+
 // Require specific files when using Firebug console output
 if((__DEBUG_OUTPUT__ == 2) && version_compare(PHP_VERSION, '6.0.0') === -1)
 {


### PR DESCRIPTION
라이믹스 만큼은 안되지만, 디버그 기능을 개선하고 에러로그기능을 추가합니다.

기존의  #1872 에서 @kijin 님의 의견에 따라 기존의 error로그 부분에 치명적인 에러도 기록할 수 있도록 개선하고
현재의 가독성이 떨어지는 디버그 항목을 좀 더 개선하여 가독성을 유리하도록 하는것이 목표입니다.

디버그 기능의 원활한 사용을 위해서는 다음과 같은 추가작업이 필요합니다.
`xe/config/config.user.inc.php`
파일에서 `define('__ERROR_LOG__', 1);`
을 추가해야 하며, `__DEBUG_PROTECT__`, 의 설정에 따라 1일경우 `__DEBUG_PROTECT_IP__`을 정상적으로 재대로 세팅을 하고, 지정된 아이피에서만 출력되도록 설정되어있습니다.

더불어 이 기능이 어디서 어떻게 실행되오는 과정(stack trace)기능을 추가합니다.

`stack trace` 기능의 경우 현재 XE의 필수 설치요건의 PHP버전의 최소값보다 약간 높은 버전에서 사용이 가능한 `debug_backtrace`함수를 이용함으로 이기능은 PHP5.3.6 이상에서만 가능합니다...
PHP 5.3.6 이하의 경우 `debug_backtrace` 내용을 제외한 기능을 추가하는것으로 목표를 잡고 작업을 진행하도록 하겠습니다.
- [x] 기본 에러 및 치명적인 에러 로그를 debug_message.php 에 함께 추가하도록 개선.
- [x] debug_backtrace 함수를 이용하여 trace 기능을 추가.
- [x] debugPrint의 내용들을 가독성있게 출력하도록 개선.
