### PR TITLE
PHP 7.2에서 배열이 아닌 것에 count()를 사용하여 발생하는 오류 수정

### DIFF
--- a/classes/db/queryparts/Query.class.php
+++ b/classes/db/queryparts/Query.class.php
@@ -161,7 +161,7 @@ class Query extends BaseObject
 
 	function setColumns($columns)
 	{
-		if(!isset($columns) || !is_array($columns) || count($columns) === 0)
+		if(!isset($columns) || (is_array($columns) && count($columns) === 0))
 		{
 			$this->columns = array(new StarExpression());
 			return;
@@ -177,7 +177,7 @@ class Query extends BaseObject
 
 	function setTables($tables)
 	{
-		if(!isset($tables) || !is_array($tables) || count($tables) === 0)
+		if(!isset($tables) || (is_array($tables) && count($tables) === 0))
 		{
 			$this->setError(TRUE);
 			$this->setMessage("You must provide at least one table for the query.");
@@ -200,7 +200,7 @@ class Query extends BaseObject
 	function setConditions($conditions)
 	{
 		$this->conditions = array();
-		if(!isset($conditions) || !is_array($conditions) || count($conditions) === 0)
+		if(!isset($conditions) || (is_array($conditions) && count($conditions) === 0))
 		{
 			return;
 		}
@@ -220,7 +220,7 @@ class Query extends BaseObject
 
 	function setGroups($groups)
 	{
-		if(!isset($groups) || count($groups) === 0)
+		if(!isset($groups) || (is_array($groups) && count($groups) === 0))
 		{
 			return;
 		}
@@ -234,7 +234,7 @@ class Query extends BaseObject
 
 	function setOrder($order)
 	{
-		if(!isset($order) || count($order) === 0)
+		if(!isset($order) || (is_array($order) && count($order) === 0))
 		{
 			return;
 		}
@@ -587,7 +587,7 @@ class Query extends BaseObject
 	function getLimitString()
 	{
 		$limit = '';
-		if(is_array($this->limit) && count($this->limit) > 0)
+		if($this->limit)
 		{
 			$limit = '';
 			$limit .= $this->limit->toString();

--- a/classes/db/queryparts/Query.class.php
+++ b/classes/db/queryparts/Query.class.php
@@ -144,7 +144,7 @@ class Query extends BaseObject
 	function setColumnList($columnList)
 	{
 		$this->columnList = $columnList;
-		if(count($this->columnList) > 0)
+		if(is_array($this->columnList) && count($this->columnList) > 0)
 		{
 			$selectColumns = array();
 			$dbParser = DB::getParser();
@@ -161,7 +161,7 @@ class Query extends BaseObject
 
 	function setColumns($columns)
 	{
-		if(!isset($columns) || count($columns) === 0)
+		if(!isset($columns) || !is_array($columns) || count($columns) === 0)
 		{
 			$this->columns = array(new StarExpression());
 			return;
@@ -177,7 +177,7 @@ class Query extends BaseObject
 
 	function setTables($tables)
 	{
-		if(!isset($tables) || count($tables) === 0)
+		if(!isset($tables) || !is_array($tables) || count($tables) === 0)
 		{
 			$this->setError(TRUE);
 			$this->setMessage("You must provide at least one table for the query.");
@@ -200,7 +200,7 @@ class Query extends BaseObject
 	function setConditions($conditions)
 	{
 		$this->conditions = array();
-		if(!isset($conditions) || count($conditions) === 0)
+		if(!isset($conditions) || !is_array($conditions) || count($conditions) === 0)
 		{
 			return;
 		}
@@ -560,7 +560,7 @@ class Query extends BaseObject
 	{
 		if(!$this->_orderByString)
 		{
-			if(count($this->orderby) === 0)
+			if(!is_array($this->orderby) || count($this->orderby) === 0)
 			{
 				return '';
 			}
@@ -587,7 +587,7 @@ class Query extends BaseObject
 	function getLimitString()
 	{
 		$limit = '';
-		if(count($this->limit) > 0)
+		if(is_array($this->limit) && count($this->limit) > 0)
 		{
 			$limit = '';
 			$limit .= $this->limit->toString();
@@ -611,7 +611,7 @@ class Query extends BaseObject
 			$this->arguments = array();
 
 			// Join table arguments
-			if(count($this->tables) > 0)
+			if(is_array($this->tables) && count($this->tables) > 0)
 			{
 				foreach($this->tables as $table)
 				{
@@ -628,7 +628,7 @@ class Query extends BaseObject
 
 			// Column arguments
 			// The if is for delete statements, all others must have columns
-			if(count($this->columns) > 0)
+			if(is_array($this->columns) && count($this->columns) > 0)
 			{
 				foreach($this->columns as $column)
 				{
@@ -644,7 +644,7 @@ class Query extends BaseObject
 			}
 
 			// Condition arguments
-			if(count($this->conditions) > 0)
+			if(is_array($this->conditions) && count($this->conditions) > 0)
 			{
 				foreach($this->conditions as $conditionGroup)
 				{
@@ -657,7 +657,7 @@ class Query extends BaseObject
 			}
 
 			// Navigation arguments
-			if(count($this->orderby) > 0)
+			if(is_array($this->orderby) && count($this->orderby) > 0)
 			{
 				foreach($this->orderby as $order)
 				{

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -923,7 +923,7 @@ class ModuleHandler extends Handler
 		{
 			Context::set('XE_VALIDATOR_ID', $_SESSION['XE_VALIDATOR_ID']);
 		}
-		if(count($_SESSION['INPUT_ERROR']))
+		if(is_array($_SESSION['INPUT_ERROR']) && count($_SESSION['INPUT_ERROR']))
 		{
 			Context::set('INPUT_ERROR', $_SESSION['INPUT_ERROR']);
 		}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -480,7 +480,7 @@ class moduleModel extends module
 
 		foreach($target_module_info as $key => $val)
 		{
-			if(!$extra_vars[$val->module_srl] || !count($extra_vars[$val->module_srl])) continue;
+			if(!$extra_vars[$val->module_srl] || !count(get_object_vars($extra_vars[$val->module_srl]))) continue;
 			foreach($extra_vars[$val->module_srl] as $k => $v)
 			{
 				if($target_module_info[$key]->{$k}) continue;
@@ -1782,7 +1782,7 @@ class moduleModel extends module
 
 			if(!$output->toBool())
 			{
-				return;
+				return array();
 			}
 
 			if(!$output->data)


### PR DESCRIPTION
PHP 7.2 이상 버전에서는 배열이나 countable object가 아닌 것에 count() 함수를 사용하면 오류를 뿜습니다. 예전부터 배열이 아닌 것에도 흔히 사용하던 함수인데, 갑자기 에러 레벨이 확 올라가 버렸어요. (수정: 커밋 메시지와 달리 현재는 Fatal Error는 아닙니다. 변수가 countable인지 확인하는 함수는 PHP 7.3에서야 추가되었습니다. 앞뒤 안 가리고 무척 빨리 바뀌고 있는 것 같으니 차기 버전에서는 아예 Fatal Error가 되어 버릴지도 모르겠네요.)

이 문제 때문에 특정한 상황에서 오류가 발생하는 것을 발견하여, 반드시 배열 여부를 확인한 후 count() 함수를 사용하도록 수정합니다.

이것 외에도 count() 함수를 사용하는 곳은 많지만, 일단 오류가 발생할 여지가 있는 곳만 수정했습니다.

참고: rhymix/rhymix@6f35f5b