### PR TITLE
HTML Parser 라이브러리가 PHP 7에서 오류를 일으키는 문제 수정

### DIFF
--- a/classes/security/phphtmlparser/src/htmlparser.inc
+++ b/classes/security/phphtmlparser/src/htmlparser.inc
@@ -174,7 +174,7 @@ class HtmlParser {
     }
 
     function isValidTagIdentifier ($name) {
-        return ereg ("^[A-Za-z0-9_\\-]+$", $name);
+        return preg_match ("/^[A-Za-z0-9_\\-]+$/", $name);
     }
     
     function skipBlanksInTag() {


### PR DESCRIPTION
HTML 필터링에 사용되는 "PHP HTML Parser" 라이브러리에 `ereg()` 함수를 사용하는 부분이 있어 PHP 7에서 치명적인 오류를 일으킵니다. 해당 부분을 `preg_match()` 함수로 교체합니다.
