### PR TITLE
CacheHandler::isValid() 에서 $modified_time 기본값이 없는 문제 수정

### DIFF
--- a/classes/cache/CacheHandler.class.php
+++ b/classes/cache/CacheHandler.class.php
@@ -210,7 +210,7 @@ class CacheHandler extends Handler
 	 * 								If stored time is older then modified time, the data is invalid.
 	 * @return bool Return true on valid or false on invalid.
 	 */
-	function isValid($key, $modified_time)
+	function isValid($key, $modified_time = 0)
 	{
 		if(!$this->handler)
 		{


### PR DESCRIPTION
CacheBase를 포함한 실제 캐시 클래스는 모두 isValid() 메소드에 $modified_time = 0 으로 기본값이 지정되어 있는데, CacheHandler 클래스에만 기본값이 없습니다.

이것 때문에 일부 서드파티 자료를 PHP 7.1에서 실행하면 Too few arguments to function CacheHandler::isValid(), 1 passed ... and exactly 2 expected 라는 에러가 발생하고 있습니다. 개발자 입장에서도 두 번째 인자가 필요한지 안 필요한지 헷갈리니까요.

일관성있는 기본값을 지정하여 에러를 방지합니다.
  