### PR TITLE
휴지통에 버려진 글 내용이 지저분하게 표시되는 문제 수정

### DIFF
--- a/modules/trash/tpl/trash_view.html
+++ b/modules/trash/tpl/trash_view.html
@@ -53,7 +53,7 @@
 
 	<tr>
 		<th scope="row">{$lang->content}</th>
-		<td class="text">{$oOrigin->content}</td>
+		<td class="text">{$oOrigin->content|noescape}</td>
 	</tr>
 </table>
 


### PR DESCRIPTION
휴지통에 버려진 글을 관리자가 열람하려고 하면 내용의 태그가 그대로 다 표시되는 문제가 있습니다. 해당 부분에 noescape 필터를 적용하여 수정했습니다.