### PR TITLE
document 모듈의 getDocumentList에서 비밀 글의 내용을 볼 수 있는 볼 수 있는 문제

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -320,6 +320,11 @@ class documentModel extends document
 				$oDocument = null;
 				$oDocument = new documentItem();
 				$oDocument->setAttribute($attribute, false);
+				if($oDocument->isSecret())
+				{
+					$attribute->content = Context::getLang('msg_is_secret');
+					$oDocument->setAttribute($attribute, false);
+				}
 				if($is_admin) $oDocument->setGrant();
 				$GLOBALS['XE_DOCUMENT_LIST'][$document_srl] = $oDocument;
 			}

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -320,7 +320,7 @@ class documentModel extends document
 				$oDocument = null;
 				$oDocument = new documentItem();
 				$oDocument->setAttribute($attribute, false);
-				if($oDocument->isSecret())
+				if($oDocument->isSecret() && !$oDocument->isGranted() && !$oDocument->isAccessible())
 				{
 					$attribute->content = Context::getLang('msg_is_secret');
 					$oDocument->setAttribute($attribute, false);


### PR DESCRIPTION
board 모듈에서 dispBoardContentList를 json으로 요청할 때 비밀 글임에도 불구하고 내용이 표시되는 문제가 있네요. 더 좋은 방식이 있을 것 같은데 일단은 이렇게 처리해봅니다.