### PR TITLE
애드온 설정에서 그룹간 구별되도록 여백 부여

### DIFF
--- a/modules/addon/tpl/setup_addon.html
+++ b/modules/addon/tpl/setup_addon.html
@@ -43,7 +43,7 @@
 	<block cond="count($addon_info->extra_vars)">
 		<block loop="$addon_info->extra_vars => $id, $var">
 			<block cond="$group != $var->group">
-				<h2>{$var->group}</h2>
+				<h2 style="margin-top:50px;">{$var->group}</h2>
 				{@$group = $var->group}
 			</block>
 			{@$not_first = true}


### PR DESCRIPTION
애드온 설정에서 
group 을 여러개 나눴을때  

그룹간 구별이 잘 안 되던 문제 해결 위해서... 
그룹제목인 h2 에 margin-top:50px;  부여