### PR TITLE
모바일에서 각 모듈의 댓글 에디터 설정이 적용되지 않는 문제 수정

### DIFF
--- a/modules/board/m.skins/default/read.html
+++ b/modules/board/m.skins/default/read.html
@@ -84,9 +84,7 @@
 			<label for="rText">{$lang->comment}</label>
 			<!--@if($module_info->mobile_use_editor === 'Y')-->
 				<input type="hidden" name="content" value="">
-				{@ $oCommentModel = getModel('comment')}
-				{@ $oComment = $oCommentModel->getComment()}
-				{$oComment->getEditor()}
+				{$oDocument->getCommentEditor()}
 			<!--@else-->
 				<textarea name="content" rows="8" cols="42" id="rText"></textarea>
 			<!--@endif-->

--- a/modules/board/m.skins/simpleGray/read.html
+++ b/modules/board/m.skins/simpleGray/read.html
@@ -75,9 +75,7 @@
 				<label for="rText" class="db fb">{$lang->comment}</label>
 				<!--@if($module_info->mobile_use_editor === 'Y')-->
 					<input type="hidden" name="content" value="">
-					{@ $oCommentModel = getModel('comment')}
-					{@ $oComment = $oCommentModel->getComment()}
-					{$oComment->getEditor()}
+					{$oDocument->getCommentEditor()}
 				<!--@else-->
 					<textarea name="content" rows="8" cols="42" id="rText" class="itxx"></textarea>
 				<!--@endif-->


### PR DESCRIPTION
최근 모바일에서 에디터를 사용하도록 패치가 되었으나, 기본 제공되는 default 및 simpleGray 스킨에서 댓글을 작성할 때 각 모듈의 에디터 설정이 아닌 editor 모듈의 공통 설정이 적용되는 문제가 있어 패치합니다.

이미 작성한 댓글을 수정할 때는 각 모듈의 에디터 설정이 정상적으로 적용됩니다.