### PR TITLE
SSL 선택적 사용시 임시저장글을 불러올 수 없는 문제 해결

### DIFF
--- a/modules/board/board.class.php
+++ b/modules/board/board.class.php
@@ -32,6 +32,10 @@ class board extends ModuleObject
 			$ssl_actions = array('dispBoardWrite', 'dispBoardWriteComment', 'dispBoardReplyComment', 'dispBoardModifyComment', 'dispBoardDelete', 'dispBoardDeleteComment', 'procBoardInsertDocument', 'procBoardDeleteDocument', 'procBoardInsertComment', 'procBoardDeleteComment', 'procBoardVerificationPassword');
 			Context::addSSLActions($ssl_actions);
 		}
+		if(!Context::isExistsSSLAction('dispTempSavedList') && Context::getSslStatus() == 'optional')
+		{
+			Context::addSSLAction('dispTempSavedList');
+		}
 	}
 
 	/**


### PR DESCRIPTION
dispTempSavedList가 sslAction으로 등록되어 있지 않아 임시저장글 목록 팝업창이 그냥 http로 로딩됩니다. 그래서 "선택" 클릭시 스크립트가 작동하지 않습니다.

dispTempSavedList를 sslAction에 추가하여 이 문제를 해결합니다.

32줄의 목록에 추가할 경우 캐싱 때문에 정상 작동하지 않으므로, 별도의 조건으로 넣었습니다.
