### PR TITLE
1.8.36에서 오류를 일으키는 .htaccess 수정

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,8 @@
 RewriteEngine On
 
-RewriteRule ^(.*/)?\.(.+)$ - [L,F]
-RewriteRule ^codeception(.*?).yml$ - [L,F]
-RewriteRule ^composer(.*?).(json|lock)$ - [L,F]
-RewriteRule ^files/.+\.php$ - [L,F]
+# deny access to files that may contain sensitive information
+RewriteRule ^(.*/)?\.(editor|git|ht|jshint|travis) - [L,F]
+RewriteRule ^(codeception(.*)\.yml|composer(.*)\.(json|lock)|package\.json)$ - [L,F]
 RewriteRule ^files/(attach|config|cache/store)/.+\.php$ - [L,F]
 RewriteRule ^files/(env|member_extra_info/(new_message_flags|point))/ - [L,F]
 


### PR DESCRIPTION
1.8.36 업데이트 후 아래와 같은 문제가 제보되고 있습니다.

- 일부 서버 환경에서 500 Internal Server Error 발생
- 문서 카테고리 로딩 불가
- Let's Encrypt 인증서 신청 불가

이 문제를 해결하기 위해 아래와 같이 수정합니다.

- 일부 아파치 버전에서 오류를 일으키는 `(.*?)` 정규식을 `(.*)`로 변경합니다.
- `files` 폴더 아래의 php 파일을 모두 막지 않고 `attach`, `config`, `cache/store` 아래에서만 막습니다.
  - 다른 경로를 막더라도 `document_category`에 접근이 가능해야 하므로, 만약 임의의 경로에 php 파일을 생성할 수 있는 취약점이 발생한다면 웹쉘 공격이 가능한 것은 마찬가지입니다. 따라서 특별히 민감한 정보가 저장되어 있거나 일반적으로 업로드에 사용되는 경로만 막습니다.
  - 문서 카테고리 등을 로딩하는 방식을 바꾼다면 `files` 폴더 아래의 php 파일을 모두 막아도 될 것입니다.
- dotfile을 모두 막지 않고 `.git`, `.htaccess`, `.travis` 등 XE에 포함된 것만 막습니다.
  - Let's Encrypt 인증서 신청에 사용되는 `.well-known`은 막지 않습니다.
  - `.bashrc` 등 XE에 포함되어 있지 않은 일반 dotfile의 노출이 우려될 수 있으나, 대부분의 호스팅 환경에서는 홈 디렉토리가 아닌 `www`, `public_html` 등의 서브디렉토리를 DOCUMENT_ROOT로 사용하므로 이런 문제가 발생할 가능성은 낮습니다.
