### PR TITLE
PHP 7.1에서 오류를 유발하는 Context 클래스의 $this 사용 제거

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -445,7 +445,7 @@ class Context
 	 */
 	function loadDBInfo()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if(!$self->isInstalled())
 		{
@@ -529,7 +529,7 @@ class Context
 	 */
 	function getDBType()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->db_info->master_db["db_type"];
 	}
 
@@ -541,7 +541,7 @@ class Context
 	 */
 	function setDBInfo($db_info)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->db_info = $db_info;
 	}
 
@@ -552,7 +552,7 @@ class Context
 	 */
 	function getDBInfo()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->db_info;
 	}
 
@@ -737,7 +737,7 @@ class Context
 	 */
 	function getFTPInfo()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if(!$self->isFTPRegisted())
 		{
@@ -761,7 +761,7 @@ class Context
 		{
 			return;
 		}
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if($self->site_title)
 		{
@@ -785,7 +785,7 @@ class Context
 		{
 			return;
 		}
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->site_title = $site_title;
 	}
 
@@ -796,7 +796,7 @@ class Context
 	 */
 	function getBrowserTitle()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		$oModuleController = getController('module');
 		$oModuleController->replaceDefinedLangCode($self->site_title);
@@ -839,7 +839,7 @@ class Context
 	{
 		global $lang;
 
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		if(!$self->lang_type)
 		{
 			return;
@@ -960,7 +960,7 @@ class Context
 	 */
 	function setLangType($lang_type = 'ko')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		$self->lang_type = $lang_type;
 		$self->set('lang_type', $lang_type);
@@ -975,7 +975,7 @@ class Context
 	 */
 	function getLangType()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->lang_type;
 	}
 
@@ -1132,7 +1132,7 @@ class Context
 	 */
 	function setResponseMethod($method = 'HTML')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		$methods = array('HTML' => 1, 'XMLRPC' => 1, 'JSON' => 1, 'JS_CALLBACK' => 1);
 		$self->response_method = isset($methods[$method]) ? $method : 'HTML';
@@ -1145,7 +1145,7 @@ class Context
 	 */
 	function getResponseMethod()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if($self->response_method)
 		{
@@ -1166,7 +1166,7 @@ class Context
 	 */
 	function setRequestMethod($type = '')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		$self->js_callback_func = $self->getJSCallbackFunc();
 
@@ -1429,7 +1429,7 @@ class Context
 	 */
 	function isUploaded()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->is_uploaded;
 	}
 
@@ -1483,7 +1483,7 @@ class Context
 	 */
 	function getRequestMethod()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->request_method;
 	}
 
@@ -1515,7 +1515,7 @@ class Context
 	 */
 	function getJSCallbackFunc()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$js_callback_func = isset($_GET['xe_js_callback']) ? $_GET['xe_js_callback'] : $_POST['xe_js_callback'];
 
 		if(!preg_match('/^[a-z0-9\.]+$/i', $js_callback_func))
@@ -1543,7 +1543,7 @@ class Context
 		static $site_module_info = null;
 		static $current_info = null;
 
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		// retrieve virtual site information
 		if(is_null($site_module_info))
@@ -1881,7 +1881,7 @@ class Context
 	 */
 	function set($key, $val, $set_to_get_vars = 0)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->context->{$key} = $val;
 		if($set_to_get_vars === FALSE)
 		{
@@ -1906,7 +1906,7 @@ class Context
 	 */
 	function get($key)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if(!isset($self->context->{$key}))
 		{
@@ -1927,7 +1927,7 @@ class Context
 		{
 			return;
 		}
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		$args_list = func_get_args();
 		$output = new stdClass();
@@ -1945,7 +1945,7 @@ class Context
 	 */
 	function getAll()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->context;
 	}
 
@@ -1956,7 +1956,7 @@ class Context
 	 */
 	function getRequestVars()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		if($self->get_vars)
 		{
 			return clone($self->get_vars);
@@ -1972,7 +1972,7 @@ class Context
 	 */
 	function addSSLAction($action)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if(!is_readable($self->sslActionCacheFile))
 		{
@@ -1996,7 +1996,7 @@ class Context
 	 */
 	function addSSLActions($action_array)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if(!is_readable($self->sslActionCacheFile))
 		{
@@ -2024,7 +2024,7 @@ class Context
 	 */
 	function subtractSSLAction($action)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if($self->isExistsSSLAction($action))
 		{
@@ -2042,7 +2042,7 @@ class Context
 	 */
 	function getSSLActions()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		if($self->getSslStatus() == 'optional')
 		{
 			return $self->ssl_actions;
@@ -2057,7 +2057,7 @@ class Context
 	 */
 	function isExistsSSLAction($action)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return isset($self->ssl_actions[$action]);
 	}
 
@@ -2123,7 +2123,7 @@ class Context
 	 */
 	function loadFile($args)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		$self->oFrontEndFileHandler->loadFile($args);
 	}
@@ -2138,7 +2138,7 @@ class Context
 	 */
 	function unloadFile($file, $targetIe = '', $media = 'all')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->unloadFile($file, $targetIe, $media);
 	}
 
@@ -2150,7 +2150,7 @@ class Context
 	 */
 	function unloadAllFiles($type = 'all')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->unloadAllFiles($type);
 	}
 
@@ -2184,7 +2184,7 @@ class Context
 			$file = $validator->getJsPath();
 		}
 
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->loadFile(array($file, $type, $targetie, $index));
 	}
 
@@ -2199,7 +2199,7 @@ class Context
 	 */
 	function unloadJsFile($file, $optimized = FALSE, $targetie = '')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->unloadFile($file, $targetie);
 	}
 
