### PR TITLE
Fix 전체 페이지 수가 페이지를 이동하는 링크 수보다 적을 때 일부 페이지 번호가 표시되지 않는 문제를 수정

### DIFF
--- a/classes/page/PageHandler.class.php
+++ b/classes/page/PageHandler.class.php
@@ -39,7 +39,7 @@ class PageHandler extends Handler
 		$this->point = 0;
 
 		$first_page = $cur_page - (int) ($page_count / 2);
-		if($first_page < 1)
+		if($first_page < 1 || $total_page <= $page_count)
 		{
 			$first_page = 1;
 		}


### PR DESCRIPTION
게시판에서 페이지를 이동하는 링크 수(pagination 의 링크수)가 10일 경우 전체 페이지가 10 보다 작거나 같은 경우 일부 페이지 번호가 표시되지 않습니다.

예를 들어, 링크 수가 10이고 전체 페이지가 10일 경우에 7번째 링크에서 링크의 시작 번호가 2입니다.
10번째 링크의 경우에는 링크의 시작 번호가 5가 되면서 전체 pagination 의 길이가 6으로 줄어듭니다.

해당 오류를 수정했습니다.