### PR TITLE
한글도메인 사용시 자바스크립트 isSameHost() 함수가 오작동하는 것을 고침

### DIFF
--- a/common/js/common.js
+++ b/common/js/common.js
@@ -145,7 +145,7 @@ if(typeof window.XE == "undefined") {
 			isSameHost: function(url) {
 				if(typeof url != "string") return false;
 
-				var target_url = global.XE.URI(url).normalizePathname();
+				var target_url = global.XE.URI(url).normalizeHostname().normalizePort().normalizePathname();
 				if(target_url.is('urn')) return false;
 
 				var port = [Number(global.http_port) || 80, Number(global.https_port) || 443];
@@ -164,7 +164,7 @@ if(typeof window.XE == "undefined") {
 				}
 
 				if(!base_url) {
-					base_url = global.XE.URI(global.request_uri).normalizePathname();
+					base_url = global.XE.URI(global.request_uri).normalizeHostname().normalizePort().normalizePathname();
 					base_url = base_url.hostname() + base_url.directory();
 				}
 				target_url = target_url.hostname() + target_url.directory();


### PR DESCRIPTION
한글도메인 사용시 동일한 도메인을 두 가지 이상의 형태로 표현할 수 있습니다. 이것 때문에 isSameHost() 함수가 동일한 도메인 여부를 제대로 판단하지 못합니다. URI.js에서 제공하는 normalizeHostname() 함수를 사용하여 punycode로 통일한 후 비교하도록 수정합니다.

불필요하게 포트가 붙은 주소도 정확하게 비교하도록 하기 위해 normalizePort() 함수도 추가합니다.

사실 URI.js에서 제공하는 normalize() 함수 하나만 호출하면 모두 정규화시켜 주지만, 쿼리스트링이나 fragment 등 불필요한 부분을 처리하느라 자원이 낭비되므로 꼭 필요한 3가지(hostname, port, pathname)만 정규화하도록 했습니다.

참고: rhymix/rhymix#1037 thanks to @misol