### PR TITLE
importer 모듈에서 규칙에 맞지 않는 아이디 등이 누락되지 않도록 수정

### DIFF
--- a/modules/importer/importer.admin.controller.php
+++ b/modules/importer/importer.admin.controller.php
@@ -372,12 +372,13 @@ class importerAdminController extends importer
 			if(!$xmlObj) continue;
 			// List Objects
 			$obj = new stdClass();
+			$obj->member_srl = getNextSequence();
 			$obj->user_id = base64_decode($xmlObj->member->user_id->body);
 			$obj->password = base64_decode($xmlObj->member->password->body);
 			$obj->user_name = base64_decode($xmlObj->member->user_name->body);
 			$obj->nick_name = base64_decode($xmlObj->member->nick_name->body);
 			if(!$obj->user_name) $obj->user_name = $obj->nick_name;
-			$obj->email = base64_decode($xmlObj->member->email->body);
+			$obj->email_address = base64_decode($xmlObj->member->email->body);
 			$obj->homepage = base64_decode($xmlObj->member->homepage->body);
 			$obj->blog = base64_decode($xmlObj->member->blog->body);
 			$obj->birthday = substr(base64_decode($xmlObj->member->birthday->body),0,8);
@@ -400,8 +401,20 @@ class importerAdminController extends importer
 			}
 			// Create url for homepage and blog
 			if($obj->homepage && strncasecmp('http://', $obj->homepage, 7) !== 0 && strncasecmp('https://', $obj->homepage, 8) !== 0) $obj->homepage = 'http://'.$obj->homepage;
-			// email address column
-			$obj->email_address = $obj->email;
+			// Check user ID
+			if(!preg_match('/^[a-z]+[\w-]*[a-z0-9_]+$/i', $obj->user_id))
+			{
+				$obj->user_id = preg_replace('/[^a-z0-9_-]+/i', '', $obj->user_id);
+			}
+			if(!preg_match('/^[a-z]+[\w-]*[a-z0-9_]+$/i', $obj->user_id))
+			{
+				$obj->user_id = 't' . $obj->member_srl;
+			}
+			// Check email address
+			if(!preg_match('/^[\w-]+((?:\.|\+|\~)[\w-]+)*@[\w-]+(\.[\w-]+)+$/', $obj->email_address))
+			{
+				$obj->email_address = $obj->user_id . '@example.com';
+			}
 			list($obj->email_id, $obj->email_host) = explode('@', $obj->email);
 			// Set the mailing option
 			if($obj->allow_mailing!='Y') $obj->allow_mailing = 'N';
@@ -410,18 +423,37 @@ class importerAdminController extends importer
 			if(!in_array($obj->allow_message, array('Y','N','F'))) $obj->allow_message= 'Y';
 			// Get member-join date if the last login time is not found
 			if(!$obj->last_login) $obj->last_login = $obj->regdate;
-			// Get a member_srl
-			$obj->member_srl = getNextSequence();
+			// Set the list order
 			$obj->list_order = -1 * $obj->member_srl;
 			// List extra vars
 			$extra_vars = $obj->extra_vars;
 			unset($obj->extra_vars);
 			$obj->extra_vars = serialize($extra_vars);
-			// Check if the same nickname is existing
-			$nick_args = new stdClass;
-			$nick_args->nick_name = $obj->nick_name;
-			$nick_output = executeQuery('member.getMemberSrl', $nick_args);
-			if(!$nick_output->toBool()) $obj->nick_name .= '_'.$obj->member_srl;
+			// Check if the same user ID exists
+			$args = new stdClass;
+			$args->user_id = $obj->user_id;
+			$output = executeQuery('member.getMemberSrl', $args);
+			if(!$output->toBool() || $output->data)
+			{
+				$obj->user_id .= '_'.$obj->member_srl;
+			}
+			// Check if the same nickname exists
+			$args = new stdClass;
+			$args->nick_name = $obj->nick_name;
+			$output = executeQuery('member.getMemberSrl', $args);
+			if(!$output->toBool() || $output->data)
+			{
+				$obj->user_id .= '_'.$obj->member_srl;
+			}
+			// Check if the same email address exists
+			$args = new stdClass;
+			$args->email_address = $obj->email_address;
+			$output = executeQuery('member.getMemberSrl', $args);
+			if(!$output->toBool() || $output->data)
+			{
+				$obj->email_address = $obj->user_id . '@example.com';
+			}
+
 			// Add a member
 			$output = executeQuery('member.insertMember', $obj);
 
