### PR TITLE
파일 크기 제한, 문서 첨부 제한 설정 오류 수정

### DIFF
--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -152,7 +152,12 @@ class fileModel extends file
 		if(!$config->allow_outlink) $config->allow_outlink = 'Y';
 		if(!$config->download_grant) $config->download_grant = array();
 
-		$size = preg_replace('/[a-z]/is', '', ini_get('upload_max_filesize'));
+		$size = ini_get('upload_max_filesize');
+		$unit = strtolower($size[strlen($size) - 1]);
+		$size = (float)$size;
+		if($unit == 'g') $size *= 1024;
+		if($unit == 'k') $size /= 1024;
+
 		if($config->allowed_filesize > $size) 
 		{	
 			$config->allowed_filesize = $size;


### PR DESCRIPTION
`upload_max_filesize`가 MB단위로 되어있지 않은 경우(ex. 2G) 발생하던 오류를 수정했습니다.
