### PR TITLE
댓글 불러오기 동작에 트리거 추가

### DIFF
--- a/modules/comment/comment.model.php
+++ b/modules/comment/comment.model.php
@@ -508,6 +508,13 @@ class commentModel extends comment
 			$args->status = 1;
 		}
 
+		// call trigger (before)
+		$trigger_output = ModuleHandler::triggerCall('comment.getCommentList', 'before', $args);
+		if($trigger_output instanceof BaseObject && !$trigger_output->toBool())
+		{
+			return $output;
+		}
+
 		$output = executeQueryArray('comment.getCommentPageList', $args);
 
 		// return if an error occurs in the query results
@@ -525,6 +532,13 @@ class commentModel extends comment
 			{
 				return;
 			}
+		}
+
+		// call trigger (after)
+		$trigger_output = ModuleHandler::triggerCall('comment.getCommentList', 'after', $output);
+		if($trigger_output instanceof BaseObject && !$trigger_output->toBool())
+		{
+			return $trigger_output;
 		}
 
 		return $output;

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -781,6 +781,9 @@ class documentItem extends BaseObject
 		Context::set('cpage', $output->page_navigation->cur_page);
 		if($output->total_page>1) $this->comment_page_navigation = $output->page_navigation;
 
+		// Call trigger (after)
+		$output = ModuleHandler::triggerCall('document.getComments', 'after', $comment_list);
+
 		return $comment_list;
 	}
 


### PR DESCRIPTION
예전에 `document.getDocumentList`에 트리거를 추가하여 여러 서드파티 자료에서 유용하게 사용하고 있습니다. 그러나 댓글에는 이와 같은 트리거가 없고, 스킨에서 `$oDocument->getComments()` 함수로 댓글을 불러오고 있다 보니 서드파티 자료에서 댓글 목록에 접근하려면 이미 렌더링된 HTML 결과물을 정규식으로 파싱해야 하는 불편을 겪습니다. 물론 이렇게 하면 성능과 정확성도 떨어집니다.

이 PR에서는 라이믹스에서 지원하는 것과 동일한 트리거를 추가하여 서드파티 자료들이 댓글 목록에 편리하게 접근할 수 있도록 합니다.

1. `commentModel` 클래스의 `getCommentList()` 메소드에 `before` 및 `after` 트리거 추가 (DB에서 불러오는 결과를 직접 조작할 필요가 있을 때 사용)
2. `documentItem` 클래스의 `getComments()` 메소드에 `after` 트리거 추가 (스킨에서 흔히 사용하는 댓글 목록에 간편하게 접근할 수 있도록 하여 편의성 강화)