### PR TITLE
conf/module.xml 파일 menus->menu name 속성에 숫자가 들어가면 이스케이프 해버리는 문제 해결

### DIFF
--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -2004,7 +2004,7 @@ class menuAdminController extends menu
 			unset($name_arr_str);
 			foreach($names as $key => $val)
 			{
-				if(preg_match('/\{\$lang->menu_gnb(?:_sub)?\[\'([a-zA-Z_]+)\'\]\}/', $val) === 1)
+				if(preg_match('/\{\$lang->menu_gnb(?:_sub)?\[\'([a-zA-Z_]?[a-zA-Z_0-9]*)\'\]\}/', $val) === 1)
 				{
 					$name_arr_str .= sprintf('"%s"=>"%s",', $key, $val);
 				}


### PR DESCRIPTION
모듈 설명 파일인 module.xml 내에 menu name에 숫자가 포함된 경우 관리자 페이지에서 즐겨찾기, 대시모드 서브 메뉴에 이름이 정상적으로 표현되지 않음

인식안되던 XML예제
```
	<menus>
		<menu name="board2" type="all">
			<title xml:lang="en">Board</title>
			<title xml:lang="ko">게시판</title>
			<title xml:lang="zh-CN">Board</title>
			<title xml:lang="jp">Board</title>
			<title xml:lang="es">Board</title>
			<title xml:lang="ru">Board</title>
			<title xml:lang="fr">Board</title>
			<title xml:lang="zh-TW">Board</title>
			<title xml:lang="vi">Board</title>
			<title xml:lang="mn">Board</title>
			<title xml:lang="tr">Board</title>
		</menu>
	</menus>
```