@@ -2210,7 +2210,7 @@ class Context
 	 */
 	function unloadAllJsFiles()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->unloadAllFiles('js');
 	}
 
@@ -2259,7 +2259,7 @@ class Context
 	 */
 	function getJsFile($type = 'head')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->oFrontEndFileHandler->getJsFileList($type);
 	}
 
@@ -2277,7 +2277,7 @@ class Context
 	 */
 	function addCSSFile($file, $optimized = FALSE, $media = 'all', $targetie = '', $index = 0)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->loadFile(array($file, $media, $targetie, $index));
 	}
 
@@ -2293,7 +2293,7 @@ class Context
 	 */
 	function unloadCSSFile($file, $optimized = FALSE, $media = 'all', $targetie = '')
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->unloadFile($file, $targetie, $media);
 	}
 
@@ -2304,7 +2304,7 @@ class Context
 	 */
 	function unloadAllCSSFiles()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->oFrontEndFileHandler->unloadAllFiles('css');
 	}
 
@@ -2315,7 +2315,7 @@ class Context
 	 */
 	function getCSSFile()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->oFrontEndFileHandler->getCssFileList();
 	}
 
@@ -2383,7 +2383,7 @@ class Context
 	{
 		static $loaded_plugins = array();
 
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		if($plugin_name == 'ui.datepicker')
 		{
 			$plugin_name = 'ui';
@@ -2439,13 +2439,13 @@ class Context
 	 */
 	function addHtmlHeader($header)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->html_header .= "\n" . $header;
 	}
 
 	function clearHtmlHeader()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->html_header = '';
 	}
 
@@ -2456,7 +2456,7 @@ class Context
 	 */
 	function getHtmlHeader()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->html_header;
 	}
 
@@ -2467,7 +2467,7 @@ class Context
 	 */
 	function addBodyClass($class_name)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->body_class[] = $class_name;
 	}
 
@@ -2478,7 +2478,7 @@ class Context
 	 */
 	function getBodyClass()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->body_class = array_unique($self->body_class);
 
 		return (count($self->body_class) > 0) ? sprintf(' class="%s"', join(' ', $self->body_class)) : '';
@@ -2491,7 +2491,7 @@ class Context
 	 */
 	function addBodyHeader($header)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->body_header .= "\n" . $header;
 	}
 
@@ -2502,7 +2502,7 @@ class Context
 	 */
 	function getBodyHeader()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->body_header;
 	}
 
@@ -2513,7 +2513,7 @@ class Context
 	 */
 	function addHtmlFooter($footer)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->html_footer .= ($self->Htmlfooter ? "\n" : '') . $footer;
 	}
 
@@ -2524,7 +2524,7 @@ class Context
 	 */
 	function getHtmlFooter()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		return $self->html_footer;
 	}
 
@@ -2643,7 +2643,7 @@ class Context
 	 */
 	function getMetaTag()
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 
 		if(!is_array($self->meta_tags))
 		{
@@ -2670,7 +2670,7 @@ class Context
 	 */
 	function addMetaTag($name, $content, $is_http_equiv = FALSE)
 	{
-		is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
+		$self = self::getInstance();
 		$self->meta_tags[$name . "\t" . ($is_http_equiv ? '1' : '0')] = $content;
 	}
 


### PR DESCRIPTION
PHP 7.1 RC1에서 XE를 실행하면 아래와 같은 오류가 발생합니다.

```
Fatal Error: Uncaught Error: Using $this when not in object context in classes/context/Context.class.php:842
```

예전에는 `static`으로 호출한 메소드에서도 `$this`를 일반 변수처럼 사용할 수 있었지만, 이제는 `$this`라고 쓰기만 해도 치명적인 오류가 발생하도록 바뀌었네요.

참고: https://secure.php.net/manual/en/migration71.other-changes.php (Inconsistency Fixes to $this)

이 문제를 해결하기 위해 Context 클래스에서 아래와 같은 코드가 등장하는 51군데를

```
is_a($this, 'Context') ? $self = $this : $self = self::getInstance();
```

모두 아래와 같이 변경합니다.

```
$self = self::getInstance();
```
