### PR TITLE
인증세션 DB 사용시 session.serialize_handler를 php로 고정 #2017 #2357

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -336,6 +336,7 @@ class Context
 		{
 			$oSessionModel = getModel('session');
 			$oSessionController = getController('session');
+			ini_set('session.serialize_handler', 'php');
 			session_set_save_handler(
 					array(&$oSessionController, 'open'), array(&$oSessionController, 'close'), array(&$oSessionModel, 'read'), array(&$oSessionController, 'write'), array(&$oSessionController, 'destroy'), array(&$oSessionController, 'gc')
 			);


### PR DESCRIPTION
`igbinary`, `php_binary` 등이 기본값으로 설정되어 있는 경우 DB 저장 과정에서 오류가 발생하므로, 인증세션 DB 사용시 session.serialize_handler 설정을 `php`로 고정합니다. #2017 #2357