### PR TITLE
트리거 실행 순서를 항상 일관성있게 고정

### DIFF
--- a/modules/module/queries/getTrigger.xml
+++ b/modules/module/queries/getTrigger.xml
@@ -12,4 +12,11 @@
         <condition operation="equal" column="called_method" var="called_method" pipe="and" />
         <condition operation="equal" column="called_position" var="called_position" pipe="and" />
     </conditions>
+    <navigation>
+        <index default="trigger_name" order="asc" />
+        <index default="called_position" order="asc" />
+        <index default="module" order="asc" />
+        <index default="type" order="asc" />
+        <index default="called_method" order="asc" />
+    </navigation>
 </query>

--- a/modules/module/queries/getTriggers.xml
+++ b/modules/module/queries/getTriggers.xml
@@ -9,4 +9,11 @@
         <condition operation="equal" column="trigger_name" var="trigger_name" />
         <condition operation="equal" column="called_position" var="called_position" pipe="and" />
     </conditions>
+    <navigation>
+        <index default="trigger_name" order="asc" />
+        <index default="called_position" order="asc" />
+        <index default="module" order="asc" />
+        <index default="type" order="asc" />
+        <index default="called_method" order="asc" />
+    </navigation>
 </query>


### PR DESCRIPTION
하나의 트리거에 여러 모듈, 여러 메소드가 연결되어 있는 경우 실행되는 순서가 정해져 있지 않아서, DB에서 약간 다른 순서로 레코드를 반환하면 순서가 바뀔 수 있습니다. 대부분의 경우에는 인덱스 덕분에 모듈명 순서대로 정렬되지만, 명시적으로 정렬한 것이 아니므로 DB 상태나 설정에 따라서는 순서가 바뀔 가능성이 있습니다. (SQL 표준은 `ORDER BY`가 없는 쿼리의 정렬 순서를 정의하지 않습니다.)

여러 서드파티 모듈을 사용하는 사이트에서 트리거 실행 순서가 갑자기 바뀌면 예상치 못한 버그가 발생할 가능성이 있고, 항상 일어나는 일이 아니므로 디버깅하기도 힘듭니다.

이 PR에서는 `module.getTrigger` 및 `module.getTriggers` 쿼리에 정렬 조건을 추가하여 항상 모듈명의 알파벳 순서대로, 같은 모듈 내에서는 메소드명의 알파벳 순서대로 트리거 실행 순서를 고정합니다. 지금도 이 순서대로 정렬되는 것이 일반적이므로, 대부분의 사이트에서는 차이가 없을 것입니다.
