### PR TITLE
에디터 컴포넌트가 디렉토리인지 확인

### DIFF
--- a/modules/editor/editor.controller.php
+++ b/modules/editor/editor.controller.php
@@ -487,6 +487,7 @@ class editorController extends editor
 		// Get xml_info of downloaded list
 		foreach($downloaded_list as $component_name)
 		{
+			if(!is_dir(_XE_PATH_.'modules/editor/components/'.$component_name)) continue;
 			if(in_array($component_name, array('colorpicker_text','colorpicker_bg'))) continue;
 			// Pass if configured
 			if($component_list->{$component_name}) continue;


### PR DESCRIPTION
`xe/modules/editor/components/` 디렉토리에 디렉토리가 아닌 파일이 있을 경우 `xe-core/modules/editor/editor.model.php`의 `getComponentList` 함수 무한히 재귀되는 문제 발생.