### PR TITLE
존재하지 않는 문서가 있을경우 캐싱을 하지 않도록 함

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -141,6 +141,10 @@ class documentModel extends document
 		if(!$GLOBALS['XE_DOCUMENT_LIST'][$document_srl])
 		{
 			$oDocument = new documentItem($document_srl, $load_extra_vars, $columnList);
+			if(!$oDocument->isExists())
+			{
+				return $oDocument;
+			}
 			$GLOBALS['XE_DOCUMENT_LIST'][$document_srl] = $oDocument;
 			if($load_extra_vars) $this->setToAllDocumentExtraVars();
 		}


### PR DESCRIPTION
https://github.com/rhymix/rhymix/commit/92d8f17482b51a74dabcafda2bb7cb2d984507f1

서드파티에서 insertDocument 실행 이후 after트리거에서 documentModel::getDocument 를 실행할경우 document 값이 모두 비어있는 값으로 리턴되는 부분을 찾았습니다. 

그래서 찾아본 원인이 board.Controller.php 에서 해당 게시글이 있는지 없는지를 검사하는 과정에서 
https://github.com/xpressengine/xe-core/blob/master/modules/board/board.controller.php#L74

를 실행하고 있었으며, 해당 액션으로 인해 미리 빈값이 캐싱이 되어버렸습니다.

```php
$GLOBALS['XE_DOCUMENT_LIST'][$document_srl] = $oDocument;
```

여기에 document 문서가 존재하지 않을경우 캐싱을 하지 않도록 하는 PR입니다.

이는 기진님께서 패치에 도움주셨으며, 전적으로 GPL v2, LGPL v2 듀얼라이선스를 책택하여 XE에서 적용할 수 있는 라이선스 코드입니다.

리뷰해주셔서 감사합니다 :) 