### PR TITLE
move the user_id field to conditions

### DIFF
--- a/modules/member/queries/updateMember.xml
+++ b/modules/member/queries/updateMember.xml
@@ -6,7 +6,6 @@
         <column name="password" var="password" notnull="notnull" />
         <column name="user_name" var="user_name" notnull="notnull" minlength="2" maxlength="40" />
         <column name="nick_name" var="nick_name" notnull="notnull" minlength="2" maxlength="40" />
-        <column name="user_id" var="user_id" notnull="notnull" />
 		<column name="email_address" var="email_address" notnull="notnull"/>
 		<column name="email_id" var="email_id" />
 		<column name="email_host" var="email_host" />
@@ -25,5 +24,6 @@
     </columns>
     <conditions>
         <condition operation="equal" column="member_srl" var="member_srl" notnull="notnull" filter="number" />
+        <condition operation="equal" column="user_id" var="user_id" notnull="notnull" filter="userid" pipe="and" />
     </conditions>
 </query>


### PR DESCRIPTION
`user_id`는 업데이트되는 field가 아니며, 다른 값으로 변경되어도 안됩니다.
`conditions`으로 넣습니다.

XE는 `grant all privileges`를 가정하나, 좀 더 안전하게 만들려면 `alter,drop`는 `revoke`시키고,
`update`는 특정 컬럼에 유효하게 고칠 수도 있을 것입니다.

간단히 `xe_member`에 대해서 `user_id` 및 `member_srl`에 대해서 `update`를 `revoke`시키고 테스트를 해보니 이 문제때문에 제대로 작동을 하지 않았습니다.