### PR TITLE
목록에서 본문 이미지 엑박일 때 섬네일 계속 생성 시도 해결

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -944,7 +944,7 @@ class documentItem extends Object
 
 		if($source_file)
 		{
-			$output = FileHandler::createImageFile($source_file, $thumbnail_file, $width, $height, 'jpg', $thumbnail_type);
+			$output_file = FileHandler::createImageFile($source_file, $thumbnail_file, $width, $height, 'jpg', $thumbnail_type);
 		}
 
 		// Remove source file if it was temporary
@@ -957,7 +957,7 @@ class documentItem extends Object
 		FileHandler::removeFile($thumbnail_lockfile);
 
 		// Return the thumbnail path if it was successfully generated
-		if($output)
+		if($output_file)
 		{
 			return $thumbnail_url;
 		}


### PR DESCRIPTION
**재현방법**

1. 게시판 목록설정에 요약이 없는 상황 (xe 기본값)

2-1. $this->get('content')값을 못가져 오는 상황에서
      새로운 크기의 섬네일 요청

2-2. 글 작성 시 섬네일 생성 오류 또는 직접 섬네일 폴더를 지웠을 경우

(섬네일 생성 크기를 자주 바꿔서 용량 확보를 위해 사용하지 않는 섬네일 삭제,
이미지 순서 변경으로 새로 생성하고 싶을 때 폴더를 통째로 삭제하는 경우가 있음)

3. 엑박이지만 thumbnailExists() true로 반환되고 빈섬네일 파일 생성안 됨.


**원인**

본문 가져오기 쿼리가 실행되고 (요약 없는 일반적인 상황)
$output = executeQuery('document.getDocument', $args, array('content'));

아래쪽에서 $output을 위 쿼리 결과를 참조함.
xe와 라이믹스 모두 해당.


**위와 별개로** 큰 문제는 아니지만
섬네일 생성과정이 섬네일은 한번만 생성해놓으면 되는데,
섬네일이 있든 없든 매번 getDocument 쿼리를 20번씩 목록에서 실행하는 것은 비효율적인 것 같음.

