### PR TITLE
다차원 배열을 설정값으로 입력할경우 정상적인 설정저장이 안되는 문제고침.

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1409,10 +1409,21 @@ class Context
 
 				if($do_stripslashes && version_compare(PHP_VERSION, '5.4.0', '<') && get_magic_quotes_gpc())
 				{
-					$result[$k] = stripslashes($result[$k]);
+					if (is_array($result[$k]))
+					{
+						array_walk_recursive($result[$k], function(&$val) { $val = stripslashes($val); });
+					}
+					else
+					{
+						$result[$k] = stripslashes($result[$k]);
+					}
 				}
 
-				if(!is_array($result[$k]))
+				if(is_array($result[$k]))
+				{
+					array_walk_recursive($result[$k], function(&$val) { $val = trim($val); });
+				}
+				else
 				{
 					$result[$k] = trim($result[$k]);
 				}


### PR DESCRIPTION
다차원 배열을 설정값으로 입력할 경우 정상적인 설정저장이 이루어지지 않고있습니다. 이는 PHP5.3 이하 유저들에게서 발생되고 있으며 실제로, https://github.com/bjrambo/gradeup/issues/2 에서 이슈를 받아 처리중에 확인된 결과물입니다.

이 코드는 라이믹스 코드이나 커밋을 한 @kijin 님의 허락하에 코드를 제공합니다. (듀얼라이선스)

XE-Core에도 필요한 코드으로 보여집니다. 
