### PR TITLE
인덱스 누락으로 댓글 삭제 시간이 오래걸리는 문제 수정

### DIFF
--- a/modules/comment/comment.class.php
+++ b/modules/comment/comment.class.php
@@ -106,6 +106,11 @@ class comment extends ModuleObject
 			return TRUE;
 		}
 
+		if(!$oDB->isIndexExists("comments", "idx_parent_srl"))
+		{
+			return TRUE;
+		}
+
 		return FALSE;
 	}
 
@@ -178,6 +183,11 @@ class comment extends ModuleObject
 		if(!$oModuleModel->getTrigger('module.procModuleAdminCopyModule', 'comment', 'controller', 'triggerCopyModule', 'after'))
 		{
 			$oModuleController->insertTrigger('module.procModuleAdminCopyModule', 'comment', 'controller', 'triggerCopyModule', 'after');
+		}
+
+		if(!$oDB->isIndexExists("comments", "idx_parent_srl"))
+		{
+			$oDB->addIndex('comments', 'idx_parent_srl', array('parent_srl'));
 		}
 
 		return new Object(0, 'success_updated');

--- a/modules/comment/schemas/comments.xml
+++ b/modules/comment/schemas/comments.xml
@@ -2,7 +2,7 @@
     <column name="comment_srl" type="number" size="11" notnull="notnull" primary_key="primary_key" />
     <column name="module_srl" type="number" size="11" default="0" notnull="notnull" index="idx_module_srl" />
     <column name="document_srl" type="number" size="11" default="0" notnull="notnull" index="idx_document_srl" />
-    <column name="parent_srl" type="number" size="11" default="0" notnull="notnull" />
+    <column name="parent_srl" type="number" size="11" default="0" notnull="notnull" index="idx_parent_srl" />
     <column name="is_secret" type="char" size="1" default="N" notnull="notnull" />
     <column name="content" type="bigtext" notnull="notnull" />
     <column name="voted_count" type="number" size="11" default="0" notnull="notnull" index="idx_voted_count" />


### PR DESCRIPTION
deleteComment에서 getChildComments으로 대댓글 가져올 때

사이트 전체 코멘트 수가 많아질수록 느려지는 문제 발생.

관리자가 댓글을 동시에 수십개를 삭제시 더 많이 느려집니다.