### PR TITLE
InnoDB에서 index hint 사용시 치명적인 오류 수정

### DIFF
--- a/classes/xml/xmlquery/tags/table/HintTableTag.class.php
+++ b/classes/xml/xmlquery/tags/table/HintTableTag.class.php
@@ -37,7 +37,7 @@ class HintTableTag extends TableTag
 		$dbType = ucfirst(Context::getDBType());
 
 		$result = sprintf('new %sTableWithHint(\'%s\'%s, array('
-				, $dbType == 'Mysqli' ? 'Mysql' : $dbType
+				, !strncasecmp($dbType, 'Mysql', 5) ? 'Mysql' : $dbType
 				, $dbParser->escape($this->name)
 				, $this->alias ? ', \'' . $dbParser->escape($this->alias) . '\'' : ', null'
 				//, ', \'' . $dbParser->escape($this->index->name) .'\', \'' . $this->index->type .'\''


### PR DESCRIPTION
`mysql_innodb`, `mysqli_innodb` 등의 DB type을 사용하는 사이트에서 index hint가 포함된 쿼리를 실행하면, 존재하지 않는 클래스를 찾으려고 해서 치명적인 오류가 발생합니다. `mysql`로 시작하는 DB type은 모두 `MysqlTableWithHint` 클래스로 연결하도록 수정합니다.