### PR TITLE
회원가입 추가폼에 다국어 지원

### DIFF
--- a/modules/member/tpl/insert_join_form.html
+++ b/modules/member/tpl/insert_join_form.html
@@ -15,7 +15,7 @@
 		<div class="x_control-group">
 			<label for="column_title" class="x_control-label"><em style="color:red">*</em> {$lang->column_title}</label>
 			<div class="x_controls">
-				<input type="text" id="column_title" name="column_title" value="{$formInfo->column_title}" />
+				<input type="text" name="column_title" value="{htmlspecialchars($formInfo->column_title, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" class="lang_code" title="{$lang->column_title}" />
 			</div>
 		</div>
 		<div class="x_control-group">
@@ -36,7 +36,7 @@
 		<div class="x_control-group">
 			<label for="desc" class="x_control-label">{$lang->description}</label>
 			<div class="x_controls">
-				<textarea rows="4" cols="42" id="desc" name="description">{$formInfo->description}</textarea>
+				<textarea rows="4" cols="42" id="desc" name="description" class="lang_code" title="{$lang->description}">{htmlspecialchars($formInfo->description, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}</textarea>
 			</div>
 		</div>
 		<div class="x_control-group">

--- a/modules/member/tpl/insert_join_form.html
+++ b/modules/member/tpl/insert_join_form.html
@@ -15,7 +15,7 @@
 		<div class="x_control-group">
 			<label for="column_title" class="x_control-label"><em style="color:red">*</em> {$lang->column_title}</label>
 			<div class="x_controls">
-				<input type="text" name="column_title" value="{htmlspecialchars($formInfo->column_title, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" class="lang_code" title="{$lang->column_title}" />
+				<input type="text" id="column_title" name="column_title" value="{htmlspecialchars($formInfo->column_title, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" class="lang_code" title="{$lang->column_title}" />
 			</div>
 		</div>
 		<div class="x_control-group">

--- a/modules/member/tpl/js/signup_config.js
+++ b/modules/member/tpl/js/signup_config.js
@@ -82,8 +82,8 @@ jQuery(function($){
 			{member_join_form_srl:memberFormSrl},
 			function(ret){
 				var tpl = ret.tpl.replace(/<enter>/g, '\n');
-				$('#extendForm').html(tpl);
-
+				$('#extendForm').html(tpl).find('.lang_code').xeApplyMultilingualUI();
+				
 				if (checked)$('#extendForm #radio_'+checked).attr('checked', 'checked');
 			},
 			['error','message','tpl']


### PR DESCRIPTION
현재 회원가입 추가폼에 다국어를 지원하지 않고 있습니다.

text 형태 ( 또는 url, email, phone, textarea 형태등 은 됩니다) 의 추가가입폼은
단순히 가입폼이름과 설명부분만 다국어로 처리하면 되기에,  
조금 수정해서 다국어를 지원했습니다.

다만,  radio, select, checkbox 형태는 기본값 이 입력하는데
이 기본값을 다국어로 처리할 수가 없는 현재 구조상
이 형태까지는 아직 다국어 지원이 어려울듯합니다.

( 게시판 사용자정의의 radio, selectbox, checkbox 도 다국어가 안 되는 동일한 이슈가 있습니다)
