### PR TITLE
#2191 getRemoteFile() 호출 후 stat cache가 갱신되지 않는 문제 수정

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -686,6 +686,8 @@ class FileHandler
 		try
 		{
 			$result = self::getRemoteResource($url, $body, $timeout, $method, $content_type, $headers, $cookies, $post_data, $request_config);
+			self::clearStatCache($target_filename);
+			self::invalidateOpcache($target_filename);
 		}
 		catch(Exception $e)
 		{


### PR DESCRIPTION
외부 파일 다운로드 직후에 파일 크기가 0바이트로 표시되는 등의 문제를 수정합니다.
 
참고: #2191
참고: https://xetown.com/qna/820244#comment_821189