### PR TITLE
jQuery를 $라고 참조할 수 있도록 변경

### DIFF
--- a/common/js/common.js
+++ b/common/js/common.js
@@ -4,9 +4,6 @@
  * @brief 몇가지 유용한 & 기본적으로 자주 사용되는 자바스크립트 함수들 모음
  **/
 
-/* jQuery 참조변수($) 제거 */
-if(jQuery) jQuery.noConflict();
-
 if(typeof window.XE == "undefined") {
 	/*jshint -W082 */
 	(function($, global) {


### PR DESCRIPTION
XE에서는 jQuery를 참조할 때 항상 `jQuery(...)`라고 해야 합니다. `$(...)`라고 하면 에러가 납니다.

이것 때문에 사용자들이 jQuery를 `$`라고 참조하는 튜토리얼을 보고 따라하거나 자바스크립트 라이브러리를 사용하는 데 불편이 많습니다. 불필요하게 jQuery를 중복으로 로딩하는 서드파티 자료가 다수 존재하는 원인을 제공하기도 합니다.

아버지를 아버지라고, 형을 형이라고, jQuery를 `$`라고 부를 수 있도록 해주시면 감사하겠습니다^^

반론 1. 잘 알아보지 않고 jQuery를 중복으로 로딩하는 서드파티 자료가 문제다

엄밀히 말하면 그렇지만, 코어에서 오해의 소지를 제공하는 것도 문제입니다. 서드파티 자료 개발자뿐 아니라 일반 사용자들도 간단한 기능을 구현하기 위해 인터넷에서 검색한 jQuery 함수를 종종 사용합니다.

반론 2. `$`라는 변수를 사용하는 다른 자료와 충돌이 발생할 수 있다

처음에 jQuery를 도입했을 때는 다른 자료나 프레임워크와의 충돌 우려 때문에 `noConflict()`를 사용하셨을 수도 있지만, jQuery가 세상에 나온 지 12년이 지난 이제는 감히 어느 누구도 `$`라는 변수를 다른 목적으로 사용하지 않으니 더이상 이런 걱정은 할 필요가 없다고 생각합니다. 라이믹스에서도 지난 2년간 jQuery를 `$`라고 참조할 수 있도록 해놓았으나, 이와 관련된 호환성 문제는 전혀 보고된 바 없습니다.

반론 3. 여러 버전의 jQuery를 동시에 사용하기 위해서는 `noConflict()` 처리가 필요하다

일부 서드파티 자료에서 특정 버전의 jQuery를 필요로 하는 경우도 있지만, 이 때도 코어에서 제공되는 버전을 `$`로 유지하고 서드파티에서 쓰고 싶은 버전을 `noConflict()` 처리하는 것이 옳습니다. 코어에서 미리 비켜줄 필요가 없어요. 코어의 jQuery에 의존하는 수많은 모듈과 애드온들을 위해서라도 코어에 포함된 버전을 지켜주어야 합니다.
