### PR TITLE
게시판을 등록일 순으로 정렬했을때 현재 페이지 못가져오는 문제 수정

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -660,6 +660,19 @@ class documentModel extends document
 					$args->{$sort_check->sort_index} = $oDocument->get($sort_check->sort_index);
 				}
 			}
+			elseif($sort_check->sort_index === 'regdate')
+			{
+
+				if($args->order_type === 'asc')
+				{
+					$args->{'rev_' . $sort_check->sort_index} = $oDocument->get($sort_check->sort_index);
+				}
+				else
+				{
+					$args->{$sort_check->sort_index} = $oDocument->get($sort_check->sort_index);
+				}
+
+			}
 			else
 			{
 				return 1;

--- a/modules/document/queries/getDocumentListPage.xml
+++ b/modules/document/queries/getDocumentListPage.xml
@@ -45,6 +45,8 @@
 			<condition operation="more" column="list_order" var="rev_list_order" filter="number" pipe="and" />
 			<condition operation="less" column="update_order" var="update_order" filter="number" pipe="and" />
 			<condition operation="more" column="update_order" var="rev_update_order" filter="number" pipe="and" />
+			<condition operation="less" column="regdate" var="rev_regdate" filter="number" pipe="and" />
+			<condition operation="more" column="regdate" var="regdate" filter="number" pipe="and" />
 		</group>
     </conditions>
 </query>


### PR DESCRIPTION
#2018 이슈와 관련해서 추가합니다. 옛날부터 이용자분들이 등록일 순으로도 많이 정렬하셨는데 고질적인 문제였습니다.