### PR TITLE
댓글관련해 object 캐시 사용할때 버그 발생

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -318,6 +318,7 @@ $GLOBALS['__xe_autoload_file_map'] = array_change_key_case(array(
 	'ConditionWithoutArgument' => 'classes/db/queryparts/condition/ConditionWithoutArgument.class.php',
 	'ClickCountExpression' => 'classes/db/queryparts/expression/ClickCountExpression.class.php',
 	'documentItem' => 'modules/document/document.item.php',
+	'commentItem' => 'modules/comment/comment.item.php',
 	'DeleteExpression' => 'classes/db/queryparts/expression/DeleteExpression.class.php',
 	'Expression' => 'classes/db/queryparts/expression/Expression.class.php',
 	'InsertExpression' => 'classes/db/queryparts/expression/InsertExpression.class.php',


### PR DESCRIPTION
XE 오브젝트 캐시 에서  commentItem 을 autoload 하지 않네요.
해당 변수 추가

- 소스 제공 : 기진곰 님