### PR TITLE
페이지 모듈에서 모듈분류 검색 기능 작동 안 하는 버그 수정

### DIFF
--- a/modules/page/tpl/index.html
+++ b/modules/page/tpl/index.html
@@ -11,15 +11,17 @@
 	<input type="hidden" name="mid" value="{$mid}" />
 	<input type="hidden" name="vid" value="{$vid}" />
 	<input type="hidden" name="act" value="dispPageAdminContent" />
+	<select cond="count($module_category)" name="module_category_srl" title="{$lang->module_category}" style="margin-right:4px">
+		<option value="" selected="selected"|cond="!$module_category_srl">{$lang->all}</option>
+		<option value="0" selected="selected"|cond="$module_category_srl==='0'">{$lang->not_exists}</option>
+		<option value="{$key}" loop="$module_category => $key,$val"  selected="selected"|cond="$module_category_srl==$key">{$val->title}</option>
+	</select>	
 	<select name="search_target" id="search_target" style="margin-right:4px">
 		<option value="s_mid" selected="selected"|cond="$search_target=='s_mid'">{$lang->mid}</option>
 		<option value="s_browser_title" selected="selected"|cond="$search_target=='s_browser_title'">{$lang->browser_title}</option>
 		<option cond="$module_category">{$lang->module_category}</option>
 	</select>
-	<select name="module_category_srl" title="{$lang->module_category}" cond="$module_category" style="margin-right:4px">
-		<option loop="$module_category => $key,$val" value="{$key}" selected="selected"|cond="$module_category_srl==$key">{$val->title}</option>
-	</select>
-	<input type="search" name="search_keyword" title="Search" value="{htmlspecialchars($search_keyword, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" required style="width:150px" />
+	<input type="search" name="search_keyword" title="Search" value="{htmlspecialchars($search_keyword, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" style="width:150px" />
 	<button class="x_btn x_btn-inverse" type="submit">{$lang->cmd_search}</button>
 	<a href="{getUrl('','module',$module,'act',$act)}" class="x_btn">{$lang->cmd_cancel}</a>
 </form>


### PR DESCRIPTION
페이지모듈에서는 모듈분류 selectbox 자체가 안 나온다
이 부분이 정상적으로 나오도록 수정 

추가로 검색어 값이 비어있으면 검색이 안 되고 에러가 나오는데..
모듈분류가 정상 작동하도록 검색어 필수를 제외