### PR TITLE
회원 캐시를 비우면 관련된 전역변수도 비우도록 변경

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -3019,6 +3019,13 @@ class memberController extends member
 			$cache_key = $oCacheHandler->getGroupKey('member', $object_key);
 			$oCacheHandler->delete($cache_key);
 		}
+		
+		unset($GLOBALS['__member_info__'][$member_srl]);
+		unset($GLOBALS['__member_info__']['profile_image'][$member_srl]);
+		unset($GLOBALS['__member_info__']['image_name'][$member_srl]);
+		unset($GLOBALS['__member_info__']['image_mark'][$member_srl]);
+		unset($GLOBALS['__member_info__']['group_image_mark'][$member_srl]);
+		unset($GLOBALS['__member_info__']['signature'][$member_srl]);
 	}
 }
 /* End of file member.controller.php */


### PR DESCRIPTION
https://xetown.com/questions/1144200 에서 제보된 문제의 원인이 아닐까 의심되는 부분입니다. 

`memberController->_clearMemberCache()`를 호출하면 오브젝트 캐시는 비우는데 여기저기 전역변수로 저장해 놓은 캐시는 그대로 두고 있어서, 회원정보를 변경하고 동일한 요청 내에서 프로필 이미지, 서명 등을 불러오려고 하면 오작동할 가능성이 있습니다.

회원 캐시를 비우면 `memberModel`에서 사용하는 전역변수 캐시도 모두 비우도록 수정해 보았습니다.