### PR TITLE
documentItem->isGranted() 결과를 캐싱하여 불필요한 중복 쿼리 방지

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -21,6 +21,11 @@ class documentItem extends Object
 	 */
 	var $lang_code = null;
 	/**
+	 * Grant cache
+	 * @var bool
+	 */
+	var $grant_cache = null;
+	/**
 	 * Status of allow trackback
 	 * @var bool
 	 */
@@ -154,25 +159,31 @@ class documentItem extends Object
 
 	function isGranted()
 	{
-		if($_SESSION['own_document'][$this->document_srl]) return true;
+		if($_SESSION['own_document'][$this->document_srl]) return $this->grant_cache = true;
 
-		if(!Context::get('is_logged')) return false;
+		if($this->grant_cache !== null)
+		{
+			return $this->grant_cache;
+		}
+
+		if(!Context::get('is_logged')) return $this->grant_cache = false;
 
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin == 'Y') return true;
+		if($logged_info->is_admin == 'Y') return $this->grant_cache = true;
 
 		$oModuleModel = getModel('module');
 		$grant = $oModuleModel->getGrant($oModuleModel->getModuleInfoByModuleSrl($this->get('module_srl')), $logged_info);
-		if($grant->manager) return true;
+		if($grant->manager) return $this->grant_cache = true;
 
-		if($this->get('member_srl') && ($this->get('member_srl') == $logged_info->member_srl || $this->get('member_srl')*-1 == $logged_info->member_srl)) return true;
+		if($this->get('member_srl') && ($this->get('member_srl') == $logged_info->member_srl || $this->get('member_srl')*-1 == $logged_info->member_srl)) return $this->grant_cache = true;
 
-		return false;
+		return $this->grant_cache = false;
 	}
 
 	function setGrant()
 	{
 		$_SESSION['own_document'][$this->document_srl] = true;
+		$this->grant_cache = true;
 	}
 
 	function isAccessible()


### PR DESCRIPTION
게시판 스킨에 따라 차이는 있지만, 댓글이 많은 문서를 열람하면 `documentItem->isGranted()` 메소드가 댓글 숫자만큼 호출되는 경우를 종종 봅니다. 그 밖에도 위젯 등에서 많이 호출하는 메소드이다 보니 한 페이지를 로딩하는 데 수십 번씩 호출되는 일이 드물지 않습니다.

관리자와 손님은 간단하게 처리되지만, 일반 회원은 매번 아래의 코드가 실행됩니다.

```
$grant = $oModuleModel->getGrant($oModuleModel->getModuleInfoByModuleSrl($this->get('module_srl')), $logged_info);
```

일단 저렇게 모듈 모델로 넘어가면 연쇄작용으로 더 많은 메소드들이 호출되고, DB와 캐시에 엄청나게 많은 요청이 발생합니다. 한 요청 내에서 같은 문서에 대한 같은 회원의 권한이 바뀔 리가 없는데 말이죠...

이 PR에서는 `documentItem` 클래스 내에서 `isGranted()` 메소드의 결과를 캐싱하도록 하여, 한 요청 내에서 같은 문서에 대해서는 한 번만 쿼리가 발생하도록 합니다. 장기간 캐싱하지 않으므로 부작용은 거의 없을 것으로 보입니다. 또한 세션 변수 체크를 캐시 체크 앞에 배치하여, 서드파티 자료가 기존 방식대로 세션 변수를 조작한 경우 캐시보다 앞서 적용되도록 했습니다.
