### PR TITLE
getDocumentList 트리거에 columnList 전달

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -222,7 +222,7 @@ class documentModel extends document
 		$obj->sort_index = $sort_check->sort_index;
 		$obj->isExtraVars = $sort_check->isExtraVars;
 		unset($obj->use_alternate_output);
-
+		$obj->columnList = $columnList;
 		// Call trigger (before)
 		// This trigger can be used to set an alternative output using a different search method
 		$output = ModuleHandler::triggerCall('document.getDocumentList', 'before', $obj);
@@ -232,13 +232,13 @@ class documentModel extends document
 		}
 
 		// If an alternate output is set, use it instead of running the default queries
-		$use_alternate_otuput = (isset($obj->use_alternate_output) && $obj->use_alternate_output instanceof Object);
-		if (!$use_alternate_otuput)
+		$use_alternate_output = (isset($obj->use_alternate_output) && $obj->use_alternate_output instanceof Object);
+		if (!$use_alternate_output)
 		{
 			$this->_setSearchOption($obj, $args, $query_id, $use_division);
 		}
 
-		if ($use_alternate_otuput)
+		if ($use_alternate_output)
 		{
 			$output = $obj->use_alternate_output;
 			unset($obj->use_alternate_output);


### PR DESCRIPTION
1) 실제 getDocumentList 를 외부 모듈에서 쓰려다보면
$columnList 가 필요한데, 이 값이 trigger 상에서 전달이 안 되고 있네요

물론 
$oBoardView = getView('board');
$columnList = $oBoardView->columnList;
이렇게 해서 외부에서 $columnList 를 구해낼 수 있지만
_makeListColumnList() 함수를 실행시킬 수 없다보니 정확치도 않고 효율적으로도 안 좋으니

아예 trigger 로 $columnList 까지 전달해버리는게 좋을듯합니다

2) $use_alternate_otuput 오타를 $use_alternate_output 으로 변경
