### PR TITLE
관리자 게시판목록에서 '검색어' 필수 입력을 제거 - 모듈분류 검색위해

### DIFF
--- a/modules/board/tpl/index.html
+++ b/modules/board/tpl/index.html
@@ -97,7 +97,7 @@
 		<option value="mid" selected="selected"|cond="$search_target=='mid'">{$lang->mid}</option>
 		<option value="browser_title" selected="selected"|cond="$search_target=='browser_title'">{$lang->browser_title}</option>
 	</select>
-	<input type="search" required name="search_keyword" value="{htmlspecialchars($search_keyword)}" />
+	<input type="search" name="search_keyword" value="{htmlspecialchars($search_keyword)}" />
 	<button class="x_btn x_btn-inverse" type="submit">{$lang->cmd_search}</button>
 	<a class="x_btn" href="{getUrl('', 'module', $module, 'act', $act)}">{$lang->cmd_cancel}</a>
 </form>


### PR DESCRIPTION
관리자페이지->게시판 목록에서
모듈분류 만으로는 검색이 안 됨 ( 검색어가 없다는 에러가 남 )
다른 검색이 아니라 단순히 모듈분류를 사용하고자할때 사용이 불가능해져서
검색어 필수 처리되어있는걸 제거