### PR TITLE
첨부 파일 본문 삽입 시 외부 URL을 포함할 수 있도록 개선

### DIFF
--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -237,7 +237,12 @@
 				if(!fileinfo) return;
 
 				if(/\.(jpe?g|png|gif)$/i.test(fileinfo.download_url)) {
-					temp_code += '<img src="' + window.request_uri + fileinfo.download_url + '" alt="' + fileinfo.source_filename + '" editor_component="image_link" data-file-srl="' + fileinfo.file_srl + '" />';
+					if(fileinfo.download_url.indexOf('http://')!=-1 || fileinfo.download_url.indexOf('https://')!=-1) {
+						temp_code += '<img src="' + fileinfo.download_url + '" alt="' + fileinfo.source_filename + '" editor_component="image_link" data-file-srl="' + fileinfo.file_srl + '" />';
+					}
+					else {
+						temp_code += '<img src="' + window.request_uri + fileinfo.download_url + '" alt="' + fileinfo.source_filename + '" editor_component="image_link" data-file-srl="' + fileinfo.file_srl + '" />';
+					}
 					temp_code += "\r\n<p><br></p>\r\n";
 				} else {
 					temp_code += '<a href="' + window.request_uri + fileinfo.download_url + '" data-file-srl="' + fileinfo.file_srl + '">' + fileinfo.source_filename + "</a>\n";


### PR DESCRIPTION
ckeditor 에서  파일첨부 후 '본문삽입'을 클릭하면 ( insertToContent )
파일이 업로드 되었던  uploaded_filename  앞에 강제로  window.request_uri ( 도메인 ) 이 붙어서 들어간다

문제는  uploaded_filename  자체가 도메인을 포함하고 있는 경우 
( 예를들면 파일서버를 분리해서, 외부서버의 파일주소를 uploaded_filename 이 다 포함하고 있는 경우 )
강제로 붙는 window.request_uri  때문에 http:// 가 두번 나오는 이상한 주소가 강제로 만들어진다

따라서 insertToContent 시,  uploaded_filename 에 http:// 또는 https:// 가 있는지 검토해서
없을땐 window.request_uri 를 붙이고, 있을땐 안 붙이게 개선을 했다

파일첨부시, 파일을 외부의 서버로 보내는 기능을 구현하려다보니, 본문추가 기능을 유지하기 위해서 개선