@@ -432,7 +464,7 @@ class importerAdminController extends importer
 				$oMail->setTitle("Password update for your " . getFullSiteUrl() . " account");
 				$webmaster_name = $member_config->webmaster_name?$member_config->webmaster_name:'Webmaster';
 				$oMail->setContent("Dear $obj->user_name, <br /><br />
-						We recently migrated our phpBB forum to XpressEngine. Since you password was encrypted we could not migrate it too, so please reset it by following this link:
+						We recently migrated our site to XpressEngine. Since you password was encrypted we could not migrate it too, so please reset it by following this link:
 						<a href='" . getFullSiteUrl() . "/?act=dispMemberFindAccount' >" . getFullSiteUrl() . "?act=dispMemberFindAccount</a>. You need to enter you email address and hit the 'Find account' button. You will then receive an email with a new, generated password that you can change after login. <br /><br />
 
 						Thank you for your understanding,<br />
@@ -748,6 +780,20 @@ class importerAdminController extends importer
 			$obj->commentStatus = base64_decode($xmlDoc->post->allow_comment->body)!='N'?'ALLOW':'DENY';
 			$obj->allow_trackback = base64_decode($xmlDoc->post->allow_trackback->body)!='N'?'Y':'N';
 			$obj->notify_message = base64_decode($xmlDoc->post->is_notice->body);
+			// Check user ID
+			if(!preg_match('/^[a-z]+[\w-]*[a-z0-9_]+$/i', $obj->user_id))
+			{
+				$obj->user_id = preg_replace('/[^a-z0-9_-]+/i', '', $obj->user_id);
+			}
+			if(!preg_match('/^[a-z]+[\w-]*[a-z0-9_]+$/i', $obj->user_id))
+			{
+				$obj->user_id = 't' . $obj->member_srl;
+			}
+			// Check email address
+			if(!preg_match('/^[\w-]+((?:\.|\+|\~)[\w-]+)*@[\w-]+(\.[\w-]+)+$/', $obj->email_address))
+			{
+				$obj->email_address = $obj->user_id . '@example.com';
+			}
 			// Change content information (attachment)
 			if(count($files))
 			{
@@ -939,6 +985,20 @@ class importerAdminController extends importer
 				$obj->ipaddress = base64_decode($xmlDoc->comment->ipaddress->body);
 				$obj->status = base64_decode($xmlDoc->comment->status->body)==''?'1':base64_decode($xmlDoc->comment->status->body);
 				$obj->list_order = $obj->comment_srl*-1;
+				// Check user ID
+				if(!preg_match('/^[a-z]+[\w-]*[a-z0-9_]+$/i', $obj->user_id))
+				{
+					$obj->user_id = preg_replace('/[^a-z0-9_-]+/i', '', $obj->user_id);
+				}
+				if(!preg_match('/^[a-z]+[\w-]*[a-z0-9_]+$/i', $obj->user_id))
+				{
+					$obj->user_id = 't' . $obj->member_srl;
+				}
+				// Check email address
+				if(!preg_match('/^[\w-]+((?:\.|\+|\~)[\w-]+)*@[\w-]+(\.[\w-]+)+$/', $obj->email_address))
+				{
+					$obj->email_address = $obj->user_id . '@example.com';
+				}
 				// Change content information (attachment)
 				if(count($files))
 				{


### PR DESCRIPTION
마이그레이션 툴을 사용하여 다른 CMS에서 가져온 데이터를 importer 모듈로 들여오려고 하면 아무런 에러가 나지 않았음에도 불구하고 일부 회원이나 게시물이 누락되는 경우가 있습니다.

원인을 추적해 보니 다른 CMS들은 아이디나 메일 주소에 들어갈 수 있는 글자, 닉네임 중복 가능 여부 등을 XE처럼 엄격하게 따지지 않아서, 데이터 추출시 XE 규칙에 맞지 않는 아이디나 메일 주소, 중복되는 닉네임 등이 발생하고 있었습니다. 이러면 `insertMember`, `insertDocument`, `insertComment` 쿼리가 오류를 뿜습니다. 그러나 오류가 발생하더라도 그대로 진행하기 때문에 해당 회원이나 게시물은 누락됩니다.

닉네임 중복 여부를 체크하는 조건이 이미 있지만, 중복된 경우가 아니라 쿼리 오류가 발생한 경우를 감지하도록 되어 있어서ㅡ.ㅡ;; 무용지물이더군요.

마이그레이션 툴과 importer 모듈의 일반적인 사용자층과 사용 방법을 고려할 때, 에러를 뿜고 중단하는 것도 좋은 방법은 아니라고 생각됩니다. 그래서 잘못된 형식의 데이터를 일부 변형하더라도 가능하면 모두 들여올 수 있도록 수정했습니다. 아이디나 메일 주소가 변형되어 로그인이 안 되는 회원이 발생하더라도 사이트 운영자가 조치해 주면 그만이니까요.

- 아이디에서 XE 규칙에 맞지 않는 문자를 삭제하고, 그래도 규칙에 맞지 않으면 아이디를 사용하지 않는 사이트처럼 `'t' + member_srl` 형태로 강제 지정합니다.
- 메일 주소도 XE 규칙에 맞지 않으면 `아이디 + '@example.com'` 형태로 강제 지정합니다. 특히 구버전의 그누보드에서는 메일 주소를 아무렇게나 입력해도 받아주었기 때문에 엉망으로 저장되어 있는 회원정보가 많더군요.
- 닉네임 중복시 `member_srl`을 덧붙여 중복되지 않는 닉네임을 생성하는 코드가 정상 작동하도록 고치고, 아이디와 메일 주소에도 동일하게 적용합니다.
- 모든 규칙은 `Validator` 클래스에서 사용하는 정규식을 그대로 사용합니다.