### PR TITLE
일부 레이아웃에서 모듈설정의 다국어 레이어가 표시되지 않는 문제점 & 다국어 문서에 존재하는 버그 개선

### DIFF
--- a/modules/admin/tpl/js/admin.js
+++ b/modules/admin/tpl/js/admin.js
@@ -1827,7 +1827,7 @@ jQuery(function($){
 	$.fn.xeLoadMultilingualWindowHtml = function(){
 		function on_complete(data){
 			// append html
-			var $content = $('#content');
+			var $content = ($('#content').length > 0) ? $('#content') : $('body');
 			$(data.html).appendTo($content).xeMultilingualWindow();
 			$('.lang_code').trigger('loaded-multilingualWindow');
 		}

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -116,11 +116,14 @@ class documentModel extends document
 			if($vars[-1][$user_lang_code]) $_document_list[$document_srl]->add('title',$vars[-1][$user_lang_code]);
 			// Information processing
 			if($vars[-2][$user_lang_code]) $_document_list[$document_srl]->add('content',$vars[-2][$user_lang_code]);
-
+			
+			// static 데이터를 갱신해주기 위해 들어간 코드같으나 어차피 언어 변경 자체는 페이지 전환이 일어나면서 발생하는게 대부분이라 효용이 없음. 또한 예기치않게 권한이 없는 다국어 문서 내용을 보여주는 부효과가 일어남		
+			/*		
 			if($vars[-1][$user_lang_code] || $vars[-2][$user_lang_code])
 			{
 				unset($checked_documents[$document_srl]);
 			}
+			*/
 
 			$GLOBALS['XE_EXTRA_VARS'][$document_srl] = $evars->getExtraVars();
 		}


### PR DESCRIPTION
레이아웃에 id가 content인 요소가 없으면 반투명 배경레이어만 나타나고 다국어 레이어가 로드되지 않는 문제를 수정