### PR TITLE
check_csrf 사용 안함 옵션 추가

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -509,7 +509,8 @@ class ModuleHandler extends Handler
 
 		// check CSRF for non-GET actions
 		$use_check_csrf = !isset($xml_info->action->{$this->act}) || $xml_info->action->{$this->act}->check_csrf !== 'false';
-		if($use_check_csrf && $_SERVER['REQUEST_METHOD'] !== 'GET' && Context::isInstalled() && !checkCSRF()) {
+		if($use_check_csrf && $_SERVER['REQUEST_METHOD'] !== 'GET' && Context::isInstalled() && !checkCSRF())
+		{
 			$this->error = 'msg_invalid_request';
 			$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
 			$oMessageObject->setError(-1);

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -509,7 +509,7 @@ class ModuleHandler extends Handler
 
 		// check CSRF for non-GET actions
 		$use_check_csrf = !isset($xml_info->action->{$this->act}) || $xml_info->action->{$this->act}->check_csrf !== 'false';
-		if($use_check_csrf && $_SERVER['REQUEST_METHOD'] !== 'GET' && Context::isInstalled() && $this->act !== 'procFileUpload' && !checkCSRF()) {
+		if($use_check_csrf && $_SERVER['REQUEST_METHOD'] !== 'GET' && Context::isInstalled() && !checkCSRF()) {
 			$this->error = 'msg_invalid_request';
 			$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
 			$oMessageObject->setError(-1);

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -507,8 +507,9 @@ class ModuleHandler extends Handler
 
 		$logged_info = Context::get('logged_info');
 
-		// check CSRF for POST actions
-		if($_SERVER['REQUEST_METHOD'] !== 'GET' && Context::isInstalled() && $this->act !== 'procFileUpload' && !checkCSRF()) {
+		// check CSRF for non-GET actions
+		$use_check_csrf = !isset($xml_info->action->{$this->act}) || $xml_info->action->{$this->act}->check_csrf !== 'false';
+		if($use_check_csrf && $_SERVER['REQUEST_METHOD'] !== 'GET' && Context::isInstalled() && $this->act !== 'procFileUpload' && !checkCSRF()) {
 			$this->error = 'msg_invalid_request';
 			$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
 			$oMessageObject->setError(-1);

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -7,7 +7,7 @@
 	</permissions>
 	<actions>
 		<action name="getFileList" type="model" />
-		<action name="procFileUpload" type="controller" />
+		<action name="procFileUpload" type="controller" check_csrf="false"/>
 		<action name="procFileIframeUpload" type="controller" />
 		<action name="procFileImageResize" type="controller" ruleset="imageResize" />
 		<action name="procFileDelete" type="controller" />

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -934,6 +934,7 @@ class moduleModel extends module
 					$standalone = $action->attrs->standalone=='false'?'false':'true';
 					$ruleset = $action->attrs->ruleset?$action->attrs->ruleset:'';
 					$method = $action->attrs->method?$action->attrs->method:'';
+					$check_csrf = $action->attrs->check_csrf=='false'?'false':'true';
 
 					$index = $action->attrs->index;
 					$admin_index = $action->attrs->admin_index;
@@ -947,6 +948,7 @@ class moduleModel extends module
 					$info->action->{$name}->standalone = $standalone;
 					$info->action->{$name}->ruleset = $ruleset;
 					$info->action->{$name}->method = $method;
+					$info->action->{$name}->check_csrf = $check_csrf;
 					if($action->attrs->menu_name)
 					{
 						if($menu_index == 'true')
@@ -970,6 +972,7 @@ class moduleModel extends module
 					$buff[] = sprintf('$info->action->%s->standalone=\'%s\';', $name, $standalone);
 					$buff[] = sprintf('$info->action->%s->ruleset=\'%s\';', $name, $ruleset);
 					$buff[] = sprintf('$info->action->%s->method=\'%s\';', $name, $method);
+					$buff[] = sprintf('$info->action->%s->check_csrf=\'%s\';', $name, $check_csrf);
 
 					if($index=='true')
 					{


### PR DESCRIPTION
XE에서 기본적으로 GET method를 제외한 모든 요청에 대해 checkCSRF를 통하여 referer 등을 체크하고 있습니다.
이는 외부와 연동되는 Restful API 등을 구현할 때 문제 요인으로 작용할 수 있습니다.
action에 check_csrf 옵션을 추가하여 부분적으로 특정 action에 checkCSRF를 호출하지 않도록 만들어 위의 문제 요인을 해결하였습니다.

```xml
<!-- 예시 -->
<action name="procIamportNotify" type="controller" check_csrf="false"/>
```