### PR TITLE
문서 모듈의 히스토리 기능 사용시 닉네임과 회원번호가 로그인 정보로 저장되는 문제 수정

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -397,8 +397,8 @@ class documentController extends document
 			$args->document_srl = $obj->document_srl;
 			$args->module_srl = $module_srl;
 			if($document_config->use_history == 'Y') $args->content = $source_obj->get('content');
-			$args->nick_name = $logged_info->nick_name;
-			$args->member_srl = $logged_info->member_srl;
+			$args->nick_name = $source_obj->get('nick_name');
+			$args->member_srl = $source_obj->get('member_srl');
 			$args->regdate = $source_obj->get('last_update');
 			$args->ipaddress = $_SERVER['REMOTE_ADDR'];
 			$output = executeQuery("document.insertHistory", $args);


### PR DESCRIPTION
문서 모듈의 히스토리 정보가 저장될 때 닉네임과 회원번호만 이전 정보를 저장하는 게 아닌 현재 로그인한 사용자의 닉네임과 회원번호를 저장합니다.
따라서 이전의 기록을 현재 수정한 회원이 작성한 것처럼 저장됩니다.

해당 오류를 수정했습니다.
