### PR TITLE
불필요한 소스 코드 제거

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -452,11 +452,7 @@ class Context
 			return;
 		}
 
-		$config_file = $self->getConfigFile();
-		if(is_readable($config_file))
-		{
-			include($config_file);
-		}
+		include($self::getConfigFile());
 
 		// If master_db information does not exist, the config file needs to be updated
 		if(!isset($db_info->master_db))


### PR DESCRIPTION
isInstalled() 메서드에서 이미 is_readable() 함수를 호출하여 파일을 확인하므로 중복된 is_readable() 함수 호출을 제거 했습니다.