### PR TITLE
XML 쿼리에서 LIMIT OFFSET을 직접 지정할 수 있도록 지원

### DIFF
--- a/classes/db/queryparts/limit/Limit.class.php
+++ b/classes/db/queryparts/limit/Limit.class.php
@@ -38,9 +38,10 @@ class Limit
 	 * @param int $list_count
 	 * @param int $page
 	 * @param int $page_count
+	 * @param int $offset
 	 * @return void
 	 */
-	function Limit($list_count, $page = NULL, $page_count = NULL)
+	function Limit($list_count, $page = NULL, $page_count = NULL, $offset = NULL)
 	{
 		$this->list_count = $list_count;
 		if($page)
@@ -50,6 +51,10 @@ class Limit
 			$this->start = ($page_value - 1) * $list_count_value;
 			$this->page_count = $page_count;
 			$this->page = $page;
+		}
+		elseif($offset)
+		{
+			$this->start = $offset->getValue();
 		}
 	}
 
@@ -81,7 +86,7 @@ class Limit
 
 	function toString()
 	{
-		if($this->page)
+		if($this->page || $this->start)
 		{
 			return $this->start . ' , ' . $this->list_count->getValue();
 		}

--- a/classes/xml/xmlquery/tags/navigation/LimitTag.class.php
+++ b/classes/xml/xmlquery/tags/navigation/LimitTag.class.php
@@ -36,6 +36,12 @@ class LimitTag
 	var $list_count;
 
 	/**
+	 * QueryArgument object
+	 * @var QueryArgument
+	 */
+	var $offset;
+
+	/**
 	 * constructor
 	 * @param object $index
 	 * @return void
@@ -58,6 +64,12 @@ class LimitTag
 			$index->list_count->attrs->default = 0;
 		$this->list_count = new QueryArgument($index->list_count);
 		$this->arguments[] = $this->list_count;
+		
+		if(isset($index->offset) && isset($index->offset->attrs))
+		{
+			$this->offset = new QueryArgument($index->offset);
+			$this->arguments[] = $this->offset;
+		}
 	}
 
 	function toString()
@@ -65,6 +77,10 @@ class LimitTag
 		if($this->page)
 		{
 			return sprintf('new Limit(${\'%s_argument\'}, ${\'%s_argument\'}, ${\'%s_argument\'})', $this->list_count->getArgumentName(), $this->page->getArgumentName(), $this->page_count->getArgumentName());
+		}
+		elseif($this->offset)
+		{
+			return sprintf('new Limit(${\'%s_argument\'}, NULL, NULL, ${\'%s_argument\'})', $this->list_count->getArgumentName(), $this->offset->getArgumentName());
 		}
 		else
 		{


### PR DESCRIPTION
LIMIT에 OFFSET을 사용하는 것은 SQL의 가장 기본적인 용법 중 하나인데, 현재 XE의 XML 쿼리 문법에서는 페이징 관련 변수들을 사용하여 간접적으로 OFFSET을 지정하는 방법밖에 없습니다.

예를 들어 아래와 같은 쿼리를 실행하려면

```
SELECT * FROM xe_documents ORDER BY list_order LIMIT 80, 20;
```

아래와 같이 페이징을 사용해야 합니다.

```
<navigation>
    <index var="sort_index" default="list_order" order="order_type" />
    <list_count var="list_count" default="20" />
    <page_count var="page_count" default="10" />
    <page var="page" default="1" />
</navigation>
```

```
$args = new stdClass;
$args->list_count = 20;
$args->page = 5;  // 80개 건너뛰려면 4페이지던가 5페이지던가? 아몰랑~
$output = executeQuery( ..... , $args);
```

게시판 모듈처럼 단순히 페이징을 하기 위한 목적이라면 이것만으로도 충분하지만, OFFSET을 직접 지정하고 싶을 때는 페이지 수를 일일이 계산해야 하기 때문에 상당히 불편합니다. 무한스크롤을 위한 AJAX 요청처럼 꼭 필요하지 않을 때도 PageHandler가 자동으로 호출되고 `SELECT COUNT(*)` 쿼리가 발생하여 성능에 상당히 큰 악영향을 미치고요. (게시판의 글 수가 수십만 개를 넘어가면 페이징을 위한 `SELECT COUNT(*)` 쿼리가 DB 부하의 대부분을 차지합니다.)

이 PR을 적용하면 `<offset>` 태그를 사용하여 OFFSET을 직접 지정할 수 있게 됩니다.

아래와 같이 쿼리를 작성하면 됩니다.

```
<navigation>
    <index var="sort_index" default="list_order" order="order_type" />
    <list_count var="list_count" default="20" />
    <offset var="offset" default="0" />
</navigation>
```

```
$args = new stdClass;
$args->list_count = 20;
$args->offset = 80;
$output = executeQuery( ..... , $args);
```

이 경우에는 PageHandler가 호출되지도 않고 `SELECT COUNT(*)` 쿼리가 발생하지도 않습니다. 정확하게 원하는 구간(80개 건너뛰고 그 다음 20개)의 데이터만 반환됩니다.

XML 쿼리 파서와 LIMIT 쿼리 생성 담당 클래스에 최소한의 기능만을 추가했으며, `<offset>` 태그를 사용하지 않는 기존 쿼리에는 어떤 영향도 주지 않습니다. `<page>` 태그와 `<offset>` 태그를 함께 쓰는 경우에는 `<page>` 태그가 우선순위를 가집니다.
