### PR TITLE
fix #2290 관리자가 회원 메모를 삭제할수 없는 문제 수정

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -31,7 +31,7 @@ class memberAdminController extends member
 
 		$args = Context::gets('member_srl','email_address','find_account_answer', 'allow_mailing','allow_message','denied','is_admin','description','group_srl_list','limit_date');
 		$oMemberModel = &getModel ('member');
-		$config = $oMemberModel->getMemberConfig ();
+		$config = $oMemberModel->getMemberConfig();
 		$getVars = array();
 		if($config->signupForm)
 		{
@@ -60,10 +60,13 @@ class memberAdminController extends member
 		unset($all_args->error_return_url);
 		unset($all_args->success_return_url);
 		unset($all_args->ruleset);
-		if(!isset($args->limit_date)) $args->limit_date = "";
 		unset($all_args->password);
 		unset($all_args->password2);
 		unset($all_args->reset_password);
+
+		if(!isset($args->limit_date)) $args->limit_date = "";
+		if(!isset($args->description)) $args->description = "";
+
 		// Add extra vars after excluding necessary information from all the requested arguments
 		$extra_vars = delObjectVars($all_args, $args);
 		$args->extra_vars = serialize($extra_vars);
@@ -166,13 +169,13 @@ class memberAdminController extends member
 			'password_hashing_work_factor',
 			'password_hashing_auto_upgrade'
 		);
-		
+
 		$oPassword = new Password();
 		if(!array_key_exists($args->password_hashing_algorithm, $oPassword->getSupportedAlgorithms()))
 		{
 			$args->password_hashing_algorithm = 'md5';
 		}
-		
+
 		$args->password_hashing_work_factor = intval($args->password_hashing_work_factor, 10);
 		if($args->password_hashing_work_factor < 4)
 		{

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -2434,7 +2434,7 @@ class memberController extends member
 		if(!$args->user_name) $args->user_name = $orgMemberInfo->user_name;
 		if(!$args->user_id) $args->user_id = $orgMemberInfo->user_id;
 		if(!$args->nick_name) $args->nick_name = $orgMemberInfo->nick_name;
-		if(!$args->description) $args->description = $orgMemberInfo->description;
+		if(!isset($args->description)) $args->description = $orgMemberInfo->description;
 		if(!$args->birthday) $args->birthday = '';
 
 		$output = executeQuery('member.updateMember', $args);


### PR DESCRIPTION
관리자가 회원 메모를 비우면 NULL이 넘어가서 메모가 변경되지 않는 문제점을 수정합니다.