### PR TITLE
일부 상대주소가 절대주소로 변환되지 않는 문제 수정

### DIFF
--- a/classes/display/HTMLDisplayHandler.php
+++ b/classes/display/HTMLDisplayHandler.php
@@ -179,8 +179,8 @@ class HTMLDisplayHandler
 			$url = parse_url(Context::getRequestUri());
 			$real_path = $url['path'];
 
-			$pattern = '/src=("|\'){1}(\.\/)?(files\/attach|files\/cache|files\/faceOff|files\/member_extra_info|modules|common|widgets|widgetstyle|layouts|addons)\/([^"\']+)\.(jpg|jpeg|png|gif)("|\'){1}/s';
-			$output = preg_replace($pattern, 'src=$1' . $real_path . '$3/$4.$5$6', $output);
+			$pattern = '/src=("|\'){1}(?:\.\/)?((?:files\/(?:attach|cache|faceOff|member_extra_info|thumbnails)|addons|common|(?:m\.)?layouts|modules|widgets|widgetstyle)\/[^"\']+)("|\'){1}/s';
+			$output = preg_replace($pattern, 'src=$1' . $real_path . '$2$3', $output);
 
 			$pattern = '/href=("|\'){1}(\?[^"\']+)/s';
 			$output = preg_replace($pattern, 'href=$1' . $real_path . '$2', $output);


### PR DESCRIPTION
참고: https://www.xetown.com/qna/650877

일부 에디터에서 이미지를 삽입하면 `<img src="./files/attach/images......jpg" />` 이렇게 상대주소로 들어가는 경우가 있습니다. 이 상태에서 짧은주소를 사용하는 글읽기 화면을 방문하면 `http://example.com/<MID>/files/attach......jpg` 라는 잘못된 주소가 생성되어 엑박이 나올 수 있습니다.

이런 문제를 막기 위해 XE에는 두 가지 안전장치가 갖춰져 있습니다.

1. `.htaccess` 파일에 위와 같은 주소를 바로잡아 주는 rewrite 규칙이 들어 있습니다.
2. `image_link` 에디터 컴포넌트와 `HTMLDisplayHandler`에서 각각 상대주소로 되어 있는 이미지 주소를 절대주소로 바로잡아 주고 있습니다.

그러나 아래와 같은 상황에서는 이 두 가지 안전장치가 모두 실패합니다.

1. `.htaccess`를 지원하지 않는 nginx 등의 서버에서 rewrite 규칙을 제대로 설정하지 않았으며
2. 절대주소로 바로잡아 주는 기능이 작동하지 않는 경우, 즉
  2-1. `image_link` 에디터 컴포넌트를 사용하지 않고 이미지를 직접 삽입했거나, 이미지가 포함된 HTML을 직접 붙여넣었으며
  2-2. 파일 확장자가 대문자인 경우

마지막 문제가 발생하는 이유는 `HTMLDisplayHandler`에서 정규식 마지막에 `/i`가 누락되어 확장자가 소문자인 이미지 주소만 변환해 주고 있기 때문입니다. 여기서 `/i`가 누락된 이유는 해당 정규식 앞부분에 대소문자 구분이 필요한 경로가 포함되어 있기 때문으로 추정됩니다.

이 PR에서는 문제의 정규식을 수정하여 확장자와 무관하게 잘못된 상대경로는 모두 변환하고, `files/thumbnails`, `m.layouts` 등 기존 정규식에서 누락된 경로도 추가하였으며, 정규식 구조를 개선하여 6부분이 아닌 3부분만 매칭하도록 하였습니다.