### PR TITLE
PHP 7에서는 자동으로 mysqli 사용

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -487,6 +487,15 @@ class Context
 			$oInstallController->makeConfigFile();
 		}
 
+		if(version_compare(PHP_VERSION, '7.0', '>='))
+		{
+			$db_info->master_db["db_type"] = preg_replace('/^mysql(_.+)$/', 'mysqli$1', $db_info->master_db["db_type"]);
+			foreach($db_info->slave_db as &$slave_db_info)
+			{
+				$slave_db_info["db_type"] = preg_replace('/^mysql(_.+)$/', 'mysqli$1', $slave_db_info["db_type"]);
+			}
+		}
+
 		if(!$db_info->use_prepared_statements)
 		{
 			$db_info->use_prepared_statements = 'Y';


### PR DESCRIPTION
기존에 mysql로 설치된 사이트(사실상 현존하는 대부분의 사이트)를 PHP 7.x로 업그레이드하면 db.config.php를 직접 열어서 db_type을 mysql 또는 mysql_innodb에서 mysqli 또는 mysqli_innodb로 변경해 주어야 합니다. 그러나 이 작업이 필요하다는 사실에 대한 어떤 안내도 없어서 에러가 나더라도 해결 방법을 찾기가 어렵고, FTP에서 해당 파일을 수정할 권한이 없는 경우도 많습니다.

mysql 또는 mysql_innodb로 설치된 사이트를 PHP 7.0 이상 버전에서 구동하면 기존에 설정된 db_type 대신 mysqli 또는 mysqli_innodb에 해당하는 DB 클래스를 로딩하도록 하여 PHP 버전 변경에 따른 불편을 줄여 보았습니다.

큐브리드나 MS SQL을 사용하는 사이트에는 영향이 없습니다.