### PR TITLE
XML 작성시 CDATA에 의존하지 않고 문자열을 제대로 escape합니다.

### DIFF
--- a/classes/display/XMLDisplayHandler.php
+++ b/classes/display/XMLDisplayHandler.php
@@ -15,7 +15,7 @@ class XMLDisplayHandler
 
 		$xmlDoc = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response>\n";
 		$xmlDoc .= sprintf("<error>%s</error>\n", $oModule->getError());
-		$xmlDoc .= sprintf("<message>%s</message>\n", str_replace(array('<', '>', '&'), array('&lt;', '&gt;', '&amp;'), $oModule->getMessage()));
+		$xmlDoc .= sprintf("<message>%s</message>\n", htmlspecialchars($oModule->getMessage(), ENT_COMPAT, 'UTF-8', true));
 
 		$xmlDoc .= $this->_makeXmlDoc($variables);
 
@@ -47,7 +47,7 @@ class XMLDisplayHandler
 
 			if(is_string($val))
 			{
-				$xmlDoc .= sprintf('<%s><![CDATA[%s]]></%s>%s', $key, $val, $key, "\n");
+				$xmlDoc .= sprintf('<%s>%s</%s>%s', $key, htmlspecialchars($val, ENT_COMPAT, 'UTF-8', true), $key, "\n");
 			}
 			else if(!is_array($val) && !is_object($val))
 			{

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -252,7 +252,7 @@ function xml2json(xml, tab, ignoreAttrib) {
 					});
 				}
 				else if (!$.isFunction(params)) {
-					stack.push('<![CDATA[' + params + ']]>');
+					stack.push(params.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;'));
 				}
 
 				return stack.join('\n');


### PR DESCRIPTION
에디터가 아닌 textarea로 댓글을 쓰거나, 그 밖의 모듈에서 문자열 데이터를 `exec_xml()` 함수로 서버에 전송할 때 내용에 `]]>` 문자 조합이 들어가면 정상 작동하지 않고 메인화면으로 튕기는 문제가 있습니다.

XML 방식으로 `]]>` 문자 조합이 들어간 데이터를 받아보려고 할 때도 마찬가지입니다. 디코딩할 수 없는 엉터리 XML이 반환됩니다.

문제의 원인은 XE에서 XML을 작성할 때 모든 문자열을 `<[CDATA[` `]]>`로 감싸는데, 그 안에 또 `]]>`가 들어가면 데이터를 받는 쪽에서 파싱에 실패하기 때문입니다.

`<[CDATA[` `]]>` 안에서 `]]>` 문자 조합을 표현하는 방법이 없는 것은 아니지만 (문자열을 두 개 이상으로 나누어 각각 `<[CDATA[` `]]>`로 묶으면 됩니다) 이렇게 하면 코드가 불필요하게 복잡해지는 것은 물론, XML 데이터를 받아서 쓰는 클라이언트 어플리케이션이 오류를 일으킬 가능성도 있고, 무엇보다도 `<[CDATA[` `]]>`에만 의존하다 보면 XML 구조 내에서 다른 의미로 해석될 가능성이 있는 특수문자가 제대로 걸러지지 않아 나중에 애매한 버그나 보안취약점으로 연결될 위험이 있습니다.

IE11에서는 정상적인 `<[CDATA[` `]]>` 태그도 중간에 다른 특수문자가 들어가면 잘못 해석되어 문자열이 깨져서 나오기도 합니다. 몇몇 사이트에서 이와 관련된 문제가 보고되고 있습니다.

이 PR에서는 서버단 및 클라이언트단에서 XML을 작성할 때 문자열을 `<[CDATA[` `]]>`로 감싸지 않고 `htmlspecialchars()` 또는 이에 준하는 방법으로 제대로 인코딩하여, 내용에 어떤 특수문자 조합이 들어가더라도 잘못 해석될 여지를 완전히 제거하였습니다. 이렇게 인코딩된 문자열은 XML 파싱 과정에서 원래의 문자열로 정확하게 복원됩니다.