### PR TITLE
공지글목록을 일반글목록처럼 trigger 이용해 별도로 추출할 수 있는 기능 추가

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -364,7 +364,24 @@ class documentModel extends document
 		$args = new stdClass();
 		$args->module_srl = $obj->module_srl;
 		$args->category_srl= $obj->category_srl;
-		$output = executeQueryArray('document.getNoticeList', $args, $columnList);
+		
+		unset($obj->use_alternate_output);
+		$obj->columnList = $columnList;
+		$output = ModuleHandler::triggerCall('document.getNoticeList', 'before', $obj);
+		if($output instanceof BaseObject && !$output->toBool())
+		{
+			return $output;
+		}
+		$use_alternate_output = (isset($obj->use_alternate_output) && $obj->use_alternate_output instanceof BaseObject);
+		if ($use_alternate_output) 
+		{
+			$output = $obj->use_alternate_output;
+			unset($obj->use_alternate_output);
+		}
+		else {
+			$output = executeQueryArray('document.getNoticeList', $args, $columnList);
+		}
+		
 		if(!$output->toBool()||!$output->data) return;
 
 		foreach($output->data as $key => $val)


### PR DESCRIPTION
일반글을 추출하는 getDocumentList 에도 
XE 의 기본 쿼리 대신 trigger 를 이용해 목록을 가져오는 기능이 있듯이

공지글을 추출하는 getNotcieList 에도
동일한 기능이 있는게 좋을듯합니다.  ( 실제 필요할때가 있어서 Core 에 추가해쓰고 있거든요 )
소스는 getDocumentlist 에서와 거의 동일합니다.
자연스럽게 
ModuleHandler::triggerCall('document.getNoticeList', 'before', $obj);   트리거도 추가되겠네요.

