### PR TITLE
지원되는 PHP 버전 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ XE 코어는 모듈, 애드온, 에디터 컴포넌트, 위젯, 레이아웃의 
 XpressEngine은 여러분들의 개발 참여를 기다립니다.
 
 ## Server Requirements
-* PHP version 5.3.0 or greater (But recommend PHP >= 5.5.0)
+* PHP version greater than 5.3.0 and less than 7.4.0 (But recommend PHP >= 5.5.0)
 * MYSQL version 4.1 or greater (But recommend MYSQL >= 5.x) , MS-SQL, CUBRID
 * XML Library
 * GD Library

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ XE 코어는 모듈, 애드온, 에디터 컴포넌트, 위젯, 레이아웃의 
 XpressEngine은 여러분들의 개발 참여를 기다립니다.
 
 ## Server Requirements
-* PHP version greater than 5.3.0 and less than 7.4.0 (But recommend PHP >= 5.5.0)
+* PHP version greater than 5.3.0 and less than 8.0.0 (But recommend PHP >= 5.5.0)
 * MYSQL version 4.1 or greater (But recommend MYSQL >= 5.x) , MS-SQL, CUBRID
 * XML Library
 * GD Library


### PR DESCRIPTION
~~PHP 7.4에서 정상 동작하지 않는다는 제보가 있고~~, PHP8에서는 오류로 아예 설치조차 불가능합니다.
PHP 지원을 위해 업데이트하실것 같지는 않으니(쌓인 이슈를 처리조차 안하고 close했음에도 아직도 이슈 45개가 열려 있습니다) README 쪽 수정이나마 진행하셨음 해서 올려봅니다.