### PR TITLE
문서 및 댓글 추천 before 시점에 트리거 추가

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -1146,7 +1146,7 @@ class commentController extends comment
 
 		// Return the result
 		$output = new BaseObject(0, $success_message);
-		if($point > 0)
+		if($trigger_obj->update_target === 'voted_count')
 		{
 			$output->add('voted_count', $trigger_obj->after_point);
 		}

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -1116,19 +1116,19 @@ class commentController extends comment
 		$oDB->begin();
 
 		// update the number of votes
-		if($point < 0)
+		if($trigger_obj->update_target === 'blamed_count')
 		{
-			$args->blamed_count = $oComment->get('blamed_count') + $point;
+			$args->blamed_count = $trigger_obj->after_point;
 			$output = executeQuery('comment.updateBlamedCount', $args);
 		}
 		else
 		{
-			$args->voted_count = $oComment->get('voted_count') + $point;
+			$args->voted_count = $trigger_obj->after_point;
 			$output = executeQuery('comment.updateVotedCount', $args);
 		}
 
 		// leave logs
-		$args->point = $point;
+		$args->point = $trigger_obj->point;
 		$output = executeQuery('comment.insertCommentVotedLog', $args);
 
 		// Call a trigger (after)

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1140,19 +1140,20 @@ class documentController extends document
 		$oDB->begin();
 
 		// Update the voted count
-		if($point < 0)
+		if($trigger_obj->update_target === 'blamed_count')
 		{
-			$args->blamed_count = $oDocument->get('blamed_count') + $point;
+			$args->blamed_count = $trigger_obj->after_point;
 			$output = executeQuery('document.updateBlamedCount', $args);
 		}
 		else
 		{
-			$args->voted_count = $oDocument->get('voted_count') + $point;
+			$args->voted_count = $trigger_obj->after_point;
 			$output = executeQuery('document.updateVotedCount', $args);
 		}
 		if(!$output->toBool()) return $output;
+
 		// Leave logs
-		$args->point = $point;
+		$args->point = $trigger_obj->point;
 		$output = executeQuery('document.insertDocumentVotedLog', $args);
 		if(!$output->toBool()) return $output;
 

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1180,7 +1180,7 @@ class documentController extends document
 
 		// Return result
 		$output = new BaseObject();
-		if($point > 0)
+		if($trigger_obj->update_target === 'voted_count')
 		{
 			$output->setMessage('success_voted');
 			$output->add('voted_count', $trigger_obj->after_point);

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1120,6 +1120,21 @@ class documentController extends document
 			return new BaseObject(-1, $failed_voted);
 		}
 
+		// Call a trigger (before)
+		$trigger_obj = new stdClass;
+		$trigger_obj->member_srl = $oDocument->get('member_srl');
+		$trigger_obj->module_srl = $oDocument->get('module_srl');
+		$trigger_obj->document_srl = $oDocument->get('document_srl');
+		$trigger_obj->update_target = ($point < 0) ? 'blamed_count' : 'voted_count';
+		$trigger_obj->point = $point;
+		$trigger_obj->before_point = ($point < 0) ? $oDocument->get('blamed_count') : $oDocument->get('voted_count');
+		$trigger_obj->after_point = $trigger_obj->before_point + $point;
+		$trigger_output = ModuleHandler::triggerCall('document.updateVotedCount', 'before', $trigger_obj);
+		if(!$trigger_output->toBool())
+		{
+			return $trigger_output;
+		}
+
 		// begin transaction
 		$oDB = DB::getInstance();
 		$oDB->begin();
@@ -1141,15 +1156,8 @@ class documentController extends document
 		$output = executeQuery('document.insertDocumentVotedLog', $args);
 		if(!$output->toBool()) return $output;
 
-		$obj = new stdClass;
-		$obj->member_srl = $oDocument->get('member_srl');
-		$obj->module_srl = $oDocument->get('module_srl');
-		$obj->document_srl = $oDocument->get('document_srl');
-		$obj->update_target = ($point < 0) ? 'blamed_count' : 'voted_count';
-		$obj->point = $point;
-		$obj->before_point = ($point < 0) ? $oDocument->get('blamed_count') : $oDocument->get('voted_count');
-		$obj->after_point = ($point < 0) ? $args->blamed_count : $args->voted_count;
-		$trigger_output = ModuleHandler::triggerCall('document.updateVotedCount', 'after', $obj);
+		// Call a trigger (after)
+		$trigger_output = ModuleHandler::triggerCall('document.updateVotedCount', 'after', $trigger_obj);
 		if(!$trigger_output->toBool())
 		{
 			$oDB->rollback();
@@ -1174,12 +1182,12 @@ class documentController extends document
 		if($point > 0)
 		{
 			$output->setMessage('success_voted');
-			$output->add('voted_count', $obj->after_point);
+			$output->add('voted_count', $trigger_obj->after_point);
 		}
 		else
 		{
 			$output->setMessage('success_blamed');
-			$output->add('blamed_count', $obj->after_point);
+			$output->add('blamed_count', $trigger_obj->after_point);
 		}
 		
 		return $output;


### PR DESCRIPTION
XE에서 지원하는 대부분의 트리거는 before와 after가 한 쌍으로 되어 있는데, 유독 문서 추천(document.updateVotedCount)과 댓글 추천(comment.updateVotedCount)는 after만 지원해서 서드파티 자료가 추천 전에 끼어들기가 쉽지 않습니다. after 트리거에서 에러를 반환하여 rollback을 유도함으로써 추천을 막는 방법이 있지만, 이것도 트랜잭션을 사용할 수 있는 DB type에서나 통하는 꼼수이고요.

- 위에서 언급한 두 액션에 before 트리거를 추가합니다.
- before 트리거에서 에러를 반환하여 추천을 막을 수 있습니다.
- before 트리거에서 update_target, point, after_point 등의 값을 변경할 수 있습니다. 특정 그룹 소속 회원의 추천에는 몇 배의 가중치를 부여하거나, 특정 조건 충족시 추천을 비추천으로 바꾸는 등 서드파티 자료의 필요에 따라 다양하게 응용하면 됩니다.
- 댓글 추천 트리거 오브젝트에 document_srl도 포함하여 활용도를 높였습니다.
