### PR TITLE
포인트를 저장하는 부분에 적용여부를 확인하지 않는 문제 고침

### DIFF
--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -564,8 +564,14 @@ class pointController extends point
 
 		// If there are points, update, if no, insert
 		$oPointModel = getModel('point');
-		if($oPointModel->isExistsPoint($member_srl)) executeQuery("point.updatePoint", $args);
-		else executeQuery("point.insertPoint", $args);
+		if($oPointModel->isExistsPoint($member_srl))
+		{
+			$output = executeQuery("point.updatePoint", $args);
+		}
+		else
+		{
+			$output = executeQuery("point.insertPoint", $args);
+		}
 
 		// Get a new level
 		$level = $oPointModel->getLevel($point, $config->level_step);

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -563,14 +563,24 @@ class pointController extends point
 		$oDB->begin();
 
 		// If there are points, update, if no, insert
-		$oPointModel = getModel('point');
-		if($oPointModel->isExistsPoint($member_srl))
+		if($current_point > 0)
 		{
 			$output = executeQuery("point.updatePoint", $args);
 		}
 		else
 		{
+			// 많은 동접시 넣는 과정에서 insert가 미리 이루어졌지만 이 공간으로 넘어올 경우 다시 한번 더 업데이트를 처리.
 			$output = executeQuery("point.insertPoint", $args);
+			if(!$output->toBool())
+			{
+				$output = executeQuery("point.updatePoint", $args);
+			}
+		}
+
+		if(!$output->toBool())
+		{
+			$oDB->rollback();
+			return $output;
 		}
 
 		// Get a new level


### PR DESCRIPTION
포인트를 저장하는 부분에 적용여부의 성공이나 실패 여부 등등의 내용을 뿌려주지 않아 확인할 수 없는 문제가 있는 것 같습니다.

적어도 return $output 이 있다면 리턴을 통해서 적용여부라도 확인할 수 있도록 제공해주는 것이 좋다고 생각해서 수정했습니다.

구현된 function 아래에 return $output 이 잇지만 어떤 내용도 리턴되고 잇지 않고 잇었습니다.

https://github.com/rhymix/rhymix/pull/1116
의 코드와 동일하고, 이 코드의 대한 라이선스는 듀얼라이선스로 적용하겠습니다..