### PR TITLE
message 모듈의 default 스킨에서 로그인, 로그아웃 링크 수정

### DIFF
--- a/modules/message/skins/default/system_message.html
+++ b/modules/message/skins/default/system_message.html
@@ -35,10 +35,10 @@
 			</fieldset>
 		</form>
 		<p cond="$is_logged" style="text-align:center">
-			<a href="{getUrl('act','dispMemberLogout','module','')}" class="btn">{$lang->cmd_logout}</a>
+			<a href="{getUrl('', 'act','dispMemberLogout','module','')}" class="btn">{$lang->cmd_logout}</a>
 		</p>
 		<p cond="!$is_logged && $module != 'admin'" style="text-align:center">
-			<a href="{getUrl('act','dispMemberLoginForm','module','', 'mid', '')}" class="btn">{$lang->cmd_login}</a>
+			<a href="{getUrl('', 'act','dispMemberLoginForm','module','', 'mid', '')}" class="btn">{$lang->cmd_login}</a>
 		</p>
 	</div>
 	<div class="login-footer" cond="!$is_logged">


### PR DESCRIPTION
에러 메시지 등을 출력할 때 많이 사용하는 message 모듈의 default 스킨에서 로그인, 로그아웃 단추 클릭시 연결되는 링크를 수정합니다. `getUrl()` 함수 호출시 첫 번째 인자에 `''`를 넣어서 링크에 불필요한 변수가 추가되는 것을 막습니다.

이게 문제가 되는 이유는 서드파티 자료들이 POST 요청을 끊고 메시지를 띄우는 일이 많기 때문입니다. 그러면 POST 요청으로 들어왔던 데이터가 URL에 모조리 붙어 버립니다. 회원가입이나 글쓰기 도중 애드온에서 끊어버리면 아이디, 비번, 글 내용 등 온갖 내용이 다 붙습니다.

장기적으로는 `Context::getUrl()`에서 URL을 생성할 때 POST 요청으로 들어온 데이터도 보존해야 하는지 따져볼 필요가 있겠으나 (애초에 변수명이 `$get_vars`인데...) 이걸 잘못 건드리면 호환성 문제가 생길 수 있으므로 일단 POST 데이터가 가장 쉽게 노출되는 message 모듈 스킨만 수정합니다.

xedition 스킨에서는 첫 번째 인자가 이미 `''`로 되어 있으므로 문제가 없습니다.